### PR TITLE
Register fae as an app

### DIFF
--- a/clients/openframe-chat/src-tauri/Cargo.lock
+++ b/clients/openframe-chat/src-tauri/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2527,6 +2527,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -5424,6 +5425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/clients/openframe-chat/src-tauri/Cargo.toml
+++ b/clients/openframe-chat/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ notify = "6.1"
 
 [target.'cfg(windows)'.dependencies]
 dirs = "5"
+winreg = "0.52"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -114,8 +114,33 @@ fn log_from_js(level: String, scope: String, message: String) {
     }
 }
 
+#[cfg(target_os = "windows")]
+fn register_app_id() {
+    use winreg::{enums::*, RegKey};
+
+    extern "system" {
+        fn SetCurrentProcessExplicitAppUserModelID(app_id: *const u16) -> i32;
+    }
+    let aumid: Vec<u16> = "com.openframe.chat\0".encode_utf16().collect();
+    unsafe { SetCurrentProcessExplicitAppUserModelID(aumid.as_ptr()); }
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    if let Ok((key, _)) =
+        hkcu.create_subkey(r"Software\Classes\AppUserModelId\com.openframe.chat")
+    {
+        let _ = key.set_value("DisplayName", &"Fae Chat");
+        if let Ok(exe) = std::env::current_exe() {
+            let icon = exe.to_string_lossy().into_owned();
+            let _ = key.set_value("IconUri", &icon.as_str());
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "windows")]
+    register_app_id();
+
     println!("[startup] openframe-chat starting (version {})", env!("CARGO_PKG_VERSION"));
 
     // Read configuration from CFPreferences (written by openframe-client daemon)

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -114,31 +114,9 @@ fn log_from_js(level: String, scope: String, message: String) {
     }
 }
 
-#[cfg(target_os = "windows")]
-fn register_app_id() {
-    use winreg::{enums::*, RegKey};
-
-    extern "system" {
-        fn SetCurrentProcessExplicitAppUserModelID(app_id: *const u16) -> i32;
-    }
-    let aumid: Vec<u16> = "com.openframe.chat\0".encode_utf16().collect();
-    unsafe { SetCurrentProcessExplicitAppUserModelID(aumid.as_ptr()); }
-
-    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    if let Ok((key, _)) =
-        hkcu.create_subkey(r"Software\Classes\AppUserModelId\com.openframe.chat")
-    {
-        let _ = key.set_value("DisplayName", &"Fae Chat");
-        if let Ok(exe) = std::env::current_exe() {
-            let icon = exe.to_string_lossy().into_owned();
-            let _ = key.set_value("IconUri", &icon.as_str());
-        }
-    }
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    println!("[INFO] OpenFrame Chat starting...");
+    println!("[startup] openframe-chat starting (version {})", env!("CARGO_PKG_VERSION"));
 
     // Read configuration from CFPreferences (written by openframe-client daemon)
     let config = config_reader::AppConfig::from_preferences();

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -114,9 +114,31 @@ fn log_from_js(level: String, scope: String, message: String) {
     }
 }
 
+#[cfg(target_os = "windows")]
+fn register_app_id() {
+    use winreg::{enums::*, RegKey};
+
+    extern "system" {
+        fn SetCurrentProcessExplicitAppUserModelID(app_id: *const u16) -> i32;
+    }
+    let aumid: Vec<u16> = "com.openframe.chat\0".encode_utf16().collect();
+    unsafe { SetCurrentProcessExplicitAppUserModelID(aumid.as_ptr()); }
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    if let Ok((key, _)) =
+        hkcu.create_subkey(r"Software\Classes\AppUserModelId\com.openframe.chat")
+    {
+        let _ = key.set_value("DisplayName", &"Fae Chat");
+        if let Ok(exe) = std::env::current_exe() {
+            let icon = exe.to_string_lossy().into_owned();
+            let _ = key.set_value("IconUri", &icon.as_str());
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    println!("[startup] openframe-chat starting (version {})", env!("CARGO_PKG_VERSION"));
+    println!("[INFO] OpenFrame Chat starting...");
 
     // Read configuration from CFPreferences (written by openframe-client daemon)
     let config = config_reader::AppConfig::from_preferences();


### PR DESCRIPTION
## Description
Register openframe-chat as app to be able to use and process "AppUserModelID".

## Improvements
1. Add the new crate: winreg = "0.52" in [target.'cfg(windows)'.dependencies].
2. Writes HKCU\Software\Classes\AppUserModelId\com.openframe.chat with DisplayName = "Fae Chat"
3. Calls SetCurrentProcessExplicitAppUserModelID via raw FFI (no extra dependency)

## Task
[Not defined](https://app.clickup.com/t/example)