### PR TITLE
fix: fix auth timeout

### DIFF
--- a/clients/openframe-client/src/services/nats_connection_manager.rs
+++ b/clients/openframe-client/src/services/nats_connection_manager.rs
@@ -114,8 +114,13 @@ impl NatsConnectionManager {
             "Auth URL callback triggered - performing reauthentication"
         );
 
-        match auth_service.reauthenticate().await {
-            Ok(_) => {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            auth_service.reauthenticate(),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
                 info!("Reauthentication successful in auth_url_callback");
 
                 match config_service.get_access_token().await {
@@ -130,9 +135,15 @@ impl NatsConnectionManager {
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 error!("Reauthentication failed in auth_url_callback: {}", e);
                 Err(async_nats::AuthError::new(format!("Reauthentication failed: {}", e)))
+            }
+            Err(_) => {
+                error!("Reauthentication timed out in auth_url_callback after 10s");
+                Err(async_nats::AuthError::new(
+                    "Reauthentication timed out after 10s".to_string(),
+                ))
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Authentication requests during connection establishment now enforce a 10-second timeout to prevent indefinite hangs. The system properly distinguishes between timeout errors and explicit authentication failures, with each scenario logged separately for better visibility. This improves system reliability and provides clearer diagnostics for authentication-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->