### PR TITLE
fix(auth): make SSO and Back buttons full-width on mobile

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/login-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/login-section.tsx
@@ -84,11 +84,11 @@ export function AuthLoginSection({ availableProviders, onSso, onBack, isLoading 
                       disabled={isLoading}
                       loading={isLoading && loginMethod === 'sso'}
                       variant="accent"
-                      className="md:!w-full"
+                      className="!w-full"
                     >
                       Sign in with OpenFrame SSO
                     </Button>
-                    <Button onClick={onBack} variant="outline" className="md:!w-full">
+                    <Button onClick={onBack} variant="outline" className="!w-full">
                       Back
                     </Button>
                   </>


### PR DESCRIPTION
The OpenFrame SSO and Back buttons used `md:!w-full`, so they only stretched on md+ and rendered auto-width (misaligned) on mobile. Switch to `!w-full` so they span 100% across all breakpoints.

## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted SSO sign-in button styling to display full-width consistently across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->