### PR TITLE
fix(frontend): route Mingo replies to the admin-message NATS subject

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.218",
+        "@flamingo-stack/openframe-frontend-core": "0.0.221",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.218",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.218.tgz",
-      "integrity": "sha512-tnWDWAIk9nPUHVQt/oYxobESOfxuIuvXqmhDs2eGCsD+S330v52etoINx0L6ox6Pco2hETxi7qm5z0XGmpkoww==",
+      "version": "0.0.221",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.221.tgz",
+      "integrity": "sha512-jtn9fWFqVDbGjfafaiy1MOi16C956k88aQnMyGmTyiOyEJT8lBiuooddnKsTZUcrqNzQ48WJ/zT2Q9RFHqtldA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -554,6 +554,7 @@
         "nats.ws": "^1.30.3",
         "next-themes": "^0.2.1",
         "react-aria-components": "^1.11.0",
+        "react-colorful": "^5.7.0",
         "react-datepicker": "^8.7.0",
         "react-day-picker": "^9.8.1",
         "react-device-detect": "^2.2.3",
@@ -9597,6 +9598,16 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
+      "integrity": "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-datepicker": {

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.218",
+    "@flamingo-stack/openframe-frontend-core": "0.0.221",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -33,7 +33,7 @@
  * No business logic lives here — everything is callback wiring.
  */
 
-import type { DialogItem, HistoricalMessage } from '@flamingo-stack/openframe-frontend-core';
+import type { DialogItem, HistoricalMessage, NatsMessageType } from '@flamingo-stack/openframe-frontend-core';
 import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useCallback, useMemo } from 'react';
 import { apiClient } from '@/lib/api-client';
@@ -314,6 +314,13 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
       // by the new adapter. Remove once node_modules is past 0.0.215.
       dialogId: null,
       getNatsWsUrl: getWsUrl,
+      // ADMIN/Mingo chat agent replies are published on the
+      // `chat.{dialogId}.admin-message` NATS subject (matches the legacy
+      // /mingo page's `MINGO_JETSTREAM_TOPIC = 'admin-message'`). Without
+      // this the adapter tails the default `…​.message` subject, never
+      // receives reply chunks, and the assistant bubble hangs forever on
+      // "Strutting…". See use-nats-chat-adapter `topics` config.
+      topics: ['admin-message'] as NatsMessageType[],
       publishUserMessage,
       fetchDialogs,
       fetchDialogMessages,


### PR DESCRIPTION
## What

Follow-up fix on top of the Mingo sidebar drawer (merged via #1836).

The Mingo (ADMIN) chat adapter was tailing the default `chat.{dialogId}.message` NATS subject, so agent reply chunks — published on `chat.{dialogId}.admin-message` — were never received. The assistant bubble hung indefinitely on "Strutting…".

## Change

- Pass `topics: ['admin-message']` in the `mingo` mode config of `OpenframeEmbeddableChatEntry`, so the adapter subscribes to the correct subject (matches the legacy `/mingo` page's `MINGO_JETSTREAM_TOPIC = 'admin-message'`).
- Bump `@flamingo-stack/openframe-frontend-core` `0.0.218 → 0.0.221` for the `topics` config option + `NatsMessageType` export.

## Notes

- The Mingo drawer surface itself is still gated behind the `mingo-sidebar` feature flag (default off).
- `.env.local` working-tree tweaks were intentionally **not** included (local dev config).

## Testing

- `npm run lint:biome` — clean (pre-existing unrelated warnings only)
- `npm run type-check` — no new errors (repo type-check is environmentally red due to the yalc-linked core lib shipping no `.d.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core frontend dependencies to latest version.

* **Bug Fixes**
  * Fixed missing admin message delivery in chat. Admin replies are now properly received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->