### PR TITLE
Mesh installation and osquery from github

### DIFF
--- a/clients/openframe-client/src/models/download_configuration.rs
+++ b/clients/openframe-client/src/models/download_configuration.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 pub struct DownloadConfiguration {
     pub os: String,
     pub file_name: String,
-    pub agent_file_name: String,
+    pub target_file_name: String,
     pub link: String,
 }
 
 impl DownloadConfiguration {
-    /// Returns true if agent_file_name is a path (requires extracting entire archive).
+    /// Returns true if target_file_name is a path (requires extracting entire archive).
     pub fn is_folder_extraction(&self) -> bool {
-        Path::new(&self.agent_file_name).components().count() > 1
+        Path::new(&self.target_file_name).components().count() > 1
     }
 
     /// Checks if this configuration matches the current OS

--- a/clients/openframe-client/src/models/tool_installation_message.rs
+++ b/clients/openframe-client/src/models/tool_installation_message.rs
@@ -39,9 +39,9 @@ pub enum SessionType {
 pub struct Asset {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub local_filename: Option<String>, // Deprecated: use localFilenameConfiguration instead
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_filename_configuration: Option<Vec<LocalFilenameConfiguration>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub download_configurations: Option<Vec<DownloadConfiguration>>,
     pub source: AssetSource,
     pub path: Option<String>,
     #[serde(default)]
@@ -61,4 +61,6 @@ pub enum AssetSource {
     Artifactory,
     #[serde(rename = "TOOL_API")]
     ToolApi,
+    #[serde(rename = "GITHUB")]
+    Github,
 }

--- a/clients/openframe-client/src/models/tool_installation_message.rs
+++ b/clients/openframe-client/src/models/tool_installation_message.rs
@@ -38,11 +38,21 @@ pub enum SessionType {
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
     pub id: String,
-    pub local_filename: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_filename: Option<String>, // Deprecated: use localFilenameConfiguration instead
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_filename_configuration: Option<Vec<LocalFilenameConfiguration>>,
     pub source: AssetSource,
     pub path: Option<String>,
     #[serde(default)]
     pub executable: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalFilenameConfiguration {
+    pub filename: String,
+    pub os: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/clients/openframe-client/src/models/tool_installation_message.rs
+++ b/clients/openframe-client/src/models/tool_installation_message.rs
@@ -39,6 +39,10 @@ pub enum SessionType {
 pub struct Asset {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>, // Optional: version for GITHUB source
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_filename: Option<String>, // Deprecated: use localFilenameConfiguration instead
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub local_filename_configuration: Option<Vec<LocalFilenameConfiguration>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub download_configurations: Option<Vec<DownloadConfiguration>>,

--- a/clients/openframe-client/src/services/github_download_service.rs
+++ b/clients/openframe-client/src/services/github_download_service.rs
@@ -47,15 +47,15 @@ impl GithubDownloadService {
         }
 
         // Extract based on file extension
-        info!("Archive file_name: '{}', agent_file_name: '{}'", config.file_name, config.agent_file_name);
+        info!("Archive file_name: '{}', target_file_name: '{}'", config.file_name, config.target_file_name);
 
         let binary_bytes = if config.file_name.ends_with(".zip") {
             info!("Detected ZIP format, extracting...");
-            self.extract_from_zip(archive_bytes, &config.agent_file_name)
+            self.extract_from_zip(archive_bytes, &config.target_file_name)
                 .with_context(|| "Failed to extract from ZIP archive")?
         } else if config.file_name.ends_with(".tar.gz") || config.file_name.ends_with(".tgz") {
             info!("Detected tar.gz format, extracting...");
-            self.extract_from_tar_gz(archive_bytes, &config.agent_file_name)
+            self.extract_from_tar_gz(archive_bytes, &config.target_file_name)
                 .with_context(|| "Failed to extract from tar.gz archive")?
         } else {
             return Err(anyhow!("Unsupported archive format: {}", config.file_name));
@@ -70,7 +70,7 @@ impl GithubDownloadService {
             ));
         }
 
-        info!("Extracted binary: {} ({} bytes)", config.agent_file_name, binary_bytes.len());
+        info!("Extracted binary: {} ({} bytes)", config.target_file_name, binary_bytes.len());
 
         Ok(binary_bytes)
     }
@@ -277,13 +277,13 @@ impl GithubDownloadService {
         default_agent_path: &Path,
     ) -> Result<Option<String>> {
         if config.is_folder_extraction() {
-            let file_path = tool_folder_path.join(&config.agent_file_name);
+            let file_path = tool_folder_path.join(&config.target_file_name);
             self.download_and_extract_all(config, tool_folder_path).await?;
             Self::set_executable_permissions(&file_path).await?;
             if !file_path.exists() {
                 warn!("Executable not found at {} after extraction", file_path.display());
             }
-            Ok(Some(config.agent_file_name.clone()))
+            Ok(Some(config.target_file_name.clone()))
         } else {
             let bytes = self.download_and_extract(config).await?;
             File::create(default_agent_path).await?.write_all(&bytes).await?;

--- a/clients/openframe-client/src/services/openframe_client_update_service.rs
+++ b/clients/openframe-client/src/services/openframe_client_update_service.rs
@@ -163,7 +163,7 @@ impl OpenFrameClientUpdateService {
         update_state.set_phase(UpdatePhase::PreparingUpdater);
         self.update_state_service.save(update_state).await?;
 
-        let archive_path = match self.create_temp_archive(&binary_bytes, &download_config.agent_file_name).await {
+        let archive_path = match self.create_temp_archive(&binary_bytes, &download_config.target_file_name).await {
             Ok(path) => path,
             Err(e) => {
                 error!("Failed to create archive: {:#}", e);

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -161,10 +161,21 @@ impl ToolInstallationService {
 
         // Download and save assets
         if let Some(ref assets) = tool_installation_message.assets {
+            let current_os = Self::get_current_os();
+            
             for asset in assets {
+                // Resolve local filename based on OS
+                let local_filename = match Self::resolve_asset_filename(asset, current_os) {
+                    Some(filename) => filename,
+                    None => {
+                        warn!("Asset {} has no valid filename configuration for OS: {}, skipping", asset.id, current_os);
+                        continue;
+                    }
+                };
+                
                 // Use the executable field from the asset
                 let is_executable = asset.executable;
-                let asset_path = self.directory_manager.get_asset_path(tool_agent_id, &asset.local_filename, is_executable);
+                let asset_path = self.directory_manager.get_asset_path(tool_agent_id, &local_filename, is_executable);
                 
                 // Check if asset file already exists
                 if asset_path.exists() {
@@ -196,6 +207,19 @@ impl ToolInstallationService {
                             .get_tool_asset(tool_id, resolved_path)
                             .await
                             .with_context(|| format!("Failed to download tool API asset: {}", asset.id))?
+                    },
+                    AssetSource::Github => {
+                        info!("Downloading GitHub asset: {}", asset.id);
+                        let download_configs = asset.download_configurations.as_ref()
+                            .with_context(|| format!("No downloadConfigurations for GitHub asset: {}", asset.id))?;
+                        
+                        let config = GithubDownloadService::find_config_for_current_os(download_configs)
+                            .with_context(|| format!("No download config for current OS for asset: {}", asset.id))?;
+                        
+                        self.github_download_service
+                            .download_and_extract(config)
+                            .await
+                            .with_context(|| format!("Failed to download GitHub asset: {}", asset.id))?
                     }
                 };
                 
@@ -205,6 +229,21 @@ impl ToolInstallationService {
                 if is_executable {
                     self.set_executable_permissions(&asset_path).await
                         .with_context(|| format!("Failed to set executable permissions for asset {}", asset_path.display()))?;
+
+                    // Publish installed asset message for GitHub assets with version
+                    if let AssetSource::Github = asset.source {
+                        if let Some(ref version) = asset.version {
+                            info!("Publishing installed asset message for: {} v{}", asset.id, version);
+                            if let Ok(machine_id) = self.config_service.get_machine_id().await {
+                                if let Err(e) = self.installed_agent_publisher
+                                    .publish(machine_id, asset.id.clone(), version.clone())
+                                    .await
+                                {
+                                    warn!("Failed to publish installed asset message for {}: {:#}", asset.id, e);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 info!("Asset {} saved to: {}", asset.id, asset_path.display());
@@ -324,5 +363,39 @@ impl ToolInstallationService {
             fs::set_permissions(path, perms).await?;
         }
         Ok(())
+    }
+
+    /// Returns the current operating system as a string
+    fn get_current_os() -> &'static str {
+        if cfg!(target_os = "windows") {
+            "windows"
+        } else if cfg!(target_os = "macos") {
+            "macos"
+        } else if cfg!(target_os = "linux") {
+            "linux"
+        } else {
+            "unknown"
+        }
+    }
+
+    /// Resolves the asset filename based on OS-specific configuration
+    /// Returns None if no valid configuration found for current OS
+    fn resolve_asset_filename(asset: &crate::models::tool_installation_message::Asset, current_os: &str) -> Option<String> {
+        // Try new localFilenameConfiguration first
+        if let Some(ref configs) = asset.local_filename_configuration {
+            if let Some(config) = configs.iter().find(|c| c.os.eq_ignore_ascii_case(current_os)) {
+                info!("Using OS-specific filename for asset {}: {} (os: {})", 
+                      asset.id, config.filename, current_os);
+                return Some(config.filename.clone());
+            }
+        }
+        
+        // Fallback to legacy localFilename field (backward compatibility)
+        if let Some(ref filename) = asset.local_filename {
+            info!("Using legacy localFilename for asset {}: {}", asset.id, filename);
+            return Some(filename.clone());
+        }
+        
+        None
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <grpc.version>1.58.0</grpc.version>
         <!-- Centralized OpenFrame OSS libs version -->
-        <openframe.libs.version>5.23.0</openframe.libs.version>
+        <openframe.libs.version>5.26.0</openframe.libs.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches tool installation and client update download/extraction paths and introduces new message schema fields, so misconfigured configs could break installs/updates across OSes.
> 
> **Overview**
> Adds support for installing tool *assets* from GitHub releases: `AssetSource::Github` can now download per-OS archives via `downloadConfigurations`, extract the target binary, and save it alongside other assets.
> 
> Evolves the installation message schema to support optional `version`, OS-specific `localFilenameConfiguration` (with legacy `localFilename` fallback), and switches `DownloadConfiguration` from `agent_file_name` to `target_file_name` across download/update flows.
> 
> Bumps the shared `openframe.libs.version` from `5.23.0` to `5.26.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2191a60f74c399b685d247c0a618284165b5c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->