### PR TITLE
feat(frontend): Current/New plan comparison on subscription update

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/plan-change-summary.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/plan-change-summary.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+import type { ReactNode } from 'react';
+import { BillingRow, SectionBlock } from '../../components/billing-section';
+import type { BillingPeriod, PlanComparison, PlanLine } from '../types/subscription.types';
+import { formatCompact, formatMoney } from '../utils/subscription.utils';
+
+export interface PlanChangeSummaryItem {
+  /** Short row label, e.g. "Devices" / "AI Tokens". */
+  label: string;
+  comparison: PlanComparison;
+}
+
+interface PlanChangeSummaryProps {
+  items: PlanChangeSummaryItem[];
+}
+
+type ChangeDirection = 'up' | 'down' | 'same';
+
+/** Green = upgrade, red = downgrade, white = unchanged. */
+function directionClass(direction: ChangeDirection): string {
+  if (direction === 'up') return 'text-ods-success';
+  if (direction === 'down') return 'text-ods-error';
+  return 'text-ods-text-primary';
+}
+
+function periodLabel(period: BillingPeriod | null): string {
+  if (period === 'YEARLY') return 'Annual';
+  if (period === 'MONTHLY') return 'Monthly';
+  return '';
+}
+
+/**
+ * Quantity change. PAYG↔package transitions follow the designer's rules:
+ * pay-as-you-go → package is an upgrade, package → pay-as-you-go a downgrade.
+ */
+function quantityDirection(current: PlanLine | null, next: PlanLine): ChangeDirection {
+  if (!current) return 'same';
+  if (current.payg && next.payg) return 'same';
+  if (current.payg && !next.payg) return 'up';
+  if (!current.payg && next.payg) return 'down';
+  const from = current.quantity ?? 0;
+  const to = next.quantity ?? 0;
+  return to > from ? 'up' : to < from ? 'down' : 'same';
+}
+
+/** Billing period change: PAYG < Monthly < Annual; longer commitment is an upgrade. */
+function periodDirection(current: PlanLine | null, next: PlanLine): ChangeDirection {
+  if (!current) return 'same';
+  const rank = (line: PlanLine) => (line.payg ? 0 : line.billingPeriod === 'YEARLY' ? 2 : 1);
+  const from = rank(current);
+  const to = rank(next);
+  return to > from ? 'up' : to < from ? 'down' : 'same';
+}
+
+/**
+ * Total cost change. Per product decision a higher total reads as a bigger plan
+ * (green); a lower total as red. Flip the two comparisons here to invert.
+ */
+function totalDirection(current: number | null, next: number | null): ChangeDirection {
+  if (current == null || next == null) return 'same';
+  return next > current ? 'up' : next < current ? 'down' : 'same';
+}
+
+function sumAnnualTotals(lines: (PlanLine | null)[]): number | null {
+  const totals = lines.map(line => line?.annualTotal).filter((value): value is number => value != null);
+  return totals.length > 0 ? totals.reduce((acc, value) => acc + value, 0) : null;
+}
+
+function currentValueText(line: PlanLine | null): string {
+  if (!line) return '—';
+  if (line.payg) return 'Pay as you go';
+  const quantity = line.quantity != null ? formatCompact(line.quantity) : '—';
+  const period = periodLabel(line.billingPeriod);
+  return period ? `${quantity} · ${period}` : quantity;
+}
+
+function NewProductValue({ current, next }: { current: PlanLine | null; next: PlanLine }): ReactNode {
+  if (next.payg) {
+    return <span className={directionClass(quantityDirection(current, next))}>Pay as you go</span>;
+  }
+  const quantity = next.quantity != null ? formatCompact(next.quantity) : '—';
+  const period = periodLabel(next.billingPeriod);
+  return (
+    <>
+      <span className={directionClass(quantityDirection(current, next))}>{quantity}</span>
+      {period && (
+        <>
+          <span className="text-ods-text-secondary">·</span>
+          <span className={directionClass(periodDirection(current, next))}>{period}</span>
+        </>
+      )}
+    </>
+  );
+}
+
+function totalText(total: number | null): string {
+  return total != null ? `$${formatMoney(total)} / year` : 'Pay as you go';
+}
+
+/**
+ * Side-by-side "Current Plan" / "New Plan" comparison shown before applying a
+ * subscription update. New-plan values are colored to signal upgrade (green) /
+ * downgrade (red) per row.
+ */
+export function PlanChangeSummary({ items }: PlanChangeSummaryProps) {
+  const currentTotal = sumAnnualTotals(items.map(item => item.comparison.current));
+  const nextTotal = sumAnnualTotals(items.map(item => item.comparison.next));
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <SectionBlock title="Current Plan">
+        {items.map(item => (
+          <BillingRow key={item.label} label={item.label} value={currentValueText(item.comparison.current)} muted />
+        ))}
+        <BillingRow label="Total" value={totalText(currentTotal)} muted />
+      </SectionBlock>
+
+      <SectionBlock title="New Plan">
+        {items.map(item => (
+          <BillingRow
+            key={item.label}
+            label={item.label}
+            value={<NewProductValue current={item.comparison.current} next={item.comparison.next} />}
+          />
+        ))}
+        <BillingRow
+          label="Total"
+          value={
+            <span className={cn(directionClass(totalDirection(currentTotal, nextTotal)))}>{totalText(nextTotal)}</span>
+          }
+        />
+      </SectionBlock>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
@@ -65,6 +65,11 @@ interface ProductSubscriptionCardProps {
   customSubtitle: string;
   helpText?: ReactNode;
   disabled?: boolean;
+  /**
+   * Reserve vertical space for the billing-period toggle even when this card
+   * has none, so cards stay aligned when a sibling card shows the toggle.
+   */
+  reserveBillingPeriodSpace?: boolean;
   onUpdatesChange: (updates: ProductUpdates) => void;
 }
 
@@ -100,6 +105,7 @@ export function ProductSubscriptionCard({
   customSubtitle,
   helpText,
   disabled = false,
+  reserveBillingPeriodSpace = false,
   onUpdatesChange,
 }: ProductSubscriptionCardProps) {
   const product = useFragment(productSubscriptionCardProductFragment, productRef);
@@ -159,13 +165,18 @@ export function ProductSubscriptionCard({
 
       <p className="text-h4 text-ods-text-primary">{description}</p>
 
-      {billingPeriodItems.length > 1 && (
+      {billingPeriodItems.length > 1 ? (
         <TabSelector
           value={selection.billingPeriod}
           onValueChange={setBillingPeriod}
           variant="primary"
           items={billingPeriodItems}
         />
+      ) : (
+        // Match the TabSelector's h-12 so cards align when a sibling shows the
+        // toggle. Only needed in the lg side-by-side layout; below that the cards
+        // stack, so the spacer is hidden to avoid an empty gap.
+        reserveBillingPeriodSpace && <div aria-hidden className="hidden h-12 lg:block" />
       )}
 
       <div className="flex flex-col gap-2 w-full">

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
@@ -8,9 +8,10 @@ import { useSubscriptionLock } from '@/app/components/subscription-lock/subscrip
 import { SubscriptionStatus } from '@/app/components/subscription-lock/subscription-status';
 import { TrialEndedBanner } from '@/app/components/subscription-lock/trial-ended-banner';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
-import type { OpenframeProduct, ProductUpdates } from '../types/subscription.types';
+import type { OpenframeProduct, PlanLine, ProductUpdates } from '../types/subscription.types';
 import { buildProductCancelUpdates } from '../utils/subscription.utils';
 import { ModelTokenRates } from './model-token-rates';
+import { PlanChangeSummary, type PlanChangeSummaryItem } from './plan-change-summary';
 import { ProductSubscriptionCard } from './product-subscription-card';
 import { SubscriptionSettingsSkeleton } from './subscription-settings-skeleton';
 import { SubscriptionSubmitButton } from './subscription-submit-button';
@@ -18,11 +19,16 @@ import { SubscriptionSubmitButton } from './subscription-submit-button';
 interface ProductDisplay {
   title: string;
   description: string;
+  /** Short label used in the Current/New plan comparison block. */
+  rowLabel: string;
   packageUnitLabel: string;
   customLabel: string;
   customSubtitle: string;
   helpText?: ReactNode;
 }
+
+/** Disabling a product cancels its committed package, falling back to always-on PAYG. */
+const PAYG_PLAN_LINE: PlanLine = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
 
 const ADDITIONAL_DEVICES_HELPER_TEXT =
   'You can add more devices anytime. Additional devices beyond your package are charged at $5/device and added to your next invoice.';
@@ -31,6 +37,7 @@ const PRODUCT_DISPLAY: Partial<Record<OpenframeProduct, ProductDisplay>> = {
   MANAGED_DEVICES: {
     title: 'Device Management Plan',
     description: "Select the number of devices you'd like to include in your monthly subscription plan:",
+    rowLabel: 'Devices',
     packageUnitLabel: 'devices',
     customLabel: 'Custom Amount',
     customSubtitle: 'Choose your number of devices',
@@ -38,6 +45,7 @@ const PRODUCT_DISPLAY: Partial<Record<OpenframeProduct, ProductDisplay>> = {
   AI_ASSISTANCE: {
     title: 'AI Assistant Add-on',
     description: 'Buy OpenFrame tokens to power your AI assistants across all supported models. One unified balance.',
+    rowLabel: 'AI Tokens',
     packageUnitLabel: 'OpenFrame tokens',
     customLabel: 'Custom Amount',
     customSubtitle: 'Choose your number of tokens',
@@ -52,6 +60,7 @@ const subscriptionSettingsViewQuery = graphql`
       products {
         id
         name
+        packageOptions { billingPeriod }
         ...productSubscriptionCardProductFragment
       }
     }
@@ -93,6 +102,15 @@ function SubscriptionSettingsContent() {
   const products = data.billingPlan?.products ?? [];
   const subscriptionProducts = data.subscription?.products ?? [];
 
+  // If any displayed card shows a billing-period (monthly/yearly) toggle, the
+  // others reserve the same space so the cards stay vertically aligned. When no
+  // card has a toggle, nothing is reserved.
+  const anyHasBillingToggle = products.some(
+    p =>
+      PRODUCT_DISPLAY[p.name] != null &&
+      new Set(p.packageOptions.map(opt => opt.billingPeriod).filter(Boolean)).size > 1,
+  );
+
   const [aiEnabled, setAiEnabled] = useState(true);
 
   const [updatesMap, setUpdatesMap] = useState<Partial<Record<OpenframeProduct, ProductUpdates>>>({});
@@ -111,6 +129,22 @@ function SubscriptionSettingsContent() {
     const updates = updatesMap[p.name];
     return updates != null && !updates.valid;
   });
+
+  // Current vs selected plan, one row per product. AI being turned off cancels
+  // its committed package, so its "next" line falls back to always-on PAYG.
+  const summaryItems: PlanChangeSummaryItem[] = products.flatMap(product => {
+    const display = PRODUCT_DISPLAY[product.name];
+    const comparison = updatesMap[product.name]?.comparison;
+    if (!display || !comparison) return [];
+    const isAiOff = product.name === 'AI_ASSISTANCE' && !aiEnabled;
+    const effective = isAiOff ? { current: comparison.current, next: PAYG_PLAN_LINE } : comparison;
+    // Skip products that are neither active today nor being committed to.
+    if (!effective.current && effective.next.payg) return [];
+    return [{ label: display.rowLabel, comparison: effective }];
+  });
+
+  // Only meaningful for the update flow (active subscription) once something changed.
+  const showPlanChange = !needsCheckout && packageUpdates.length > 0 && summaryItems.length > 0;
 
   return (
     <PageLayout
@@ -139,6 +173,7 @@ function SubscriptionSettingsContent() {
                 productRef={product}
                 subscriptionProductRef={subProduct}
                 disabled={product.name === 'AI_ASSISTANCE' && !aiEnabled}
+                reserveBillingPeriodSpace={anyHasBillingToggle}
                 onUpdatesChange={updates => handleUpdatesChange(product.name, updates)}
                 {...display}
               />
@@ -149,6 +184,8 @@ function SubscriptionSettingsContent() {
           );
         })}
       </div>
+
+      {showPlanChange && <PlanChangeSummary items={summaryItems} />}
 
       <div className="hidden md:flex flex-row gap-6 items-center">
         <p className="hidden lg:block text-h6 text-ods-text-secondary flex-1 max-w-[500px]">
@@ -164,13 +201,18 @@ function SubscriptionSettingsContent() {
         </div>
       </div>
 
-      <div className="md:hidden sticky bottom-0 z-10 -mx-[var(--spacing-system-l)] border-t border-ods-border bg-ods-card px-[var(--spacing-system-l)] py-4">
-        <div className="flex justify-end">
+      {/* Fixed (not sticky) so the bar always pins to the bottom of the viewport,
+          even when the page is shorter than the screen — sticky only engages while
+          scrolling, leaving the bar stranded mid-page on short content. The app's
+          <main> reserves pb-20 for exactly this bar. */}
+      <div className="md:hidden fixed inset-x-0 bottom-0 z-20 border-t border-ods-border bg-ods-card p-[var(--spacing-system-l)]">
+        <div className="flex">
           <SubscriptionSubmitButton
             needsCheckout={needsCheckout}
             packageUpdates={packageUpdates}
             checkoutProducts={checkoutProducts}
             hasInvalidCustom={hasInvalidCustom}
+            className="w-full"
           />
         </div>
       </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-submit-button.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-submit-button.tsx
@@ -14,6 +14,8 @@ interface SubscriptionSubmitButtonProps {
   checkoutProducts: ProductCheckoutInput[];
   /** True when a Custom Amount has an empty/invalid quantity (update flow only). */
   hasInvalidCustom: boolean;
+  /** Extra classes for the button (e.g. `w-full` for the mobile action bar). */
+  className?: string;
 }
 
 /**
@@ -28,13 +30,11 @@ export function SubscriptionSubmitButton({
   packageUpdates,
   checkoutProducts,
   hasInvalidCustom,
+  className,
 }: SubscriptionSubmitButtonProps) {
   const updateSubscription = useUpdateSubscription();
   const createCheckout = useCreateCheckoutSession();
   const { toast } = useToast();
-
-  console.log(packageUpdates, 'packageUpdates');
-  console.log(checkoutProducts, 'checkoutProducts');
 
   const isPending = updateSubscription.isPending || createCheckout.isPending;
 
@@ -42,6 +42,7 @@ export function SubscriptionSubmitButton({
     return (
       <Button
         variant="accent"
+        className={className}
         onClick={() => {
           if (!checkoutProducts.length) return;
           createCheckout.mutate({ products: checkoutProducts });
@@ -70,6 +71,7 @@ export function SubscriptionSubmitButton({
   return (
     <Button
       variant="accent"
+      className={className}
       onClick={handleUpdate}
       loading={isPending}
       disabled={isPending || packageUpdates.length === 0}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-product-selection.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-product-selection.ts
@@ -7,6 +7,7 @@ import type { BillingPeriod, ProductUpdates } from '../types/subscription.types'
 import {
   buildCheckoutProduct,
   buildInitialSelection,
+  buildPlanComparison,
   CUSTOM_OPTION_ID,
   diffPackageUpdates,
   PAYG_OPTION_ID,
@@ -43,6 +44,7 @@ export function useProductSelection({ product, subscriptionProduct, onUpdatesCha
       packageUpdates: diffPackageUpdates(product, selection, subscriptionProduct),
       checkout: buildCheckoutProduct(product, selection),
       valid,
+      comparison: buildPlanComparison(product, selection, subscriptionProduct),
     });
   }, [product, subscriptionProduct, selection]);
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/types/subscription.types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/types/subscription.types.ts
@@ -15,6 +15,23 @@ export interface ProductSelectionState {
   customQuantity: number | null;
 }
 
+/** One side (current or next) of a product's plan, used by the Current/New comparison block. */
+export interface PlanLine {
+  /** Pay-as-you-go (usage-based) — no committed quantity. */
+  payg: boolean;
+  /** Committed quantity in real product units (devices, tokens); null for PAYG. */
+  quantity: number | null;
+  billingPeriod: BillingPeriod | null;
+  /** Annualized committed cost in dollars; null for PAYG / not computable. */
+  annualTotal: number | null;
+}
+
+export interface PlanComparison {
+  /** null when the product is not part of the current subscription. */
+  current: PlanLine | null;
+  next: PlanLine;
+}
+
 export interface ProductUpdates {
   /** ADD/CANCEL diff for `updateSubscription` (active paid subscriptions). */
   packageUpdates: PackageUpdateInput[];
@@ -22,4 +39,6 @@ export interface ProductUpdates {
   checkout: ProductCheckoutInput;
   /** False when Custom Amount is selected with an empty/invalid quantity. */
   valid: boolean;
+  /** Current vs selected plan, for the "how your subscription changes" summary. */
+  comparison: PlanComparison;
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
@@ -2,7 +2,7 @@ import type { productSubscriptionCardProductFragment$data } from '@/__generated_
 import type { productSubscriptionCardSubscriptionFragment$data } from '@/__generated__/productSubscriptionCardSubscriptionFragment.graphql';
 import type { ProductCheckoutInput } from '../hooks/use-create-checkout-session';
 import type { PackageUpdateInput } from '../hooks/use-update-subscription';
-import type { BillingPeriod, ProductSelectionState } from '../types/subscription.types';
+import type { BillingPeriod, PlanComparison, PlanLine, ProductSelectionState } from '../types/subscription.types';
 
 export const CUSTOM_OPTION_ID = '__custom__';
 export const PAYG_OPTION_ID = '__payg__';
@@ -246,4 +246,79 @@ export function buildCheckoutProduct(
     quantity,
     payAsYouGoEnabled: true,
   };
+}
+
+/** Selected committed quantity in billable units (null for PAYG / empty Custom). */
+function selectionUnits(product: ProductData, selection: ProductSelectionState): number | null {
+  if (selection.selectedPackageId === PAYG_OPTION_ID) return null;
+  if (selection.selectedPackageId === CUSTOM_OPTION_ID) return customUnits(product, selection.customQuantity);
+  if (selection.selectedPackageId) {
+    const parsed = Number.parseInt(selection.selectedPackageId, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Annualized committed cost for `units` billable units against `tiers`.
+ * `priceTier.unitPrice` is per unit per month, so a year is always × 12 — the
+ * yearly discount is already baked into the yearly period's tiers.
+ */
+function annualizedPackagePrice(
+  units: number | null,
+  tiers: readonly PriceTierInput[] | null | undefined,
+): number | null {
+  if (units == null || units <= 0 || !tiers || tiers.length === 0) return null;
+  const applicable = tiers.find(t => units >= t.from && (t.upTo == null || units <= t.upTo)) ?? tiers[tiers.length - 1];
+  if (!applicable) return null;
+  return units * applicable.unitPrice * 12;
+}
+
+function tiersForPeriod(product: ProductData, period: BillingPeriod | null): readonly PriceTierInput[] {
+  const option = product.packageOptions.find(opt => opt.billingPeriod === period) ?? product.packageOptions[0];
+  return option?.priceTiers ?? [];
+}
+
+/**
+ * Current vs selected plan for the Current/New summary block. Prices are derived
+ * from the catalog tiers (the subscription fragment has no price tiers), so a
+ * current committed package is priced against the catalog option for its period.
+ */
+export function buildPlanComparison(
+  product: ProductData,
+  selection: ProductSelectionState,
+  subscriptionProduct: SubscriptionProductData | null,
+): PlanComparison {
+  const activePackage = subscriptionProduct?.packageOptions.find(opt => opt.status === 'ACTIVE') ?? null;
+
+  let current: PlanLine | null = null;
+  if (subscriptionProduct) {
+    if (activePackage && activePackage.quantity != null) {
+      const period = (activePackage.billingPeriod ?? null) as BillingPeriod | null;
+      current = {
+        payg: false,
+        quantity: toDisplayQuantity(activePackage.quantity, product.unitSize),
+        billingPeriod: period,
+        annualTotal: annualizedPackagePrice(activePackage.quantity, tiersForPeriod(product, period)),
+      };
+    } else {
+      // No committed package → product is on always-on PAYG.
+      current = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
+    }
+  }
+
+  let next: PlanLine;
+  if (selection.selectedPackageId === PAYG_OPTION_ID) {
+    next = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
+  } else {
+    const units = selectionUnits(product, selection);
+    next = {
+      payg: false,
+      quantity: units != null ? toDisplayQuantity(units, product.unitSize) : null,
+      billingPeriod: selection.billingPeriod,
+      annualTotal: annualizedPackagePrice(units, tiersForPeriod(product, selection.billingPeriod)),
+    };
+  }
+
+  return { current, next };
 }


### PR DESCRIPTION
## What

Adds the **Current Plan / New Plan** comparison block that appears when updating an active subscription, showing how the plan changes with the selected packages. Implements the Figma design ([node 4-17453](https://www.figma.com/design/ukMlNlIidL3Wk4tcz5DLCA/openframe---settings?node-id=4-17453&m=dev)).

Two side-by-side cards (`Current Plan` / `New Plan`); new-plan values are colored to signal **upgrade (green)** / **downgrade (red)** per row.

## Color logic (per designer)

| Dimension | Upgrade (green) | Downgrade (red) |
|---|---|---|
| Quantity (Devices / AI Tokens) | more | less |
| PAYG ↔ package | PAYG → package | package → PAYG |
| Billing period | Monthly → Annual (PAYG < Monthly < Annual) | Annual → Monthly |
| Total (annualized) | higher | lower |

> Note: the Figma mockup colored a **lower** total green — confirmed with the designer that this was a mistake. The rule here is **higher total = green**, isolated in `totalDirection()` for a one-line flip if it ever changes.

## How

- `buildPlanComparison()` (utils) builds `current` / `next` `PlanLine`s per product from the active subscription + current selection; reported up via the existing `onUpdatesChange` (`ProductUpdates.comparison`).
- Prices are derived from **catalog tiers** and annualized (×12, since tier `unitPrice` is per-unit-per-month) for an apples-to-apples Total.
- Per-product billing period is rendered inline (`300 · Annual`) since Devices and AI Tokens can differ.
- Block renders only in the update flow once a pending change exists.
- Reuses existing `SectionBlock` / `BillingRow` billing primitives — no new UI primitives.

## Known caveats (non-blocking)

- **Current total uses catalog prices**, not the subscription's contracted tiers (not exposed on the fragment). If catalog prices change or discounts apply, the shown current total can drift. Fix would add `priceTiers` to `productSubscriptionCardSubscriptionFragment`.
- **Total = committed cost only** (PAYG usage excluded).

## Test

- `npm run lint:biome` — clean
- `npm run type-check` — no errors in changed files (pre-existing environmental TS7016 yalc noise unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plan change summary showing current vs. new plan billing comparison with cost impact indicators (price increases highlighted in red, decreases in green).

* **Improvements**
  * Enhanced visual alignment of subscription cards when billing period options vary.
  * Optimized subscription checkout flow layout.

* **Bug Fixes**
  * Removed debug console logs from subscription updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->