### PR TITLE
feat: Add Device Information to Logs with Compact Card Component

### DIFF
--- a/openframe/services/openframe-frontend/src/app/log-details/components/log-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/log-details/components/log-details-view.tsx
@@ -155,7 +155,13 @@ export function LogDetailsView({ logId, ingestDay, toolType, eventType, timestam
         </div>
 
         {/* Device Info Section */}
-        {logDetails.deviceId && <DeviceInfoSection deviceId={logDetails.deviceId} userId={logDetails.userId} />}
+        {logDetails.deviceId && (
+          <DeviceInfoSection
+            deviceId={logDetails.deviceId}
+            userId={logDetails.userId}
+            device={logDetails.device}
+          />
+        )}
 
         {/* Full Information Section */}
         <FullInformationSection logDetails={logDetails} />

--- a/openframe/services/openframe-frontend/src/app/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/logs-page/components/logs-table.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   ListPageLayout,
   TableDescriptionCell,
+  DeviceCardCompact,
   type TableColumn,
   type RowAction
 } from "@flamingo/ui-kit/components/ui"
@@ -102,8 +103,10 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
           toolType: toUiKitToolType(log.toolType)
         },
         device: {
-          name: log.deviceId ? log.deviceId === 'null' ? '' : log.deviceId : '',
-          organization: log.userId ? log.userId === 'null' ? '' : log.userId : ''
+          // Use device.hostname if available, fallback to deviceId
+          name: log.device?.hostname || log.hostname || log.deviceId || '-',
+          // Use device.organization (string) if available, fallback to organizationName or userId
+          organization: log.device?.organization || log.organizationName || log.userId || '-'
         },
         description: {
           title: log.summary || 'No summary available',
@@ -119,7 +122,7 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
       {
         key: 'logId',
         label: 'Log ID',
-        width: 'w-1/3',
+        width: 'w-[200px]',
         renderCell: (log) => (
           <div className="flex flex-col justify-center shrink-0">
             <span className="font-['DM_Sans'] font-medium text-[18px] leading-[24px] text-ods-text-primary truncate">
@@ -134,7 +137,7 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
       {
         key: 'status',
         label: 'Status',
-        width: 'w-1/6',
+        width: 'w-[120px]',
         filterable: true,
         filterOptions: [
           { id: 'ERROR', label: 'Error', value: 'ERROR' },
@@ -155,7 +158,7 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
       {
         key: 'tool',
         label: 'Tool',
-        width: 'w-1/6',
+        width: 'w-[160px]',
         filterable: true,
         filterOptions: [
           { id: 'tactical', label: 'Tactical', value: 'tactical' },
@@ -172,23 +175,18 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
       {
         key: 'device',
         label: 'DEVICE',
-        width: 'w-1/6',
+        width: 'w-[240px]',
         renderCell: (log) => (
-          <div className="bg-ods-card box-border content-stretch flex gap-4 h-20 items-center justify-start py-0 relative shrink-0 w-full">
-            {log.device.name && (
-              <div className="font-['DM_Sans'] font-medium text-[18px] leading-[20px] text-ods-text-primary truncate">
-                <p className="leading-[24px] overflow-ellipsis overflow-hidden whitespace-pre">
-                  {log.device.name}
-                </p>
-              </div>
-            )}
-          </div>
+          <DeviceCardCompact
+            deviceName={log.device.name}
+            organization={log.device.organization}
+          />
         )
       },
       {
         key: 'description',
         label: 'Log Details',
-        width: 'w-1/2',
+        width: 'flex-1',
         renderCell: (log) => (
           <TableDescriptionCell text={log.description.title} />
         )

--- a/openframe/services/openframe-frontend/src/app/logs-page/queries/logs-queries.ts
+++ b/openframe/services/openframe-frontend/src/app/logs-page/queries/logs-queries.ts
@@ -14,6 +14,9 @@ export const GET_LOGS_QUERY = `
           severity
           userId
           deviceId
+          hostname
+          organizationName
+          organizationId
           summary
           timestamp
           __typename
@@ -48,6 +51,9 @@ export const GET_LOG_DETAILS_QUERY = `
       severity
       userId
       deviceId
+      hostname
+      organizationName
+      organizationId
       message
       timestamp
       details

--- a/openframe/services/openframe-frontend/src/app/logs-page/stores/logs-store.ts
+++ b/openframe/services/openframe-frontend/src/app/logs-page/stores/logs-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
+import type { Device } from '../../devices/types/device.types'
 
 /**
  * Logs Store
@@ -20,6 +21,15 @@ export interface LogEntry {
   timestamp: string
   details?: string
   metadata?: Record<string, any>
+
+  // New device-related fields from backend
+  hostname?: string
+  organizationName?: string
+  organizationId?: string
+
+  // Transformed device object (follows Device type pattern)
+  device?: Partial<Device>
+
   __typename?: string
 }
 


### PR DESCRIPTION
## Summary
- Integrated device information from GraphQL logs schema into frontend
- Created `DeviceCardCompact` component in ui-kit for table display
- Added data transformation layer to map flat backend fields to Device type structure
- Fixed device information fetching in log modal
- Optimized column widths and empty state handling

## Changes Made

### Backend Integration
- **GraphQL Queries** (`logs-queries.ts`): Added `hostname`, `organizationName`, `organizationId` fields
- **Store Types** (`logs-store.ts`): Extended `LogEntry` interface with device-related fields and `device?: Partial<Device>` object
- **Data Transformation** (`use-logs.ts`): 
  - Added `transformLogEntry()` function to map flat backend fields to nested Device structure
  - Handles cases where device data is partial or missing
  - Applies transformation to both logs list and log details

### UI Components
- **DeviceCardCompact Component** (ui-kit): 
  - New compact variant specifically for table cells
  - Displays device name and organization in stacked layout
  - Returns empty fragment when both values are missing/null
  - Handles edge cases: null, undefined, '-', string 'null'
  
- **Logs Table** (`logs-table.tsx`):
  - Replaced inline device rendering with `DeviceCardCompact` component
  - Updated column widths: Tool=160px, Device=240px, Log Details=flex-1
  - Proper empty state handling

- **Log Info Modal** (`log-info-modal.tsx`):
  - Fixed critical bug where device wasn't fetched properly
  - Changed to ALWAYS fetch full device object when deviceId exists
  - Previously tried to skip fetch if partial data existed, but partial log data was insufficient for DeviceCard

- **Device Info Section** (`device-info-section.tsx`):
  - Accepts device prop from log data
  - Only fetches full device if not provided

## Technical Details

### Data Flow
```
Backend (GraphQL) → use-logs.ts transformation → logs-store → UI Components
  hostname              device.hostname            DeviceCardCompact
  organizationName  →   device.organization    →   (name + org display)
  organizationId        device.organizationId
```

### Device Type Reuse
- Leverages existing `Partial<Device>` type for consistency
- Maintains backward compatibility with flat fields
- organization is string (not object) as per Device type

### Column Layout
- Log ID: 200px (timestamp + ID)
- Status: 120px (status badge)
- Tool: 160px (tool badge)
- Device: 240px (name + organization)
- Log Details: flex-1 (remaining space)

## Related Changes
- **ui-kit commit 5c3fcca**: Created `DeviceCardCompact` component and exported from ui-kit

🤖 Generated with [Claude Code](https://claude.com/claude-code)