### PR TITLE
fix(): invalidate status transition

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/statuses/hooks/use-ticket-statuses-mutations.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/statuses/hooks/use-ticket-statuses-mutations.ts
@@ -119,6 +119,7 @@ export function useSaveTicketStatusesMutation() {
     mutationFn: saveTicketStatuses,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ticketsQueryKeys.statuses() });
+      queryClient.invalidateQueries({ queryKey: ticketsQueryKeys.statusTransitionRules() });
       toast({ title: 'Saved', description: 'Ticket statuses updated', variant: 'success' });
     },
     onError: err => {
@@ -150,6 +151,7 @@ export function useDeleteTicketStatusMutation() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ticketsQueryKeys.statuses() });
+      queryClient.invalidateQueries({ queryKey: ticketsQueryKeys.statusTransitionRules() });
       // Deleting a status reassigns its tickets to the replacement status — refresh the board columns / list.
       invalidateAllDialogs(queryClient);
       toast({ title: 'Deleted', description: 'Ticket status removed', variant: 'success' });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where transition rule data didn't update in the UI when ticket statuses were created or deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->