### PR TITLE
Allow configure orgId for client registration 

### DIFF
--- a/client/src/models/agent_registration_request.rs
+++ b/client/src/models/agent_registration_request.rs
@@ -5,4 +5,6 @@ use serde::Serialize;
 pub struct AgentRegistrationRequest {
     pub hostname: String,
     pub agent_version: String,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub organization_id: String,
 } 

--- a/client/src/models/initial_configuration.rs
+++ b/client/src/models/initial_configuration.rs
@@ -5,6 +5,8 @@ pub struct InitialConfiguration {
     pub server_host: String,
     pub initial_key: String,
     pub local_mode: bool,
+    #[serde(default)]
+    pub org_id: String,
 }
 
 impl Default for InitialConfiguration {
@@ -13,6 +15,7 @@ impl Default for InitialConfiguration {
             server_host: String::new(),
             initial_key: String::new(),
             local_mode: false,
+            org_id: String::new(),
         }
     }
 }

--- a/client/src/services/agent_registration_service.rs
+++ b/client/src/services/agent_registration_service.rs
@@ -63,10 +63,12 @@ impl AgentRegistrationService {
             .unwrap_or_else(|| String::new());
         let agent_version = self.device_data_fetcher.get_agent_version()
             .unwrap_or_else(|| String::new());
+        let organization_id = self.initial_configuration_service.get_org_id().unwrap_or_default();
 
         let request = AgentRegistrationRequest {
             hostname,
             agent_version,
+            organization_id,
         };
 
         Ok(request)

--- a/client/src/services/initial_configuration_service.rs
+++ b/client/src/services/initial_configuration_service.rs
@@ -37,6 +37,11 @@ impl InitialConfigurationService {
         Ok(config.local_mode)
     }
 
+    pub fn get_org_id(&self) -> Result<String> {
+        let config = self.get()?;
+        Ok(config.org_id.clone())
+    }
+
     fn get(&self) -> Result<InitialConfiguration> {
         if !self.config_file_path.exists() {
             return Err(anyhow::anyhow!("Initial configuration file does not exist"));

--- a/openframe/services/openframe-client/src/main/java/com/openframe/client/service/agentregistration/AgentRegistrationService.java
+++ b/openframe/services/openframe-client/src/main/java/com/openframe/client/service/agentregistration/AgentRegistrationService.java
@@ -83,6 +83,7 @@ public class AgentRegistrationService {
         machine.setAgentVersion(request.getAgentVersion());
         machine.setLastSeen(Instant.now());
         machine.setStatus(DeviceStatus.ACTIVE);
+        machine.setOrganizationId(request.getOrganizationId());
 
         machineRepository.save(machine);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <grpc.version>1.58.0</grpc.version>
         <!-- Centralized OpenFrame OSS libs version -->
-        <openframe.libs.version>999-SNAPSHOT</openframe.libs.version>
+        <openframe.libs.version>1.1.2</openframe.libs.version>
         <openframe.saas.libs.version>1.1.1</openframe.saas.libs.version>
     </properties>
 


### PR DESCRIPTION
## Description
Allow configure orgId for client registration 

## Improvements
- Add orgId to initial configuration 
- Send orgId during client registration request
- Save orgId to database
