### PR TITLE
feat(frontend): host Mingo chat in an in-layout AppLayoutDrawer

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.216",
+        "@flamingo-stack/openframe-frontend-core": "0.0.218",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.216",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.216.tgz",
-      "integrity": "sha512-i6IhtRvyNNuD+jA+7zNmEK/+RjS98GRIvDLFNV8M1c3VzyvdUeVMD7pzx3xGkpTCWmCa/sbe+o6lAwttrsTC3Q==",
+      "version": "0.0.218",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.218.tgz",
+      "integrity": "sha512-tnWDWAIk9nPUHVQt/oYxobESOfxuIuvXqmhDs2eGCsD+S330v52etoINx0L6ox6Pco2hETxi7qm5z0XGmpkoww==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.216",
+    "@flamingo-stack/openframe-frontend-core": "0.0.218",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { AppLayout } from '../components/app-layout';
+import { OpenframeChatRuntimeProvider } from '../components/openframe-chat-runtime-provider';
 
 function getMainClassNameOverride(pathname: string | null): string | undefined {
   if (!pathname) return undefined;
@@ -14,6 +15,18 @@ function getMainClassNameOverride(pathname: string | null): string | undefined {
 export default function AppGroupLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const mainClassNameOverride = getMainClassNameOverride(pathname);
-  // Additional padding for widgets with absolute positioning at the bottom of the page, to prevent overlap with the app layout's fixed bottom bar
-  return <AppLayout mainClassName={mainClassNameOverride || 'pb-14'}>{children}</AppLayout>;
+  // EmbeddableChat now lives inside the app shell as an in-layout
+  // `AppLayoutDrawer` (see `AppShell` in `components/app-layout.tsx`): it
+  // occupies only the main content area, leaving the header and sidebar
+  // visible and interactive, and is opened from a header trigger instead of a
+  // body-level floating "Ask AI" button. This provider still supplies the
+  // `ChatRuntime` context the chat consumes. Hosts both Guide (SSE → MPH via
+  // /guide proxy) and Mingo (NATS → openframe backend) modes side-by-side
+  // with an in-panel toggle. The existing `/mingo` route stays untouched
+  // during the migration — both surfaces coexist until validation is done.
+  return (
+    <OpenframeChatRuntimeProvider>
+      <AppLayout mainClassName={mainClassNameOverride || 'pb-14'}>{children}</AppLayout>
+    </OpenframeChatRuntimeProvider>
+  );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
@@ -412,7 +412,14 @@ export default function Mingo() {
             <ChatInput
               ref={chatInputRef}
               placeholder="Enter your Request..."
-              onSend={handleSendMessage}
+              // `onSend`'s return type was widened in core 0.0.218 to
+              // `void | boolean | Promise<boolean>` (return `false` to keep the
+              // draft). Our async handler resolves to `Promise<void>`, which the
+              // union's `void` arm doesn't cover; wrap so the arrow returns void
+              // (clears the draft as before — unchanged behavior).
+              onSend={message => {
+                handleSendMessage(message);
+              }}
               onStop={isTyping && !isCompacting ? stopGeneration : undefined}
               sending={isComposerBusy}
               autoFocus={effectiveDraft}

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { AppLayout as CoreAppLayout } from '@flamingo-stack/openframe-frontend-core/components/navigation';
+import {
+  AppLayoutDrawer,
+  AppLayoutDrawerContent,
+  AppLayout as CoreAppLayout,
+} from '@flamingo-stack/openframe-frontend-core/components/navigation';
 import { CompactPageLoader } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { NavigationSidebarConfig } from '@flamingo-stack/openframe-frontend-core/types/navigation';
 import { usePathname, useRouter } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useMemo } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuthSession } from '@/app/(auth)/auth/hooks/use-auth-session';
 import { useAuthStore } from '@/app/(auth)/auth/stores/auth-store';
 import { performLogout } from '@/app/(auth)/auth/utils/auth-actions';
@@ -13,6 +17,7 @@ import { getFullImageUrl } from '@/lib/image-url';
 import { isAuthOnlyMode, isOssTenantMode, isSaasTenantMode } from '../../lib/app-mode';
 import { getNavigationItems } from '../../lib/navigation-config';
 import { AppShellSkeleton } from './app-shell-skeleton';
+import { OpenframeEmbeddableChatEntry } from './openframe-embeddable-chat-entry';
 import { SubscriptionGuard } from './subscription-lock/subscription-guard';
 import { SubscriptionLockContent } from './subscription-lock/subscription-lock-content';
 import { useSubscriptionLock } from './subscription-lock/subscription-lock-context';
@@ -32,6 +37,12 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
   const userRole = useAuthStore(state => state.user?.role);
   const userImageUrl = useAuthStore(state => state.user?.image?.imageUrl);
 
+  // Mingo chat open state — shared between the header trigger below and the
+  // in-layout `AppLayoutDrawer` + `OpenframeEmbeddableChatEntry` in the
+  // `drawer` slot. The chat runs shell-less inside the drawer, so the drawer
+  // (not the chat) owns the panel chrome.
+  const [chatOpen, setChatOpen] = useState(false);
+
   const handleNavigate = useCallback(
     (path: string) => {
       router.push(path);
@@ -47,11 +58,19 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
     router.push('/settings');
   }, [router]);
 
+  // Toggle the Mingo chat drawer from the header's "Mingo AI" launcher.
+  const toggleChat = useCallback(() => setChatOpen(prev => !prev), []);
+
   const { isLocked } = useSubscriptionLock();
   // Checkout result pages render their own success/cancel UI; they're the only
   // place a paying user lands before the webhook flips the subscription to ACTIVE.
   const isCheckoutResultPage = pathname?.startsWith('/checkout') ?? false;
   const showLockContent = isLocked && !isCheckoutResultPage;
+  // The Mingo sidebar (header launcher + in-layout chat drawer) is gated by the
+  // `mingo-sidebar` feature flag. It's also only meaningful inside the full,
+  // unlocked app shell (it hits authed endpoints), so the subscription lock
+  // suppresses both the launcher and the drawer regardless of the flag.
+  const chatEnabled = featureFlags.mingoSidebar.enabled() && !showLockContent;
   const navigationItems = useMemo(() => getNavigationItems(pathname), [pathname]);
 
   const sidebarConfig: NavigationSidebarConfig = useMemo(
@@ -81,8 +100,26 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
       userAvatarUrl: avatarUrl,
       onProfile: handleProfile,
       onLogout: handleLogout,
+      // These three are core `AppHeader` prop names (the "AI" digraph trips
+      // biome's strictCase camelCase rule); they're external API, not ours.
+      // biome-ignore lint/style/useNamingConvention: external lib prop name
+      showMingoAI: chatEnabled,
+      // biome-ignore lint/style/useNamingConvention: external lib prop name
+      onMingoAI: toggleChat,
+      // biome-ignore lint/style/useNamingConvention: external lib prop name
+      isMingoAIActive: chatOpen,
     }),
-    [notificationsEnabled, displayName, userEmail, avatarUrl, handleProfile, handleLogout],
+    [
+      notificationsEnabled,
+      displayName,
+      userEmail,
+      avatarUrl,
+      handleProfile,
+      handleLogout,
+      chatEnabled,
+      toggleChat,
+      chatOpen,
+    ],
   );
 
   const mobileBurgerMenuProps = useMemo(
@@ -98,6 +135,25 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
     [displayName, userEmail, avatarUrl, userRole, handleLogout],
   );
 
+  const chatDrawer = chatEnabled ? (
+    <AppLayoutDrawer open={chatOpen} onOpenChange={setChatOpen}>
+      <AppLayoutDrawerContent
+        side="right"
+        flush
+        resizable
+        minSize={480}
+        defaultSize={640}
+        storageKey="openframe:mingo-chat-width"
+        panelClassName="!bg-ods-bg"
+        debugLayoutShift
+      >
+        {/* No AppLayoutDrawerHeader/Title — EmbeddableChat renders its own
+            header + X button; a wrapper header would double it up. */}
+        <OpenframeEmbeddableChatEntry open={chatOpen} onOpenChange={setChatOpen} />
+      </AppLayoutDrawerContent>
+    </AppLayoutDrawer>
+  ) : null;
+
   return (
     <CoreAppLayout
       mainClassName={mainClassName ?? 'pb-20 md:pb-20'}
@@ -106,6 +162,7 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
       mobileBurgerMenuProps={mobileBurgerMenuProps}
       headerProps={headerProps}
       disabled={showLockContent}
+      drawer={chatDrawer}
     >
       {showLockContent ? <SubscriptionLockContent /> : children}
     </CoreAppLayout>

--- a/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+/**
+ * OpenframeChatRuntimeProvider — supplies the `ChatRuntime` context the
+ * lib's `<EmbeddableChat>` requires. Openframe-frontend exposes BOTH
+ * Mingo (NATS, openframe backend) and Guide (SSE, MPH backend via the
+ * `/guide` proxy) modes through the in-panel toggle. The endpoint URLs
+ * below cover both transports:
+ *
+ *   - Mingo callbacks live in `MingoEmbeddableChatEntry` and don't touch
+ *     this runtime — they call `apiClient` against `/chat/*` directly.
+ *   - Guide reads its endpoint URLs FROM this runtime. Each Guide path
+ *     is prefixed with `/guide/`; the openframe-frontend Next.js layer
+ *     reverse-proxies that prefix to the MPH origin so neither the lib
+ *     nor the host page learns the upstream MPH URL.
+ *
+ * Navigation is `mode: 'host'` with `navigate` routed through the Next.js
+ * App Router so in-app chip clicks land via `router.push` instead of a
+ * hard `location.assign`. New-tab decisions fall back to the lib default.
+ */
+
+import { type ChatRuntime, ChatRuntimeContext } from '@flamingo-stack/openframe-frontend-core/contexts';
+import {
+  clearEmbedProxyAuth,
+  type EmbedAuthAdapter,
+  setEmbedAuthAdapter,
+} from '@flamingo-stack/openframe-frontend-core/utils';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useMemo } from 'react';
+import { runtimeEnv } from '@/lib/runtime-config';
+
+import { refreshAccessToken } from '@/lib/token-refresh-manager';
+
+/** localStorage key the openframe `apiClient` writes/reads. Kept in sync
+ *  with [api-client.ts:7](src/lib/api-client.ts#L7) — both sides MUST
+ *  use the same key so the bearer is consistent. */
+const ACCESS_TOKEN_KEY = 'of_access_token';
+
+/** Stable source identifier used for localStorage namespacing inside the
+ *  lib (`mingo-chat-openframe-v1` keys). Must not change between
+ *  deployments or users lose their local Guide history. Openframe is
+ *  Mingo-only today, so the source value is more of a namespace label
+ *  than a content discriminator. */
+const CHAT_SOURCE = 'openframe' as const;
+
+/** Read `of_access_token` without throwing (sandboxed iframes can). */
+function safeReadToken(): string | null {
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Auth adapter the lib's `embedAuthedFetch` consults on every embedded-chat
+ * request. Defined at module scope (not rebuilt per render) so it can be
+ * registered SYNCHRONOUSLY on first render — before the child chat effects
+ * (identity / slash-commands fire in their own mount effects, which run
+ * BEFORE a parent `useEffect`). All deps it closes over are module-level.
+ */
+const CHAT_AUTH_ADAPTER: EmbedAuthAdapter = {
+  getHeaders: () => {
+    // Mirror `apiClient.getAuthHeaders()` EXACTLY: only attach a localStorage
+    // Bearer in dev-ticket mode. In normal cookie mode the access token lives
+    // in an http-only cookie that `oauth/refresh` rotates server-side, while
+    // the `of_access_token` localStorage copy is written ONCE at login and
+    // never refreshed (token-refresh-manager gates that write on dev-ticket).
+    // Sending that copy would ship a stale/expired Bearer that the gateway
+    // prefers over the fresh cookie. Omit it and let `credentials: 'include'`
+    // carry the cookie — same way the rest of the app authenticates.
+    if (!runtimeEnv.enableDevTicketObserver()) return {};
+    const token = safeReadToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  },
+  // Send openframe cookies cross-origin to the gateway; CORS +
+  // `SameSite=None` on cookies must be configured server-side. (Harmless
+  // no-op in production, where the frontend and gateway share one origin.)
+  credentials: 'include',
+  // `refreshAccessToken` already dedups concurrent refreshes internally, and
+  // `embedAuthedFetch` dedups 401-triggered retries on top — so a stampede of
+  // simultaneously-expiring chat requests refreshes once.
+  refresh: () => refreshAccessToken(),
+};
+
+// Register the auth adapter + drop legacy proxy-auth ONCE, at module load —
+// i.e. before the provider renders or any child chat effect fires a request.
+// Why not in render / useEffect: the chat's identity & slash-command requests
+// fire from CHILD mount effects, which run before a parent `useEffect`; and a
+// `useState` initializer races StrictMode's double-invoke + the unmount-null,
+// leaving the first requests adapter-less (the `credentials: 'same-origin'` +
+// 401 + no-refresh symptom). The adapter is a stateless module singleton
+// (reads localStorage/env fresh per call), so a single app-lifetime
+// registration with no teardown is correct — and runs exactly once, so there
+// is no "overwriting a previously-registered adapter" warning.
+//
+// `clearEmbedProxyAuth()`: openframe never does proxy-impersonation, but an
+// earlier `setEmbedProxyAuth`-based approach persisted the openframe JWT under
+// `<appType>.chat.proxy-auth.v1`. That copy is frozen at login, so
+// `applyProxyAuth` kept attaching a stale/expired Bearer to `/guide/*`.
+if (typeof window !== 'undefined') {
+  clearEmbedProxyAuth();
+  setEmbedAuthAdapter(CHAT_AUTH_ADAPTER);
+}
+
+export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
+  const runtime = useMemo<ChatRuntime>(() => {
+    // All Guide-mode endpoints are built as absolute URLs against the
+    // backend gateway (`NEXT_PUBLIC_TENANT_HOST_URL`, e.g.
+    // `https://test-dev.openframe.build`). The gateway exposes the
+    // `/guide/*` route mapped to MPH so the lib's bare `fetch()` calls
+    // land directly on the gateway with no Next.js rewrite hop.
+    //
+    // The lib's `embedAuthedFetch` normally rejects cross-origin URLs as
+    // defense-in-depth (bearer + Supabase cookies must not leak), BUT
+    // its dev-mode escape hatch (`NODE_ENV !== 'production'`) lets the
+    // browser call across origins for local development. Production
+    // bundles either keep the strict guard (if served cross-origin from
+    // the gateway) or naturally pass it (if openframe-frontend and the
+    // gateway end up on the same origin behind a single reverse proxy).
+    const tenantHost = runtimeEnv.tenantHostUrl().replace(/\/+$/, '');
+    const guide = (path: string): string => `${tenantHost}/guide${path}`;
+
+    return {
+      endpoints: {
+        // Upstream paths verified live against the deployed instance
+        // (2026-05-29 endpoint table).
+        chatStreamUrl: guide('/api/docs/chat'),
+        approvalToolUrl: guide('/api/chat/agent/confirm-tool'),
+        commandsUrl: guide('/api/docs/commands'),
+        // RAG entity-card list URLs are MPH-owned; openframe-frontend
+        // has no native equivalent. Return null until a per-type
+        // builder is wired against the proxy.
+        buildListUrl: () => null,
+        attachmentUploadUrl: guide('/api/storage/generate-upload-url'),
+        attachmentViewUrlPrefix: guide('/api/storage/view/chat-attachments/'),
+        // SOURCE-VS-DEPLOYED GAP: MPH source has `/api/auth/identity`
+        // (at `app/api/auth/identity/route.ts`). The deployed instance
+        // also serves `/api/chat/identity` per the live endpoint table
+        // verified 2026-05-29. We use the deployed path because it's
+        // the one verified to work end-to-end; if 404, swap to
+        // `/api/auth/identity`.
+        identityUrl: guide('/api/chat/identity'),
+        imageProxyUrlPrefix: guide('/api/image-proxy'),
+      },
+      navigation: {
+        mode: 'host',
+        navigate: ({ href }: { href: string; path?: string | null; targetPlatform?: string | null }) => {
+          // Route in-app links through Next router so SPA state survives.
+          // Returning true tells the lib we've handled it; false would
+          // make it fall back to `location.assign`.
+          if (!href) return false;
+          router.push(href);
+          return true;
+        },
+      },
+      source: CHAT_SOURCE,
+    };
+  }, [router]);
+
+  return <ChatRuntimeContext.Provider value={runtime}>{children}</ChatRuntimeContext.Provider>;
+}

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+/**
+ * OpenframeEmbeddableChatEntry — the EmbeddableChat surface for
+ * openframe-frontend. Hosted inside AppLayout's in-layout drawer
+ * (`AppLayoutDrawer`) rather than as a body-level overlay, so the header
+ * and sidebar stay visible and interactive while the chat is open. The
+ * drawer owns the shell; this component runs the chat shell-less
+ * (`shell="none"`) and is open/close-controlled by the host via the
+ * `open` / `onOpenChange` props it shares with the drawer.
+ *
+ * Because the shell is external:
+ *   - no floating "Ask AI" trigger renders (the host provides the trigger),
+ *   - no body scroll-lock,
+ *   - the X button in the chat's own header still calls `onOpenChange(false)`
+ *     to close the host drawer.
+ *
+ * Configures BOTH modes per Michael's design mandate
+ * ([[chat-architecture-and-migration]]):
+ *   - `modes.guide` — SSE/Guide. Endpoint URLs come from the runtime
+ *     provider, all prefixed with `/guide/` and reverse-proxied to MPH
+ *     by the openframe-frontend Next.js layer. The slot can be `{}` —
+ *     the SSE adapter reads its config from the ambient runtime, so an
+ *     empty options object is enough to flip the mode "on" and make the
+ *     in-panel toggle appear.
+ *   - `modes.mingo` — NATS/Mingo. All callbacks wired below against the
+ *     openframe REST/GraphQL endpoints + the NATS WS URL from
+ *     `useNatsAppConfig`.
+ *
+ * Coexists with the old `/mingo` page route during migration; removal of
+ * that route is deferred to a later step.
+ *
+ * No business logic lives here — everything is callback wiring.
+ */
+
+import type { DialogItem, HistoricalMessage } from '@flamingo-stack/openframe-frontend-core';
+import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { useCallback, useMemo } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { useNatsAppConfig } from '@/lib/nats/nats-app-config';
+import {
+  GET_MINGO_DIALOG_QUERY,
+  GET_MINGO_DIALOGS_QUERY,
+  getMingoDialogMessagesQuery,
+} from '../(app)/mingo/queries/dialogs-queries';
+
+// =============================================================================
+// Local mirrors of the new lib types that aren't yet in the published
+// `@flamingo-stack/openframe-frontend-core` bundle. After the next yalc
+// publish bumps the consumer past the dialog-management feature, these
+// can be replaced with direct imports from the package.
+// =============================================================================
+
+interface FetchDialogsParams {
+  cursor?: string;
+  limit?: number;
+  search?: string;
+}
+
+interface FetchDialogsResult {
+  dialogs: DialogItem[];
+  nextCursor: string | null;
+}
+
+interface FetchDialogMessagesParams {
+  dialogId: string;
+  cursor?: string;
+  limit?: number;
+}
+
+interface DialogTokenUsageSnapshot {
+  chatType?: string;
+  inputTokensSize: number;
+  outputTokensSize: number;
+  totalTokensSize: number;
+  contextSize?: number;
+}
+
+interface FetchDialogMessagesResult {
+  messages: HistoricalMessage[];
+  nextCursor: string | null;
+  tokenUsage?: DialogTokenUsageSnapshot | null;
+}
+
+// =============================================================================
+// Wire-format constants — mirror the existing `mingo-api-service.ts` values
+// =============================================================================
+
+const AGENT_TYPE = 'ADMIN' as const;
+const CHAT_TYPE_ADMIN = 'ADMIN_AI_CHAT' as const;
+
+// =============================================================================
+// GraphQL response shapes
+// =============================================================================
+
+interface GraphQlDialogEdge {
+  cursor?: string;
+  node: {
+    id: string;
+    title?: string;
+    status?: string;
+    createdAt: string;
+    statusUpdatedAt?: string;
+  };
+}
+
+interface GraphQlPageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage?: boolean;
+  startCursor?: string;
+  endCursor?: string;
+}
+
+interface GraphQlDialogsResponse {
+  data?: {
+    dialogs?: {
+      edges?: GraphQlDialogEdge[];
+      pageInfo?: GraphQlPageInfo;
+    };
+  };
+}
+
+interface GraphQlMessagesResponse {
+  data?: {
+    messages?: {
+      edges?: Array<{ cursor?: string; node: HistoricalMessage & { chatType?: string } }>;
+      pageInfo?: GraphQlPageInfo;
+    };
+  };
+}
+
+interface GraphQlDialogResponse {
+  data?: {
+    dialog?: {
+      id: string;
+      tokenUsage?: {
+        chatType?: string;
+        inputTokensSize?: number;
+        outputTokensSize?: number;
+        totalTokensSize?: number;
+        contextSize?: number;
+      } | null;
+    };
+  };
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+interface OpenframeEmbeddableChatEntryProps {
+  /** Controlled open state, shared with the host `AppLayoutDrawer`. */
+  open: boolean;
+  /** Change handler, shared with the host `AppLayoutDrawer`. The chat's own
+   *  in-header X button calls this with `false` to close the drawer. */
+  onOpenChange: (open: boolean) => void;
+}
+
+export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEmbeddableChatEntryProps) {
+  const { getWsUrl } = useNatsAppConfig();
+
+  const fetchDialogs = useCallback(async (params: FetchDialogsParams): Promise<FetchDialogsResult> => {
+    const response = await apiClient.post<GraphQlDialogsResponse>('/chat/graphql', {
+      query: GET_MINGO_DIALOGS_QUERY,
+      variables: {
+        filter: { agentTypes: [AGENT_TYPE] },
+        pagination: {
+          limit: params.limit ?? 20,
+          cursor: params.cursor,
+        },
+        search: params.search,
+      },
+    });
+    if (!response.ok || !response.data?.data?.dialogs) {
+      throw new Error(response.error || 'Failed to fetch Mingo dialogs');
+    }
+    const edges = response.data.data.dialogs.edges ?? [];
+    const pageInfo = response.data.data.dialogs.pageInfo;
+    const dialogs: DialogItem[] = edges.map(edge => ({
+      id: edge.node.id,
+      title: edge.node.title || 'Untitled Dialog',
+      timestamp: new Date(edge.node.createdAt),
+    }));
+    return {
+      dialogs,
+      nextCursor: pageInfo?.hasNextPage ? (pageInfo.endCursor ?? null) : null,
+    };
+  }, []);
+
+  const fetchDialogMessages = useCallback(
+    async (params: FetchDialogMessagesParams): Promise<FetchDialogMessagesResult> => {
+      const limit = params.limit ?? 50;
+      // First-page calls also fetch the dialog header so we can hydrate
+      // `dialogTokenUsage` from the backend snapshot. Paginated calls
+      // (cursor set) skip the header — token usage doesn't change with
+      // older message pages, the lib keeps the value it already has.
+      const messagesPromise = apiClient.post<GraphQlMessagesResponse>('/chat/graphql', {
+        query: getMingoDialogMessagesQuery({ includeThinking: false }),
+        variables: {
+          dialogId: params.dialogId,
+          cursor: params.cursor,
+          limit,
+          sortField: 'createdAt',
+          sortDirection: 'DESC',
+        },
+      });
+      const dialogPromise =
+        params.cursor === undefined
+          ? apiClient.post<GraphQlDialogResponse>('/chat/graphql', {
+              query: GET_MINGO_DIALOG_QUERY,
+              variables: { id: params.dialogId },
+            })
+          : Promise.resolve(null);
+
+      const [messagesResp, dialogResp] = await Promise.all([messagesPromise, dialogPromise]);
+      if (!messagesResp.ok || !messagesResp.data?.data?.messages) {
+        throw new Error(messagesResp.error || 'Failed to fetch Mingo dialog messages');
+      }
+
+      const edges = messagesResp.data.data.messages.edges ?? [];
+      const pageInfo = messagesResp.data.data.messages.pageInfo;
+      // GraphQL pagination sorts DESC (newest first within page) → flip to
+      // chronological order before handing off to the lib, which expects
+      // oldest-first when processing through `MessageSegmentAccumulator`.
+      // Filter on chatType so non-admin messages stay invisible (admin
+      // sees a clean Mingo-only thread even when the backend mixes chat
+      // types in the same dialog).
+      const messages: HistoricalMessage[] = edges
+        .map(edge => edge.node)
+        .filter(node => !node.chatType || node.chatType === CHAT_TYPE_ADMIN)
+        .reverse();
+
+      const tokenUsage =
+        dialogResp && dialogResp.ok && dialogResp.data?.data?.dialog?.tokenUsage
+          ? {
+              chatType: dialogResp.data.data.dialog.tokenUsage.chatType,
+              inputTokensSize: dialogResp.data.data.dialog.tokenUsage.inputTokensSize ?? 0,
+              outputTokensSize: dialogResp.data.data.dialog.tokenUsage.outputTokensSize ?? 0,
+              totalTokensSize: dialogResp.data.data.dialog.tokenUsage.totalTokensSize ?? 0,
+              contextSize: dialogResp.data.data.dialog.tokenUsage.contextSize,
+            }
+          : null;
+
+      return {
+        messages,
+        nextCursor: pageInfo?.hasNextPage ? (pageInfo.endCursor ?? null) : null,
+        tokenUsage,
+      };
+    },
+    [],
+  );
+
+  const createDialog = useCallback(async (): Promise<{ dialogId: string }> => {
+    const response = await apiClient.post<{ id: string }>('/chat/api/v1/dialogs', {
+      agentType: AGENT_TYPE,
+    });
+    if (!response.ok || !response.data?.id) {
+      throw new Error(response.error || 'Failed to create Mingo dialog');
+    }
+    return { dialogId: response.data.id };
+  }, []);
+
+  const publishUserMessage = useCallback(
+    async (text: string, options: { hidden?: boolean; dialogId: string | null }): Promise<void> => {
+      if (!options.dialogId) return;
+      const response = await apiClient.post('/chat/api/v1/messages', {
+        dialogId: options.dialogId,
+        content: text,
+        chatType: CHAT_TYPE_ADMIN,
+      });
+      if (!response.ok) {
+        throw new Error(response.error || 'Failed to send Mingo message');
+      }
+    },
+    [],
+  );
+
+  const approveRequest = useCallback(async (requestId: string): Promise<void> => {
+    const response = await apiClient.post(`/chat/api/v1/approval-requests/${encodeURIComponent(requestId)}/approve`, {
+      approve: true,
+    });
+    if (!response.ok) {
+      throw new Error(response.error || 'Failed to approve Mingo request');
+    }
+  }, []);
+
+  const rejectRequest = useCallback(async (requestId: string, _reason?: string): Promise<void> => {
+    const response = await apiClient.post(`/chat/api/v1/approval-requests/${encodeURIComponent(requestId)}/approve`, {
+      approve: false,
+    });
+    if (!response.ok) {
+      throw new Error(response.error || 'Failed to reject Mingo request');
+    }
+  }, []);
+
+  const stopGeneration = useCallback(async (dialogId: string): Promise<void> => {
+    const response = await apiClient.post(`/chat/api/v1/dialogs/${encodeURIComponent(dialogId)}/stop`, {
+      chatType: CHAT_TYPE_ADMIN,
+    });
+    if (!response.ok) {
+      throw new Error(response.error || 'Failed to stop Mingo generation');
+    }
+  }, []);
+
+  const mingoModeConfig = useMemo(
+    () => ({
+      // `dialogId: null` here is a compat shim for the published
+      // `UseNatsChatAdapterConfig` (0.0.215) which still requires the
+      // field. The next lib version flips the discriminator from
+      // "dialogId presence" to "fetchDialogs presence" — managed-dialog
+      // mode kicks in based on `fetchDialogs`, and any host-passed
+      // `dialogId` is ignored in that mode. The literal `null` is
+      // therefore future-safe: it satisfies the old type and is ignored
+      // by the new adapter. Remove once node_modules is past 0.0.215.
+      dialogId: null,
+      getNatsWsUrl: getWsUrl,
+      publishUserMessage,
+      fetchDialogs,
+      fetchDialogMessages,
+      createDialog,
+      approveRequest,
+      rejectRequest,
+      stopGeneration,
+      assistantName: 'Mingo',
+      chatTypeFilter: CHAT_TYPE_ADMIN,
+    }),
+    [
+      getWsUrl,
+      publishUserMessage,
+      fetchDialogs,
+      fetchDialogMessages,
+      createDialog,
+      approveRequest,
+      rejectRequest,
+      stopGeneration,
+    ],
+  );
+
+  return (
+    <EmbeddableChat
+      // Shell-less: the host `AppLayoutDrawer` owns the panel chrome,
+      // open/close, and positioning. `open` / `onOpenChange` are the same
+      // state the drawer is bound to, so the chat's in-header X button and
+      // the drawer close in lockstep.
+      shell="none"
+      open={open}
+      onOpenChange={onOpenChange}
+      // `modes.guide` is an empty options object — the SSE adapter reads
+      // its actual endpoints from the runtime provider (all /guide/*
+      // paths reverse-proxied to MPH). The presence of the slot is what
+      // makes the in-panel mode toggle render and lets users flip
+      // between Guide and Mingo without leaving the panel.
+      modes={{ guide: {}, mingo: mingoModeConfig }}
+      defaultActiveMode="mingo"
+      emptyStateGreeting="Ask Mingo anything about your fleet."
+    />
+  );
+}

--- a/openframe/services/openframe-frontend/src/lib/feature-flags.ts
+++ b/openframe/services/openframe-frontend/src/lib/feature-flags.ts
@@ -13,6 +13,7 @@ export const FEATURE_FLAG_NAMES = [
   'batch-approval',
   'ai-streaming-jetstream',
   'debug-nats-chunks',
+  'mingo-sidebar',
 ] as const;
 
 /**
@@ -71,6 +72,11 @@ export const featureFlags = {
   debugNatsChunks: {
     enabled(): boolean {
       return getFlagValue('debug-nats-chunks', () => false);
+    },
+  },
+  mingoSidebar: {
+    enabled(): boolean {
+      return getFlagValue('mingo-sidebar', () => false);
     },
   },
 } as const;


### PR DESCRIPTION
## What

Replaces the body-level `EmbeddableChat` overlay (floating "Ask AI" trigger + full-page `Drawer`) with an **in-layout `AppLayoutDrawer`** that occupies only the main content area. The header and sidebar stay visible and interactive while the chat is open.

## Changes

- **Shell-less chat** — `EmbeddableChat` runs with `shell="none"`; the `AppLayoutDrawer` owns the panel chrome, open/close, and positioning. No floating trigger, no body scroll-lock. The chat's in-header X button still drives `onOpenChange`.
- **Header trigger** — opens from the core `AppHeader`'s native **Mingo AI** launcher (`showMingoAI` / `onMingoAI` / `isMingoAIActive`), wired to a shared `chatOpen` state that also binds the drawer (toggle + pressed state).
- **Panel** — right-side, `flush`, `resizable`; width persisted to `localStorage` (`openframe:mingo-chat-width`).
- **Feature flag** — the whole surface is gated behind a new `mingo-sidebar` flag (default `false`); also suppressed under the subscription lock.
- **Lib bump** — `@flamingo-stack/openframe-frontend-core` `0.0.215 → 0.0.218` for the `AppLayoutDrawer` + `AppHeader` Mingo launcher APIs.

## Behavior

| Action | Result |
|---|---|
| Click Mingo AI launcher | Toggles the drawer |
| Click X in chat header / Esc | Closes the drawer |
| Click dim overlay over main | Closes the drawer |
| Click header / sidebar | Stays open (chrome remains interactive) |

## Known issue / follow-up

⚠️ Radix logs a console warning: ``DialogContent` requires a `DialogTitle``. The chat renders its own visible header instead of a Radix `DialogTitle`. Recommended fix is a visually-hidden title — arguably belongs in the lib's `AppLayoutDrawerContent` (it owns `DialogPrimitive.Content`). **Not addressed in this PR.**

> Note: `mingo-sidebar` is `false` by default and the backend currently returns `false`, so this is dark-shipped until the flag is enabled.

## Testing

- `npm run lint:biome` — clean (pre-existing unrelated warnings only)
- `npm run type-check` — no new errors (the repo's type-check is environmentally red due to the yalc-linked core lib shipping no `.d.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mingo AI chat drawer added — toggle from the header; hosted in the app layout.
  * Drawer chat supports Guide and Mingo modes (default Mingo) with a customized empty-state greeting.
  * Chat launcher respects a new "mingo-sidebar" feature flag and subscription lock rules (suppressed when locked except on checkout).

* **Chores**
  * Updated embedded chat runtime/configuration and bumped embedded chat dependency for improved integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->