### PR TITLE
feat(devices): add Signed by Flamingo footer to agent cards

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.244",
+        "@flamingo-stack/openframe-frontend-core": "0.0.254",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.244",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.244.tgz",
-      "integrity": "sha512-EIbEZp8WZ9z2S/Jv78g4O6ytwrPm6SAfLAyaj24mgnnAFdI6irOvakqR7GRDVd/qq4bP+GFCGUZmwaBanMBQYA==",
+      "version": "0.0.254",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.254.tgz",
+      "integrity": "sha512-V08pxd0IckdseLi2uAkar+AizUTcdKy0XYZAzvjmcxD09zr1o2t07HZmB97vH+ZwThc1YtRera0fSn7VqkXG0g==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.244",
+    "@flamingo-stack/openframe-frontend-core": "0.0.254",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
@@ -13,6 +13,7 @@ import { normalizeToolTypeWithFallback } from '@flamingo-stack/openframe-fronten
 import { Info as InfoIcon } from 'lucide-react';
 import { formatDateTime } from '@/lib/format-date';
 import type { Device, InstalledAgent, ToolConnection } from '../../types/device.types';
+import { getAgentFooter } from '../../utils/agent-footer';
 import { getDeviceStatusConfig } from '../../utils/device-status';
 
 interface AgentsTabProps {
@@ -152,6 +153,8 @@ export function AgentsTab({ device }: AgentsTabProps) {
               items.push({ label: 'Last fetched', value: formatted });
             }
 
+            const cardData = { items, footer: getAgentFooter(agent.toolType) };
+
             return (
               <div key={`${agent.agentType}-${agent.agentToolId || idx}`} className="relative flex flex-col">
                 <div className="absolute top-4 left-4 z-10">
@@ -171,12 +174,7 @@ export function AgentsTab({ device }: AgentsTabProps) {
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <InfoCard
-                  data={{
-                    items: items,
-                  }}
-                  className="pt-16 flex-1 min-h-0"
-                />
+                <InfoCard data={cardData} className="pt-16 flex-1 min-h-0" />
               </div>
             );
           })

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/agent-footer.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/agent-footer.tsx
@@ -1,17 +1,7 @@
+import type { InfoCardFooterData } from '@flamingo-stack/openframe-frontend-core';
 import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import { ShieldCheckIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import type { ReactNode } from 'react';
 import type { ToolType } from '../types/device.types';
-
-export interface InfoCardFooterData {
-  icon?: ReactNode;
-  text: string;
-  logo?: ReactNode;
-  link?: {
-    href: string;
-    label?: string;
-  };
-}
 
 /** External repository links per tool type; agents without an entry get no footer */
 const AGENT_REPO_LINKS: Record<ToolType, string> = {

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/agent-footer.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/agent-footer.tsx
@@ -1,0 +1,34 @@
+import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
+import { ShieldCheckIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import type { ReactNode } from 'react';
+import type { ToolType } from '../types/device.types';
+
+export interface InfoCardFooterData {
+  icon?: ReactNode;
+  text: string;
+  logo?: ReactNode;
+  link?: {
+    href: string;
+    label?: string;
+  };
+}
+
+/** External repository links per tool type; agents without an entry get no footer */
+const AGENT_REPO_LINKS: Record<ToolType, string> = {
+  FLEET_MDM: 'https://github.com/flamingo-ai/fleetdm',
+  MESHCENTRAL: 'https://github.com/flamingo-ai/meshcentral',
+  TACTICAL_RMM: 'https://github.com/flamingo-ai/tactical-rmm',
+};
+
+/** toolType stays a string: agents-tab synthesizes values outside ToolType (e.g. OSQUERYD) */
+export function getAgentFooter(toolType: string): InfoCardFooterData | undefined {
+  const href = AGENT_REPO_LINKS[toolType as ToolType];
+  if (!href) return undefined;
+
+  return {
+    icon: <ShieldCheckIcon size={24} className="text-ods-success" />,
+    text: 'Signed by Flamingo',
+    logo: <FlamingoLogo width={24} height={24} />,
+    link: { href },
+  };
+}


### PR DESCRIPTION
## Description
Add Signed by Flamingo footer to agent cards, component`InfoCard`

## Improvements

- New `InfoCardFooterData`: `icon`, `text`, `logo`, optional `link` (label falls back to href without protocol)
- `footer?` added to `InfoCardData` - rendered only when provided, existing cards unchanged
- Layout: bottom rounding moves to the footer (`overflow-hidden`), divider via `border-t`, footer pinned to the bottom with `mt-auto` so cards in a stretched grid stay aligned
- ODS tokens only: `text-h4` / `text-h6`, `border-ods-border`, `--spacing-system-m`
- Stories: `WithFooter`, `WithFooterWithoutLink`, footer in `WithCopyableValues`
- Review fixes: ARIA copy label fallback, story widths `w-80`/`w-96` instead of inline px

## Task
[Customizable Quick Actions for Fae and Mingo](https://app.clickup.com/t/86ahjjw4v)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent cards now include tool-specific footers that show verification details (Signed by Flamingo), an associated logo, and a direct link to the agent’s repository when available — improving at-a-glance trust and access to external resources for each agent type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->