### PR TITLE
Update lib to include NATS tool url type schema 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <grpc.version>1.58.0</grpc.version>
         <!-- Centralized OpenFrame OSS libs version -->
-        <openframe.libs.version>1.19.0</openframe.libs.version>
+        <openframe.libs.version>1.19.1</openframe.libs.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Description
Update lib to the next patch version.
1.19.1 include fix for graphql schema to support nats url type.
