### PR TITLE
hotfix(frontend): bump openframe-frontend-core to 0.0.225 (Mingo chat pagination fix)

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.224",
+        "@flamingo-stack/openframe-frontend-core": "0.0.225",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.224",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.224.tgz",
-      "integrity": "sha512-yQbU8DHmKKFW31djeWCSJr5Yv9pNAZ9NHpTIN+4w6ijA39ixP2SDvx/ZmLKnN9Pgji20W6DE01tQH3lHAJV3hw==",
+      "version": "0.0.225",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.225.tgz",
+      "integrity": "sha512-+HoAMjQ4Ttp/zbdu5wEV/O0hqftK0wb1mdnMymiNCfr2f3OTvVbUvaX6eiuoLUx4kRqEVwZReaRGSqtnVNv0/A==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.224",
+    "@flamingo-stack/openframe-frontend-core": "0.0.225",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## What

Bumps `@flamingo-stack/openframe-frontend-core` `0.0.224 → 0.0.225` in `openframe-frontend`.

## Why

Picks up the load-more pagination fix for the Mingo **EmbeddableChat** thread (lib PR flamingo-stack/openframe-oss-lib#1115, merged).

Message pagination (infinite-scroll up to load older messages) worked on the standalone `/mingo` page but was dead inside the embeddable chat — no request fired on scroll, because `EmbeddableChat` never forwarded `hasMoreMessages` / `loadMoreMessages` to `ChatMessageList`. The lib fix wires those props through; this bump consumes it.

## Changes

- `package.json` + `package-lock.json`: core lib `0.0.224 → 0.0.225`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core frontend dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->