### PR TITLE
fix(devices): hide DELETED devices on Customer details devices tab

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
@@ -16,7 +16,6 @@ export function CustomerDevicesTab({ organizationId }: CustomerDevicesTabProps) 
       lockedFilters={lockedFilters}
       hideColumns={['organization']}
       hideFilters={['organization']}
-      defaultStatuses={[]}
     />
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices-url-params.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices-url-params.ts
@@ -3,20 +3,21 @@
 import type { TagSearchOption } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useApiParams, useDebounce } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { DEFAULT_DEVICES_LIST_STATUSES } from '../constants/device-statuses';
+import { DEFAULT_VISIBLE_STATUSES } from '../constants/device-statuses';
 import type { DeviceFilterInput } from '../types/device.types';
 
 interface UseDevicesUrlParamsOptions {
   /**
    * Default statuses applied when the user hasn't picked any.
-   * - omitted → `DEFAULT_DEVICES_LIST_STATUSES` (hides PENDING/etc — main devices page behavior).
-   * - `[]` → no default, all statuses returned (e.g. customer scope).
+   * - omitted → `DEFAULT_VISIBLE_STATUSES` (ONLINE / OFFLINE / PENDING / ARCHIVED,
+   *   hides DELETED). Used on the main Devices page and the Customer devices tab.
+   * - `[]` → no default, every status (including DELETED) returned.
    */
   defaultStatuses?: string[];
 }
 
 export function useDevicesUrlParams(options: UseDevicesUrlParamsOptions = {}) {
-  const defaultStatuses = options.defaultStatuses ?? DEFAULT_DEVICES_LIST_STATUSES;
+  const defaultStatuses = options.defaultStatuses ?? DEFAULT_VISIBLE_STATUSES;
 
   const { params, setParam, setParams } = useApiParams({
     search: { type: 'string', default: '' },


### PR DESCRIPTION
## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted device status visibility to hide deleted devices by default in customer device views.

* **Refactor**
  * Improved default device filtering to display only relevant statuses (online, offline, pending, archived) while suppressing deleted device visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->