### PR TITLE
Remove unnecessary Tactical RMM images

### DIFF
--- a/integrated-tools/tactical-rmm/tactical-base/skaffold.yaml
+++ b/integrated-tools/tactical-rmm/tactical-base/skaffold.yaml
@@ -1,0 +1,71 @@
+apiVersion: skaffold/v4beta13
+kind: Config
+metadata:
+  name: tactical-base
+build:
+  artifacts:
+    - image: ghcr.io/flamingo-cx/openframe/tactical-base
+      context: .
+      sync: 
+        manual:
+          - src: "**/*"
+            dest: "/app"
+      docker:
+        dockerfile: Dockerfile
+      hooks:
+        before:
+          - command: [ "mvn", "clean", "package", "-DskipTests"]
+      docker:
+        dockerfile: Dockerfile
+        buildArgs:
+          POSTGRES_DB: "tacticalrmm"
+          POSTGRES_USER: "postgres"
+          POSTGRES_PASSWORD: "postgrespass"
+          POSTGRES_HOST: "tactical-postgres"
+          POSTGRES_PORT: "5432"
+          REDIS_HOST: "tactical-redis"
+          SMTP_HOST: "smtp.example.com"
+          SMTP_PORT: "587"
+          SMTP_FROM: "mesh@example.com"
+          SMTP_USER: "mesh@example.com"
+          SMTP_PASS: "mesh-smtp-pass"
+          SMTP_TLS: "false"
+          TRMM_USER: "tactical"
+          TRMM_PASS: "tactical"
+          TACTICAL_BACKEND_PORT: "8000"
+          TRMM_PROTO: "http"
+          TRMM_DISABLE_WEB_TERMINAL: "False"
+          TRMM_DISABLE_SERVER_SCRIPTS: "False"
+          TRMM_DISABLE_SSO: "False"
+          TRMM_DISABLE_2FA: "True"
+          NODE_ENV: "development"
+          WS_PROTO: "ws"
+          WS_MASK_OVERRIDE: "1"
+          TACTICAL_DIR: "/opt/tactical"
+          TACTICAL_TMP_DIR: "/tmp/tactical"
+          API_HOST: "tactical-backend:8000"
+          API_LOCALHOST_HOST: "localhost:8000"
+          APP_HOST: "tactical-frontend:8080"
+          APP_LOCALHOST_HOST: "localhost:8080"
+          NATS_CONFIG: "/opt/tactical/nats-rmm.conf"
+          NATS_API_CONFIG: "/opt/tactical/nats-api.conf"
+          NATS_CONFIG_CHECK_INTERVAL: "5"
+          NATS_STD_BIND_HOST: "tactical-nats"
+          NATS_WS_BIND_HOST: "tactical-nats"
+          NATS_CONNECT_HOST: "tactical-nats"
+          NATS_STANDARD_PORT: "9235"
+          NATS_WEBSOCKET_PORT: "4222"
+          WEBSOCKET_PORT: "8383"
+          WEBSOCKETS_BIND_HOST: "tactical-websockets"
+  local:
+    useDockerCLI: false
+    useBuildkit: true
+    push: false
+manifests:
+  helm:
+    releases:
+      - name: tactical-rmm
+        chartPath: ../../../manifests/integrated-tools/tactical-rmm
+        valuesFiles:
+          - ../../../manifests/integrated-tools/tactical-rmm/values.yaml
+        # setValues:


### PR DESCRIPTION
## Description
Remove unnecessary Tactical RMM images. There are only three tactical images: nginx, frontend, base (it includes all others). Ought to remove tactical-celery, tactical-celerybeat, tactical-nats, tactical-websocets, tactical-backend only for tactical-base

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->
