### PR TITLE
Add windows scm recovery configurations

### DIFF
--- a/clients/openframe-client/src/service.rs
+++ b/clients/openframe-client/src/service.rs
@@ -4,21 +4,29 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{error, info, warn};
 
+use crate::installation_initial_config_service::{
+    InstallConfigParams, InstallationInitialConfigService,
+};
 use crate::platform::permissions::{Capability, PermissionUtils};
-use crate::service_adapter::{CrossPlatformServiceManager, ServiceConfig};
+use crate::service_adapter::{CrossPlatformServiceManager, RecoveryConfig, ServiceConfig};
 use crate::{platform::DirectoryManager, Client};
-use crate::installation_initial_config_service::{InstallationInitialConfigService, InstallConfigParams};
 
 #[cfg(windows)]
 use windows_service::{
-    define_windows_service, service_dispatcher,
+    define_windows_service,
     service::{ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus, ServiceType},
     service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
+    service_dispatcher,
 };
 
 const SERVICE_NAME: &str = "client";
 const DISPLAY_NAME: &str = "OpenFrame Client Service";
 const DESCRIPTION: &str = "OpenFrame client service for remote management and monitoring";
+
+// Windows SCM recovery policy: restart on every failure after a 5-minute delay,
+// reset the failure counter after a full day of clean operation.
+const RESTART_SERVICE_SECS: u64 = 300;
+const RECOVERY_RESET_PERIOD_DAYS: u32 = 1;
 
 // Full service identifier used by all platforms
 // Format: "com.openframe.{SERVICE_NAME}" -> "com.openframe.client"
@@ -47,7 +55,7 @@ fn windows_service_main(_args: Vec<std::ffi::OsString>) {
                     if let Some(tx) = shutdown_tx.lock().unwrap().take() {
                         let _ = tx.send(());
                     }
-                    
+
                     ServiceControlHandlerResult::NoError
                 }
                 ServiceControl::Interrogate => {
@@ -310,6 +318,13 @@ impl Service {
             file_limit: Some(4096),
             exit_timeout_seconds: Some(10),
             is_interactive: true,
+            recovery: Some(RecoveryConfig {
+                first_restart_secs: RESTART_SERVICE_SECS,
+                second_restart_secs: RESTART_SERVICE_SECS,
+                subsequent_restart_secs: RESTART_SERVICE_SECS,
+                reset_period_days: RECOVERY_RESET_PERIOD_DAYS,
+                enable_on_non_crash_failures: true,
+            }),
             ..ServiceConfig::default()
         };
 
@@ -552,9 +567,9 @@ impl Service {
     /// Broadcast environment change notification to Windows
     #[cfg(target_os = "windows")]
     fn broadcast_environment_change() -> Result<()> {
-        use windows::Win32::UI::WindowsAndMessaging::*;
-        use windows::Win32::Foundation::*;
         use windows::core::PCWSTR;
+        use windows::Win32::Foundation::*;
+        use windows::Win32::UI::WindowsAndMessaging::*;
 
         unsafe {
             let env_str: Vec<u16> = "Environment\0".encode_utf16().collect();

--- a/clients/openframe-client/src/service.rs
+++ b/clients/openframe-client/src/service.rs
@@ -25,7 +25,9 @@ const DESCRIPTION: &str = "OpenFrame client service for remote management and mo
 
 // Windows SCM recovery policy: restart on every failure after a 5-minute delay,
 // reset the failure counter after a full day of clean operation.
-const RESTART_SERVICE_SECS: u64 = 300;
+const FIRST_RESTART_SERVICE_SECS: u64 = 10;
+const SECOND_RESTART_SERVICE_SECS: u64 = 60;
+const SUBSEQUENT_RESTART_SERVICE_SECS: u64 = 300;
 const RECOVERY_RESET_PERIOD_DAYS: u32 = 1;
 
 // Full service identifier used by all platforms
@@ -319,9 +321,9 @@ impl Service {
             exit_timeout_seconds: Some(10),
             is_interactive: true,
             recovery: Some(RecoveryConfig {
-                first_restart_secs: RESTART_SERVICE_SECS,
-                second_restart_secs: RESTART_SERVICE_SECS,
-                subsequent_restart_secs: RESTART_SERVICE_SECS,
+                first_restart_secs: FIRST_RESTART_SERVICE_SECS,
+                second_restart_secs: SECOND_RESTART_SERVICE_SECS,
+                subsequent_restart_secs: SUBSEQUENT_RESTART_SERVICE_SECS,
                 reset_period_days: RECOVERY_RESET_PERIOD_DAYS,
                 enable_on_non_crash_failures: true,
             }),

--- a/clients/openframe-client/src/service_adapter.rs
+++ b/clients/openframe-client/src/service_adapter.rs
@@ -201,15 +201,7 @@ impl CrossPlatformServiceManager {
                 let service_name = format!("com.openframe.{}", self.config.name.to_lowercase());
                 apply_windows_recovery(&service_name, recovery)
                     .context("Failed to configure Windows recovery actions")?;
-                info!(
-                    "Configured Windows recovery for '{}': restart after {}s/{}s/{}s, reset counter after {} day(s), non-crash-failures={}",
-                    service_name,
-                    recovery.first_restart_secs,
-                    recovery.second_restart_secs,
-                    recovery.subsequent_restart_secs,
-                    recovery.reset_period_days,
-                    recovery.enable_on_non_crash_failures,
-                );
+                info!("Configured Windows recovery for '{}'", service_name);
             }
         }
 

--- a/clients/openframe-client/src/service_adapter.rs
+++ b/clients/openframe-client/src/service_adapter.rs
@@ -11,6 +11,16 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tracing::{debug, error, info, warn};
 
+/// Windows SCM recovery ("failure actions") configuration.
+#[derive(Debug, Clone)]
+pub struct RecoveryConfig {
+    pub first_restart_secs: u64,
+    pub second_restart_secs: u64,
+    pub subsequent_restart_secs: u64,
+    pub reset_period_days: u32,
+    pub enable_on_non_crash_failures: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct ServiceConfig {
     // Basic service information
@@ -43,6 +53,9 @@ pub struct ServiceConfig {
 
     // Process type - maps to Interactive on macOS
     pub is_interactive: bool,
+
+    // Windows SCM recovery actions
+    pub recovery: Option<RecoveryConfig>,
 }
 
 impl Default for ServiceConfig {
@@ -65,6 +78,7 @@ impl Default for ServiceConfig {
             file_limit: None,
             exit_timeout_seconds: None,
             is_interactive: true,
+            recovery: None,
         }
     }
 }
@@ -179,6 +193,25 @@ impl CrossPlatformServiceManager {
         // Install the service using the platform's native service manager
         info!("Installing service with full configuration via CrossPlatformServiceManager");
         manager.install(ctx).context("Failed to install service")?;
+
+        // Apply Windows SCM recovery actions (no-op on other platforms).
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(recovery) = &self.config.recovery {
+                let service_name = format!("com.openframe.{}", self.config.name.to_lowercase());
+                apply_windows_recovery(&service_name, recovery)
+                    .context("Failed to configure Windows recovery actions")?;
+                info!(
+                    "Configured Windows recovery for '{}': restart after {}s/{}s/{}s, reset counter after {} day(s), non-crash-failures={}",
+                    service_name,
+                    recovery.first_restart_secs,
+                    recovery.second_restart_secs,
+                    recovery.subsequent_restart_secs,
+                    recovery.reset_period_days,
+                    recovery.enable_on_non_crash_failures,
+                );
+            }
+        }
 
         // After installation, start the service to ensure it's running
         self.start()?;
@@ -608,4 +641,64 @@ impl CrossPlatformServiceManager {
             }
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn apply_windows_recovery(service_name: &str, cfg: &RecoveryConfig) -> Result<()> {
+    use std::time::Duration;
+    use windows_service::{
+        service::{
+            ServiceAccess, ServiceAction, ServiceActionType, ServiceFailureActions,
+            ServiceFailureResetPeriod,
+        },
+        service_manager::{ServiceManager, ServiceManagerAccess},
+    };
+
+    let scm = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
+        .context("Failed to connect to service control manager")?;
+
+    let service = scm
+        .open_service(
+            service_name,
+            ServiceAccess::CHANGE_CONFIG | ServiceAccess::START,
+        )
+        .context("Failed to open service for recovery configuration")?;
+
+    // Three entries: index 0 = first failure, 1 = second, 2 = subsequent.
+    // Delay is the pause before SCM performs the action.
+    let actions = vec![
+        ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: Duration::from_secs(cfg.first_restart_secs),
+        },
+        ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: Duration::from_secs(cfg.second_restart_secs),
+        },
+        ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: Duration::from_secs(cfg.subsequent_restart_secs),
+        },
+    ];
+
+    let reset_period = Duration::from_secs(cfg.reset_period_days as u64 * 86_400);
+
+    service
+        .update_failure_actions(ServiceFailureActions {
+            reset_period: ServiceFailureResetPeriod::After(reset_period),
+            reboot_msg: None,
+            command: None,
+            actions: Some(actions),
+        })
+        .context("Failed to update service failure actions")?;
+
+    // Without this, SCM only treats crashes as failures — a clean exit(1)
+    // would silently skip recovery.
+    if cfg.enable_on_non_crash_failures {
+        service
+            .set_failure_actions_on_non_crash_failures(true)
+            .context("Failed to enable failure actions on non-crash failures")?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Description
Added windows scm recovery configurations with following "Recovery policy":
- First failure → restart after 10 sec
- Second failure → restart after 1 min
- Subsequent failures → restart after 5 min
- Reset failure counter after 1 day

## Task
[Add Windows SCM recovery actions to OpenFrame Client service](https://app.clickup.com/t/86ah0g7wg)
<!-- Links to any related tickets, issues, or requirements -->
