### PR TITLE
Allow all corses for meshcentral

### DIFF
--- a/integrated-tools/meshcentral/server/config.json
+++ b/integrated-tools/meshcentral/server/config.json
@@ -49,12 +49,7 @@
       "minify": true,
       "NewAccounts": false,
       "localSessionRecording": true,
-      "allowedOrigin": [
-        "${MESH_NGINX_HOST}",
-        "${MESH_NGINX_NAT_HOST}",
-        "${MESH_EXTERNAL_HOST}",
-        "localhost"
-      ]
+      "allowedOrigin": true
     }
   }
 }


### PR DESCRIPTION
## Description
There's cors issue for meshcentral when we run cluster with ngrok or at the cloud environment. 
Openframe gateway is responsible for the CORS validation now.
Disabled it at meshcentral configuration to allow all CORS.
