### PR TITLE
feat: backoff retries

### DIFF
--- a/clients/openframe-client/src/services/registration_processor.rs
+++ b/clients/openframe-client/src/services/registration_processor.rs
@@ -1,10 +1,14 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use tokio::time::{sleep, Duration};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::services::AgentRegistrationService;
 use crate::services::agent_configuration_service::AgentConfigurationService;
 use crate::models::AgentRegistrationResponse;
+
+const MAX_RETRIES: u32 = 5;
+const INITIAL_BACKOFF_SECS: u64 = 30;
+const MAX_BACKOFF_SECS: u64 = 240;
 
 #[derive(Clone)]
 pub struct RegistrationProcessor {
@@ -34,19 +38,24 @@ impl RegistrationProcessor {
         }
 
         info!("No machine_id found – starting registration loop");
-        loop {
+        for attempt in 1..=MAX_RETRIES {
             match self.attempt_registration().await {
                 Ok(_) => {
                     info!("Registration succeeded");
                     return Ok(());
                 }
                 Err(e) => {
-                    error!("Registration attempt failed. Retrying in 60 seconds…: {:#}", e);
-                    // TODO: Add exponential backoff
-                    sleep(Duration::from_secs(60)).await;
+                    let backoff_secs = (INITIAL_BACKOFF_SECS * 2u64.pow(attempt - 1)).min(MAX_BACKOFF_SECS);
+                    error!(
+                        "Registration attempt {}/{} failed. Retrying in {} seconds: {:#}",
+                        attempt, MAX_RETRIES, backoff_secs, e
+                    );
+                    sleep(Duration::from_secs(backoff_secs)).await;
                 }
             }
         }
+
+        bail!("Registration failed after {} attempts", MAX_RETRIES)
     }
 
     async fn attempt_registration(&self) -> Result<AgentRegistrationResponse> {

--- a/clients/openframe-client/src/services/registration_processor.rs
+++ b/clients/openframe-client/src/services/registration_processor.rs
@@ -45,12 +45,12 @@ impl RegistrationProcessor {
                     return Ok(());
                 }
                 Err(e) => {
-                    let backoff_secs = (INITIAL_BACKOFF_SECS * 2u64.pow(attempt - 1)).min(MAX_BACKOFF_SECS);
-                    error!(
-                        "Registration attempt {}/{} failed. Retrying in {} seconds: {:#}",
-                        attempt, MAX_RETRIES, backoff_secs, e
-                    );
-                    sleep(Duration::from_secs(backoff_secs)).await;
+                    error!("Registration attempt {}/{} failed: {:#}", attempt, MAX_RETRIES, e);
+                    if attempt < MAX_RETRIES {
+                        let backoff_secs = (INITIAL_BACKOFF_SECS * 2u64.pow(attempt - 1)).min(MAX_BACKOFF_SECS);
+                        info!("Retrying in {} seconds", backoff_secs);
+                        sleep(Duration::from_secs(backoff_secs)).await;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup/registration control flow by adding a hard retry limit, which could cause agents to stop attempting registration in environments with prolonged outages or intermittent failures.
> 
> **Overview**
> The agent registration processor now performs a **bounded retry loop** (max 5 attempts) instead of retrying indefinitely.
> 
> Retry delays now use **exponential backoff** (30s doubling up to 240s), and the processor returns an explicit error via `bail!` after exhausting retries; logging was updated to include attempt counts and remove unused `warn` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c27cf0fce9d5f75e8f00d85f2dc01442d4e09bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->