### PR TITLE
Separate CI to pre-test/test/post-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,7 @@ jobs:
         env:
           TERM: dumb
         run: |
-          eexit 1
+          ./scripts/run.sh bootstrap
   
 
   # !!!post-test logic should be migrated to "PR closed" event


### PR DESCRIPTION
## Description
Separate CI to pre-test/test/post-test

## Improvements
- Create pre-test job that create temporary branch for the ArgoCD tests to run
- Leave test job just for the run.sh bootstrap 
- Create post-test job for cleaning and pushing the latest tag (should be migrated to "PR closed" event)

## Task
No task

## SOC 2 Compliance Verification

### Change Management
- [ ] This change follows our documented SDLC process
- [ ] Required testing has been performed in development/test environment
- [ ] Changes have been reviewed by someone other than the author
- [ ] Security implications of this change have been considered

### Technical Verification [Link](https://app.clickup.com/9013925967/v/dc/8cmb62f-2253)
- [ ] All services running in k3d cluster
- [ ] UI accessible and responsive
- [ ] Authentication working correctly
- [ ] Agents connected and visible in OpenFrame UI
- [ ] Command execution works from both OpenFrame and Tactical RMM
- [ ] Remote access via MeshCentral functioning
- [ ] No critical errors in logs 
- [ ] Bootstrap script completes successfully

### Risk Assessment
<!-- Assess the impact of this change and any potential security implications -->
**Risk Level**: (Low/Medium/High)
**Explanation**: 

## Testing Performed
<!-- Describe the testing that was conducted to validate this change -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual verification

## Documentation Updates
- [ ] Documentation has been updated to reflect these changes
- [ ] No documentation updates required

## Reviewer Instructions
<!-- Any specific instructions for the reviewer to test or validate the changes -->

## Emergency Change
- [ ] This is an emergency change (requires post-implementation review)
<!-- If checked, provide justification for bypassing normal review process -->

---
*By submitting this PR, I confirm that these changes have been tested adequately and comply with our security standards and SOC 2 requirements.*
