### PR TITLE
feat: Add Device-Specific Logs Tab with Consistent Table Styling

### DIFF
--- a/openframe/services/openframe-frontend/src/app/devices/components/tabs/software-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/devices/components/tabs/software-tab.tsx
@@ -107,7 +107,7 @@ export function SoftwareTab({ device }: SoftwareTabProps) {
         data={software}
         columns={columns}
         rowKey="id"
-        className="bg-ods-card border border-ods-border rounded-lg"
+        rowClassName="mb-1"
       />
     </div>
   )

--- a/openframe/services/openframe-frontend/src/app/devices/components/tabs/vulnerabilities-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/devices/components/tabs/vulnerabilities-tab.tsx
@@ -214,7 +214,7 @@ export function VulnerabilitiesTab({ device }: VulnerabilitiesTabProps) {
         data={vulnerabilities}
         columns={columns}
         rowKey="unique_key"
-        className="bg-ods-card border border-ods-border rounded-lg"
+        rowClassName="mb-1"
       />
     </div>
   )

--- a/openframe/services/openframe-frontend/src/app/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/logs-page/components/logs-table.tsx
@@ -314,7 +314,14 @@ export function LogsTable({ deviceId, embedded = false }: LogsTableProps = {}) {
   // Embedded mode: return table without ListPageLayout
   if (embedded) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-4 mt-6">
+        {/* Title */}
+        <div className="flex items-center justify-between">
+          <h3 className="font-['Azeret_Mono'] font-medium text-[14px] leading-[20px] tracking-[-0.28px] uppercase text-ods-text-secondary">
+            Logs ({transformedLogs.length})
+          </h3>
+        </div>
+
         {/* Embedded header with search and refresh */}
         <div className="flex items-center gap-4">
           <div className="flex-1">


### PR DESCRIPTION
## Summary
Implemented device-specific logs display on device details page with unified table styling across all device tabs.

## Changes Made

### LogsTable Component Refactoring (`logs-table.tsx`)
- Added optional `deviceId` and `embedded` props for flexible rendering
- **TEMPORARY WORKAROUND**: Client-side deviceId filtering (backend GraphQL doesn't support deviceId in LogFilterInput yet)
- Sends severities and toolTypes to backend, filters logs by deviceId on client
- Dynamic column filtering: hides device column in embedded mode
- Conditional rendering: embedded mode without ListPageLayout, full-page mode with it
- Added title section for embedded mode: "Logs (count)"
- Preserved LogInfoModal (side menu) functionality in both contexts

### LogsTab Integration (`logs-tab.tsx`)
- Integrated LogsTable with `embedded={true}` and device-specific filtering
- Uses machineId as primary identifier with fallback to id
- Added deviceId validation and error handling

### Consistent Table Styling
- **software-tab.tsx**: Added `rowClassName="mb-1"` for consistent row spacing
- **vulnerabilities-tab.tsx**: Added `rowClassName="mb-1"` for consistent row spacing
- **logs-table.tsx**: Uses `rowClassName="mb-1"` consistently
- All tables now have identical spacing and background styling

## Technical Details

### Temporary Client-Side Filtering
Backend GraphQL API doesn't support `deviceId` in `LogFilterInput` yet:
```typescript
// TEMPORARY: Don't pass deviceId to backend (not supported yet)
const backendFilters = useMemo(() => {
  return {
    severities: filters.severities,
    toolTypes: filters.toolTypes
    // deviceId NOT included - backend doesn't support it yet
  }
}, [filters])

// Client-side filtering as workaround
const transformedLogs = useMemo(() => {
  let filteredLogs = logs
  if (deviceId) {
    filteredLogs = logs.filter(log => log.deviceId === deviceId)
  }
  return filteredLogs.map(...)
}, [logs, deviceId])
```

**When backend adds deviceId support**:
1. Add deviceId to backendFilters
2. Remove client-side filter (lines 79-81)

### Dynamic UI Adaptations
- **Embedded mode**: Title + search + table without ListPageLayout wrapper
- **Full-page mode**: Complete ListPageLayout with all features
- **Column visibility**: Device column hidden when showing device-specific logs

## Features
✅ Single reusable LogsTable component for both contexts ✅ Device-specific log filtering (client-side workaround) ✅ Side menu modal (LogInfoModal) works in both modes ✅ Consistent table styling across all device tabs
✅ Dynamic column visibility based on context
✅ Unified title sections with counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->
