### PR TITLE
fix(frontend): use local timezone and ODS text tokens in schedule history

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-history-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-history-tab.tsx
@@ -111,22 +111,18 @@ export function ScheduleHistoryTab({ schedule, scheduleId }: ScheduleHistoryTabP
           const entry = row.original;
           return (
             <div className="flex flex-col">
-              <span className="font-['Azeret_Mono'] font-medium text-[18px] leading-[24px] text-ods-text-primary">
-                LOG-{String(entry.id).padStart(3, '0')}
-              </span>
-              <span className="font-medium text-[14px] leading-[20px] text-ods-text-secondary">
+              <span className="text-h4 text-ods-text-primary">LOG-{String(entry.id).padStart(3, '0')}</span>
+              <span className="text-h6 text-ods-text-secondary">
                 {entry.last_run
                   ? new Date(entry.last_run).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: '2-digit',
                       day: '2-digit',
-                      timeZone: 'UTC',
                     }) +
                     ',' +
                     new Date(entry.last_run).toLocaleTimeString('en-US', {
                       hour: '2-digit',
                       minute: '2-digit',
-                      timeZone: 'UTC',
                     })
                   : '—'}
               </span>


### PR DESCRIPTION
## Summary
- Removed forced UTC timezone from schedule history `last_run` date/time formatting so timestamps render in the user's local timezone
- Replaced inline font/size classes with ODS design tokens (`text-h4`, `text-h6`) per frontend conventions

## Test plan
- [ ] Open a script schedule, switch to the History tab
- [ ] Verify LOG entries display the run timestamp in the local browser timezone
- [ ] Verify typography matches surrounding ODS-styled text

🤖 Generated with [Claude Code](https://claude.com/claude-code)