### PR TITLE
fix(ai-settings): bust avatar cache in read-only views

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-customer-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-customer-card.tsx
@@ -26,7 +26,7 @@ export function AiSettingsCustomerCard({ settings }: AiSettingsCustomerCardProps
   const cells: ReactNode[] = [
     <>
       <EntityImage
-        src={getFullImageUrl(settings.assistantAvatar?.imageUrl)}
+        src={getFullImageUrl(settings.assistantAvatar?.imageUrl, settings.assistantAvatar?.hash)}
         alt={settings.assistantName}
         className="size-10 rounded-full"
       />

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
@@ -75,7 +75,7 @@ export function CustomerAiAssistantTab({ settings, isEditMode, onSubmit }: Custo
         <AiSettingsCustomerCard settings={settings} />
         <AiSettingsPreviews
           assistantName={settings.assistantName}
-          avatarUrl={getFullImageUrl(settings.assistantAvatar?.imageUrl)}
+          avatarUrl={getFullImageUrl(settings.assistantAvatar?.imageUrl, settings.assistantAvatar?.hash)}
           accentColor={settings.accentColor}
           theme={settings.applicationTheme}
           providerName={settings.llmProvider}


### PR DESCRIPTION
## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 

## Task
[Link](https://app.clickup.com/t/example)
<!-- Links to any related tickets, issues, or requirements -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assistant avatar image loading in AI settings to properly retrieve and display assistant avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->