### PR TITLE
fix(frontend): remove Viewer role from add users modal

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/add-users-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/add-users-modal.tsx
@@ -25,23 +25,17 @@ interface AddUsersModalProps {
 }
 
 export function AddUsersModal({ isOpen, onClose, onInvited, invite }: AddUsersModalProps) {
-  const [rows, setRows] = useState<InviteRow[]>([{ email: '', role: 'Viewer' }]);
+  const [rows, setRows] = useState<InviteRow[]>([{ email: '', role: 'ADMIN' }]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
 
   const emailRegex = useMemo(() => /^[^\s@]+@[^\s@]+\.[^\s@]+$/, []);
   const canSubmit = useMemo(() => rows.some(r => emailRegex.test(r.email.trim())), [rows, emailRegex]);
-  const roleOptions = useMemo(
-    () => [
-      { value: 'Admin', label: 'Admin' },
-      { value: 'Viewer', label: 'Viewer' },
-    ],
-    [],
-  );
+  const roleOptions = useMemo(() => [{ value: 'ADMIN', label: 'Admin' }], []);
 
   useEffect(() => {
     if (!isOpen) {
-      setRows([{ email: '', role: 'Viewer' }]);
+      setRows([{ email: '', role: 'ADMIN' }]);
       setIsSubmitting(false);
     }
   }, [isOpen]);
@@ -50,7 +44,7 @@ export function AddUsersModal({ isOpen, onClose, onInvited, invite }: AddUsersMo
     setRows(prev => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
   };
 
-  const addRow = () => setRows(prev => [...prev, { email: '', role: 'Viewer' }]);
+  const addRow = () => setRows(prev => [...prev, { email: '', role: 'ADMIN' }]);
   const removeRow = (idx: number) => setRows(prev => prev.filter((_, i) => i !== idx));
 
   const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- Drop the Viewer option from the role selector in `AddUsersModal`
- Default new invite rows to `ADMIN` (was `Viewer`)
- Keep Admin as the only invitable role (display label stays `Admin`, value is `ADMIN`)

## Test plan
- [ ] Open Settings → Company & Users → Add Employees
- [ ] Verify the role select shows only `Admin`
- [ ] Verify newly added rows default to `Admin`
- [ ] Verify invites send successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)