### PR TITLE
Quit osquery when uninstall

### DIFF
--- a/client/src/services/tool_kill_service.rs
+++ b/client/src/services/tool_kill_service.rs
@@ -17,62 +17,95 @@ impl ToolKillService {
     /// command pattern and attempt to terminate them gracefully, falling back
     /// to force kill if necessary.
     pub async fn stop_tool(&self, tool_id: &str) -> Result<()> {
-        info!("Attempting to stop tool: {}", tool_id);
+        let pattern = Self::build_tool_cmd_pattern(tool_id);
+        self.stop_processes_by_pattern(&pattern, &format!("tool: {}", tool_id)).await
+    }
+
+    /// Stop an asset process by asset ID and tool ID
+    /// 
+    /// This method will search for any running processes that match the asset's
+    /// command pattern and attempt to terminate them gracefully, falling back
+    /// to force kill if necessary.
+    pub async fn stop_asset(&self, asset_id: &str, tool_id: &str) -> Result<()> {
+        let pattern = Self::build_asset_cmd_pattern(asset_id, tool_id);
+        self.stop_processes_by_pattern(&pattern, &format!("asset: {} (tool: {})", asset_id, tool_id)).await
+    }
+
+    /// Generic method to stop processes matching a command pattern
+    /// 
+    /// This method will search for any running processes that match the given
+    /// pattern and attempt to terminate them gracefully, falling back to force
+    /// kill if necessary.
+    async fn stop_processes_by_pattern(&self, pattern: &str, description: &str) -> Result<()> {
+        info!("Attempting to stop {}", description);
+        info!("Use pattern to stop {}", pattern);
         
         let mut sys = System::new_all();
         sys.refresh_all();
 
-        // Match processes whose command contains "/{tool_id}/agent"
-        let pattern = Self::build_cmd_pattern(tool_id);
         let mut stopped_count = 0;
 
         for (pid, process) in sys.processes() {
             let cmd_items = process.cmd();
             let cmdline = cmd_items.join(" ").to_lowercase();
 
-            if cmdline.contains(&pattern) {
-                info!("Found tool process for {} with pid {}", tool_id, pid);
+            if cmdline.contains(pattern) {
+                info!("Found process for {} with pid {}", description, pid);
 
                 // Try graceful termination first
                 if process.kill() {
-                    info!("Tool process terminated gracefully for {} with pid {}", tool_id, pid);
+                    info!("Process terminated gracefully for {} with pid {}", description, pid);
                     stopped_count += 1;
                 } else {
-                    warn!("Failed to terminate tool process gracefully for {} with pid {}, attempting force kill", tool_id, pid);
+                    warn!("Failed to terminate process gracefully for {} with pid {}, attempting force kill", description, pid);
                     
                     // Fall back to force kill
                     if let Some(killed) = process.kill_with(Signal::Kill) {
                         if killed {
-                            info!("Tool process force killed for {} with pid {}", tool_id, pid);
+                            info!("Process force killed for {} with pid {}", description, pid);
                             stopped_count += 1;
                         } else {
-                            error!("Failed to force kill tool process for {} with pid {}", tool_id, pid);
+                            error!("Failed to force kill process for {} with pid {}", description, pid);
                         }
                     } else {
-                        error!("Failed to send kill signal to tool process for {} with pid {}", tool_id, pid);
+                        error!("Failed to send kill signal to process for {} with pid {}", description, pid);
                     }
                 }
             }
         }
 
         if stopped_count > 0 {
-            info!("Stopped {} process(es) for tool: {}", stopped_count, tool_id);
+            info!("Stopped {} process(es) for {}", stopped_count, description);
         } else {
-            info!("No running processes found for tool: {}", tool_id);
+            info!("No running processes found for {}", description);
         }
 
         Ok(())
     }
 
     /// Build the command pattern to match for a given tool ID
-    fn build_cmd_pattern(tool_id: &str) -> String {
+    /// Pattern: {tool}\agent (Windows) or {tool}/agent (Unix)
+    fn build_tool_cmd_pattern(tool_id: &str) -> String {
         #[cfg(target_os = "windows")]
         {
-            format!("\\{}\\agent", tool_id).to_lowercase()
+            format!("{}\\agent", tool_id).to_lowercase()
         }
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         {
-            format!("/{}/agent", tool_id).to_lowercase()
+            format!("{}/agent", tool_id).to_lowercase()
+        }
+    }
+
+    /// Build the command pattern to match for a given asset ID and tool ID
+    /// Pattern: \{tool}\{asset} (Windows) or /{tool}/{asset} (Unix)
+    fn build_asset_cmd_pattern(asset_id: &str, tool_id: &str) -> String {
+        #[cfg(target_os = "windows")]
+        {
+            format!("\\{}\\{}", tool_id, asset_id).to_lowercase()
+        }
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        {
+            format!("/{}/{}", tool_id, asset_id).to_lowercase()
         }
     }
 }

--- a/client/src/services/tool_uninstall_service.rs
+++ b/client/src/services/tool_uninstall_service.rs
@@ -71,6 +71,17 @@ impl ToolUninstallService {
         self.tool_kill_service.stop_tool(tool_agent_id).await
             .with_context(|| format!("Failed to stop tool process for: {}", tool_agent_id))?;
 
+        // TODO: make this stop from fleet orbit side or using asset path
+        // Now it's dirty solution to stop osquery manually
+        if (tool.tool_agent_id.to_lowercase().contains("fleet")) {
+            info!("Stopping osqueryd for tool: {}", tool_agent_id);
+            self.tool_kill_service.stop_asset("osqueryd", tool_agent_id).await
+                .with_context(|| format!("Failed to stop tool process for: {}", tool_agent_id))?;
+            info!("Successfully stopped osqueryd for tool: {}", tool_agent_id);
+        } else {
+            info!("Not stopping osqueryd for tool: {}", tool_agent_id);
+        }
+
         // Check if uninstallation command is provided
         if tool.uninstallation_command_args.is_none() {
             info!("No uninstallation command provided for tool: {}, skipping", tool_agent_id);


### PR DESCRIPTION
## Description
It was impossible to remove openframe folder because of running osquery. 
There was used specific asset path to kill osuqery during uninstall. 

## TODO
It was hardcoded that's out of our architecture. 
This solutions was introduced as quick one to unblock testing. 

Fleet agent should be responsible for the osqueryd process kill and cleanup data at openframe uninstall mode.
Should be refactored.
