### PR TITLE
chore(): bump openframe-frontend-core to 0.0.204

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.203",
+        "@flamingo-stack/openframe-frontend-core": "0.0.204",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.203",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.203.tgz",
-      "integrity": "sha512-At1qQtmC832mbEHK+rfdyHW5lPTGNnBqx/A3HgenpWlWt3rYMj8Gh37jp5H4TDuLcTpzuRqifuHd8zKAMyKEZw==",
+      "version": "0.0.204",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.204.tgz",
+      "integrity": "sha512-wHFp78SIpY1rZgh16tSJFMCF+5j/7hiVtabLkqHTHYAPmc1qeEd4F07kn0pOr09F042AnLIHeFzUuaZ1PbVKEw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.203",
+    "@flamingo-stack/openframe-frontend-core": "0.0.204",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Summary
- Bump `@flamingo-stack/openframe-frontend-core` from 0.0.203 to 0.0.204 in `openframe/services/openframe-frontend`

## Test plan
- [ ] `npm install` succeeds
- [ ] `npm run type-check` passes
- [ ] `npm run lint:biome` passes
- [ ] `npm run build` passes
- [ ] Smoke test the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)