### PR TITLE
Create kafka listener at stream service

### DIFF
--- a/configs/base/openframe-client.yml
+++ b/configs/base/openframe-client.yml
@@ -131,7 +131,7 @@ openframe:
       topics:
         outbound:
           devices-topic: devices-topic
-          rmm-command-events: rmm.command.events
+          logs-events: logs.events
   integration:
     tool:
       enabled: true

--- a/configs/base/openframe-client.yml
+++ b/configs/base/openframe-client.yml
@@ -131,6 +131,7 @@ openframe:
       topics:
         outbound:
           devices-topic: devices-topic
+          rmm-command-events: rmm.command.events
   integration:
     tool:
       enabled: true

--- a/configs/base/openframe-stream.yml
+++ b/configs/base/openframe-stream.yml
@@ -69,8 +69,8 @@ openframe:
             name: fleet.query_results.events
           fleet-mdm-policy-membership-events:
             name: fleet.policy_membership.events
-          rmm-command-events:
-            name: rmm.command.events
+          logs-events:
+            name: logs.events
         outbound:
           integrated-tool-events: integrated-tool.events.pinot
           devices-topic: devices-topic

--- a/configs/base/openframe-stream.yml
+++ b/configs/base/openframe-stream.yml
@@ -69,6 +69,8 @@ openframe:
             name: fleet.query_results.events
           fleet-mdm-policy-membership-events:
             name: fleet.policy_membership.events
+          rmm-command-events:
+            name: rmm.command.events
         outbound:
           integrated-tool-events: integrated-tool.events.pinot
           devices-topic: devices-topic

--- a/openframe/services/openframe-stream/src/main/java/com/openframe/stream/listener/LogsEventListener.java
+++ b/openframe/services/openframe-stream/src/main/java/com/openframe/stream/listener/LogsEventListener.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(name = "openframe.oss.tenant.kafka.topics.inbound.logs-events")
+@ConditionalOnProperty(name = "openframe.oss-tenant.kafka.topics.inbound.logs-events.name")
 public class LogsEventListener {
 
     private final GenericJsonMessageProcessor messageProcessor;

--- a/openframe/services/openframe-stream/src/main/java/com/openframe/stream/listener/LogsEventListener.java
+++ b/openframe/services/openframe-stream/src/main/java/com/openframe/stream/listener/LogsEventListener.java
@@ -1,0 +1,41 @@
+package com.openframe.stream.listener;
+
+import com.openframe.data.model.enums.MessageType;
+import com.openframe.kafka.enumeration.KafkaHeader;
+import com.openframe.kafka.model.debezium.CommonDebeziumMessage;
+import com.openframe.stream.processor.GenericJsonMessageProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumer for the generic <b>logs-events</b> topic ({@code shared.logs.events}).
+ *
+ * <p>A single topic carries many event types; the concrete type is read from the
+ * {@code message-type} header rather than encoded in the topic name (no
+ * topic-per-type).
+ *
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "openframe.oss.tenant.kafka.topics.inbound.logs-events")
+public class LogsEventListener {
+
+    private final GenericJsonMessageProcessor messageProcessor;
+
+    @KafkaListener(
+            topics = "${openframe.oss-tenant.kafka.topics.inbound.logs-events.name}",
+            groupId = "openframe-saas-logs-events-group",
+            containerFactory = "saasTenantKafkaListenerContainerFactory"
+    )
+    public void listenLogsEvents(@Payload CommonDebeziumMessage message,
+                                 @Header(KafkaHeader.MESSAGE_TYPE_HEADER) MessageType messageType) {
+        log.info("Received logs-event: type={}", messageType);
+        messageProcessor.process(message, messageType);
+    }
+}


### PR DESCRIPTION
Relates to https://app.clickup.com/t/9013925967/86aht5nky

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added log event processing: the system can now ingest and handle log events via a dedicated event stream.
  * Listener activation is configurable and can be enabled or disabled per deployment.

* **Chores**
  * Configuration extended to include the new logs-events topic for integration across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->