### PR TITLE
chore(frontend): bump openframe-frontend-core to 0.0.215

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.213",
+        "@flamingo-stack/openframe-frontend-core": "0.0.215",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.213",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.213.tgz",
-      "integrity": "sha512-Kv6QnYMLnWq8gLiQIkvz/Plg+zoXDs5vSVAPbnF2J/6ZOofwxSMJqPQ0pQfTKRUM4WtkMc8fGtdD1yY6Jn9XPQ==",
+      "version": "0.0.215",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.215.tgz",
+      "integrity": "sha512-uPLKodBcecIAaMK187TUjL/ZumObjAc3SCUfr9utQ65u2gqKWvIfd3ZHaiwC5ccCTQQaPlP2r92ZlA6IDT+N+g==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.213",
+    "@flamingo-stack/openframe-frontend-core": "0.0.215",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Summary
- Bump `@flamingo-stack/openframe-frontend-core` from 0.0.213 to 0.0.215

## Test plan
- [ ] `npm install` succeeds
- [ ] `npm run type-check` passes
- [ ] `npm run build` passes
- [ ] Smoke-test app in dev (login, dashboard, devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)