### PR TITLE
Hotfix/mingo quick actions

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { getFullImageUrl } from '@/lib/image-url';
+import type { FaeQuickAction, FaeSettings } from '../types/fae-settings';
+import { AiSettingsCustomerCard } from './ai-settings-customer-card';
+import { AiSettingsQuickActions } from './ai-settings-quick-actions';
+import { AiSettingsPreviews } from './previews/ai-settings-previews';
+
+interface AiSettingsOverviewProps {
+  /** Renders the assistant card + previews when provided. */
+  settings?: FaeSettings;
+  /** Renders the quick actions list when provided. */
+  quickActions?: FaeQuickAction[];
+}
+
+/**
+ * Shared read-only view for the AI settings tabs. Each section renders only
+ * when its data is passed, so tabs compose just the parts they need
+ */
+export function AiSettingsOverview({ settings, quickActions }: AiSettingsOverviewProps) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-system-l)]">
+      {settings && (
+        <>
+          <AiSettingsCustomerCard settings={settings} />
+          <AiSettingsPreviews
+            assistantName={settings.assistantName}
+            avatarUrl={getFullImageUrl(settings.assistantAvatar?.imageUrl, settings.assistantAvatar?.hash)}
+            accentColor={settings.accentColor}
+            theme={settings.applicationTheme}
+            providerName={settings.llmProvider}
+            modelDisplayName={settings.providerModel}
+          />
+        </>
+      )}
+      {quickActions && <AiSettingsQuickActions actions={quickActions} />}
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-quick-actions-editor.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-quick-actions-editor.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { PlusCircleIcon, TrashIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button, Input, Textarea } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+import { type Control, Controller, type FieldValues, useFieldArray } from 'react-hook-form';
+import type { QuickActionsFormValues } from '../types/quick-action.types';
+
+interface AiSettingsQuickActionsEditorProps<T extends QuickActionsFormValues & FieldValues> {
+  control: Control<T>;
+  title?: string;
+  className?: string;
+}
+
+/**
+ * Shared quick actions editor for the Fae and Mingo settings forms.
+ * Owns the `quickActions` field array; the host form only needs a
+ * `quickActions` field matching QuickActionsFormValues in its schema.
+ */
+export function AiSettingsQuickActionsEditor<T extends QuickActionsFormValues & FieldValues>({
+  control,
+  title = 'Assistant Quick Actions',
+  className,
+}: AiSettingsQuickActionsEditorProps<T>) {
+  // The generic constraint guarantees the form has a compatible `quickActions`
+  // array; the cast narrows Control to that shape for type-safe field names.
+  const quickActionsControl = control as unknown as Control<QuickActionsFormValues>;
+  const { fields, append, remove } = useFieldArray({ control: quickActionsControl, name: 'quickActions' });
+
+  return (
+    <div className={cn('flex flex-col gap-[var(--spacing-system-l)]', className)}>
+      <span className="text-h2 text-ods-text-primary">{title}</span>
+
+      <div className="flex flex-col gap-[var(--spacing-system-xl)]">
+        {fields.map((field, index) => (
+          <QuickActionCard key={field.id} index={index} control={quickActionsControl} onRemove={() => remove(index)} />
+        ))}
+      </div>
+
+      <Button
+        type="button"
+        variant="transparent"
+        onClick={() => append({ name: '', instructions: '' })}
+        leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
+        className="self-start"
+      >
+        Add Quick Action
+      </Button>
+    </div>
+  );
+}
+
+interface QuickActionCardProps {
+  index: number;
+  control: Control<QuickActionsFormValues>;
+  onRemove: () => void;
+}
+
+function QuickActionCard({ index, control, onRemove }: QuickActionCardProps) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-system-m)] bg-ods-card border border-ods-border rounded-md p-[var(--spacing-system-l)]">
+      <div className="flex items-end gap-[var(--spacing-system-l)]">
+        <div className="flex-1 min-w-0">
+          <Controller
+            name={`quickActions.${index}.name`}
+            control={control}
+            render={({ field, fieldState }) => (
+              <Input {...field} label="Action Name" error={fieldState.error?.message} />
+            )}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={onRemove}
+          aria-label="Remove quick action"
+          leftIcon={<TrashIcon className="w-5 h-5" />}
+          className="[&_svg]:!text-ods-error"
+        />
+      </div>
+
+      <Controller
+        name={`quickActions.${index}.instructions`}
+        control={control}
+        render={({ field, fieldState }) => (
+          <Textarea {...field} label="Action Instructions" error={fieldState.error?.message} rows={4} />
+        )}
+      />
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
@@ -5,12 +5,13 @@ import { useCallback, useState } from 'react';
 import { useFaeSettings } from '../hooks/use-fae-settings';
 import { useUpdateFaeSettings } from '../hooks/use-update-fae-settings';
 import { getDefaultFaeSettings, type UpdateFaeSettingsInput } from '../types/fae-settings';
+import { MINGO_AI_CHAT_FORM_ID } from '../types/mingo-ai-chat.types';
 import { useAiSettingsActions } from './ai-settings-actions';
 import { AiSettingsLayout } from './ai-settings-layout';
 import { type AiSettingsTabId, AiSettingsTabs, getVisibleAiSettingsTabs } from './ai-settings-tabs';
 import { CUSTOMER_AI_ASSISTANT_FORM_ID, CustomerAiAssistantTab } from './customer-ai-assistant-tab';
 import { GUARDRAILS_FORM_ID, GuardrailsTab } from './guardrails-tab';
-import { MINGO_AI_CHAT_FORM_ID, MingoAiChatTab } from './mingo-ai-chat-tab';
+import { MingoAiChatTab } from './mingo-ai-chat-tab';
 
 const FORM_ID_BY_TAB: Record<AiSettingsTabId, string> = {
   customer: CUSTOMER_AI_ASSISTANT_FORM_ID,

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
@@ -1,14 +1,7 @@
 'use client';
 
+import { MonitorIcon, MoonStarIcon, Sun01Icon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import {
-  MonitorIcon,
-  MoonStarIcon,
-  PlusCircleIcon,
-  Sun01Icon,
-  TrashIcon,
-} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import {
-  Button,
   ColorPickerInput,
   ImageUploader,
   Input,
@@ -21,13 +14,9 @@ import {
   TabSelector,
   Textarea,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
-import { type Control, Controller } from 'react-hook-form';
-import { getFullImageUrl } from '@/lib/image-url';
+import { Controller } from 'react-hook-form';
 import { useCustomerAiAssistantForm } from '../hooks/use-customer-ai-assistant-form';
-import {
-  CUSTOMER_AI_ASSISTANT_FORM_ID,
-  type CustomerAiAssistantFormValues,
-} from '../types/customer-ai-assistant.types';
+import { CUSTOMER_AI_ASSISTANT_FORM_ID } from '../types/customer-ai-assistant.types';
 import type { FaeSettings, UpdateFaeSettingsInput } from '../types/fae-settings';
 import {
   ANSWER_STYLE_OPTIONS,
@@ -36,8 +25,8 @@ import {
   LLM_PROVIDER_OPTIONS,
   PROVIDER_MODELS,
 } from '../utils/fae-settings-display';
-import { AiSettingsCustomerCard } from './ai-settings-customer-card';
-import { AiSettingsQuickActions } from './ai-settings-quick-actions';
+import { AiSettingsOverview } from './ai-settings-overview';
+import { AiSettingsQuickActionsEditor } from './ai-settings-quick-actions-editor';
 import { AiSettingsPreviews } from './previews/ai-settings-previews';
 
 export type { CustomerAiAssistantFormValues } from '../types/customer-ai-assistant.types';
@@ -50,16 +39,10 @@ interface CustomerAiAssistantTabProps {
 }
 
 export function CustomerAiAssistantTab({ settings, isEditMode, onSubmit }: CustomerAiAssistantTabProps) {
-  const {
-    form,
-    avatarUrl,
-    handleAvatarChange,
-    handleAvatarRemove,
-    quickActionFields,
-    addQuickAction,
-    removeQuickAction,
-    handleSubmit,
-  } = useCustomerAiAssistantForm({ settings, onSubmit });
+  const { form, avatarUrl, handleAvatarChange, handleAvatarRemove, handleSubmit } = useCustomerAiAssistantForm({
+    settings,
+    onSubmit,
+  });
 
   const llmProvider = form.watch('llmProvider');
   const modelOptions = PROVIDER_MODELS[llmProvider] ?? [];
@@ -70,20 +53,7 @@ export function CustomerAiAssistantTab({ settings, isEditMode, onSubmit }: Custo
   const accentColor = form.watch('accentColor');
 
   if (!isEditMode) {
-    return (
-      <div className="flex flex-col gap-[var(--spacing-system-l)]">
-        <AiSettingsCustomerCard settings={settings} />
-        <AiSettingsPreviews
-          assistantName={settings.assistantName}
-          avatarUrl={getFullImageUrl(settings.assistantAvatar?.imageUrl, settings.assistantAvatar?.hash)}
-          accentColor={settings.accentColor}
-          theme={settings.applicationTheme}
-          providerName={settings.llmProvider}
-          modelDisplayName={settings.providerModel}
-        />
-        <AiSettingsQuickActions actions={settings.quickActions} />
-      </div>
-    );
+    return <AiSettingsOverview settings={settings} quickActions={settings.quickActions} />;
   }
 
   return (
@@ -241,69 +211,7 @@ export function CustomerAiAssistantTab({ settings, isEditMode, onSubmit }: Custo
         />
       )}
 
-      <span className="text-h2 text-ods-text-primary mt-8">Assistant Quick Actions</span>
-
-      <div className="flex flex-col gap-[var(--spacing-system-xl)]">
-        {quickActionFields.map((field, index) => (
-          <QuickActionCard
-            key={field.id}
-            index={index}
-            control={form.control}
-            onRemove={() => removeQuickAction(index)}
-          />
-        ))}
-      </div>
-
-      <Button
-        type="button"
-        variant="transparent"
-        onClick={addQuickAction}
-        leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
-        className="self-start"
-      >
-        Add Quick Action
-      </Button>
+      <AiSettingsQuickActionsEditor control={form.control} className="mt-8" />
     </form>
-  );
-}
-
-interface QuickActionCardProps {
-  index: number;
-  control: Control<CustomerAiAssistantFormValues>;
-  onRemove: () => void;
-}
-
-function QuickActionCard({ index, control, onRemove }: QuickActionCardProps) {
-  return (
-    <div className="flex flex-col gap-[var(--spacing-system-m)] bg-ods-card border border-ods-border rounded-md p-[var(--spacing-system-l)]">
-      <div className="flex items-end gap-[var(--spacing-system-l)]">
-        <div className="flex-1 min-w-0">
-          <Controller
-            name={`quickActions.${index}.name`}
-            control={control}
-            render={({ field, fieldState }) => (
-              <Input {...field} label="Action Name" error={fieldState.error?.message} />
-            )}
-          />
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          onClick={onRemove}
-          aria-label="Remove quick action"
-          leftIcon={<TrashIcon className="w-5 h-5" />}
-          className="[&_svg]:!text-ods-error"
-        />
-      </div>
-
-      <Controller
-        name={`quickActions.${index}.instructions`}
-        control={control}
-        render={({ field, fieldState }) => (
-          <Textarea {...field} label="Action Instructions" error={fieldState.error?.message} rows={4} />
-        )}
-      />
-    </div>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/mingo-ai-chat-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/mingo-ai-chat-tab.tsx
@@ -2,14 +2,15 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 import type { FaeSettings, UpdateFaeSettingsInput } from '../types/fae-settings';
-
-export const MINGO_AI_CHAT_FORM_ID = 'ai-settings-mingo-ai-chat-form';
-
-const mingoAiChatSchema = z.object({});
-
-type MingoAiChatFormValues = z.infer<typeof mingoAiChatSchema>;
+import {
+  getMingoAiChatDefaults,
+  MINGO_AI_CHAT_FORM_ID,
+  type MingoAiChatFormValues,
+  mingoAiChatSchema,
+} from '../types/mingo-ai-chat.types';
+import { AiSettingsOverview } from './ai-settings-overview';
+import { AiSettingsQuickActionsEditor } from './ai-settings-quick-actions-editor';
 
 interface MingoAiChatTabProps {
   settings: FaeSettings;
@@ -17,32 +18,29 @@ interface MingoAiChatTabProps {
   onSubmit: (values: UpdateFaeSettingsInput) => void;
 }
 
-export function MingoAiChatTab({ settings: _settings, isEditMode, onSubmit }: MingoAiChatTabProps) {
+export function MingoAiChatTab({ settings, isEditMode, onSubmit }: MingoAiChatTabProps) {
   const form = useForm<MingoAiChatFormValues>({
     resolver: zodResolver(mingoAiChatSchema),
-    defaultValues: {},
+    defaultValues: getMingoAiChatDefaults(settings),
   });
 
-  const handleSubmit = form.handleSubmit(() => {
-    // TODO: map form values to UpdateFaeSettingsInput once Mingo fields exist.
-    // No fields are implemented yet, so guard against sending an empty payload
-    // through the shared Save flow (which would trigger a no-op backend update).
-    const payload: UpdateFaeSettingsInput = {};
-    if (Object.keys(payload).length === 0) {
-      return;
-    }
-    onSubmit(payload);
+  // DEMO: Mingo quick actions will get their own BE query/mutation; until then
+  // they read and save the shared Fae quickActions field.
+  const handleSubmit = form.handleSubmit(values => {
+    onSubmit({ quickActions: values.quickActions });
   });
 
   if (!isEditMode) {
-    return (
-      <div className="flex flex-col gap-[var(--spacing-system-l)]">{/* TODO: Mingo AI chat read-only content */}</div>
-    );
+    return <AiSettingsOverview quickActions={settings.quickActions} />;
   }
 
   return (
-    <form id={MINGO_AI_CHAT_FORM_ID} onSubmit={handleSubmit} className="flex flex-col gap-[var(--spacing-system-l)]">
-      {/* TODO: Mingo AI chat fields */}
+    <form
+      id={MINGO_AI_CHAT_FORM_ID}
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-[var(--spacing-system-l)] max-md:[&_input]:!text-[14px] max-md:[&_textarea]:!text-[14px]"
+    >
+      <AiSettingsQuickActionsEditor control={form.control} title="Mingo Quick Actions" />
     </form>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/mingo-ai-chat-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/mingo-ai-chat-tab.tsx
@@ -35,11 +35,7 @@ export function MingoAiChatTab({ settings, isEditMode, onSubmit }: MingoAiChatTa
   }
 
   return (
-    <form
-      id={MINGO_AI_CHAT_FORM_ID}
-      onSubmit={handleSubmit}
-      className="flex flex-col gap-[var(--spacing-system-l)] max-md:[&_input]:!text-[14px] max-md:[&_textarea]:!text-[14px]"
-    >
+    <form id={MINGO_AI_CHAT_FORM_ID} onSubmit={handleSubmit} className="flex flex-col gap-[var(--spacing-system-l)]">
       <AiSettingsQuickActionsEditor control={form.control} title="Mingo Quick Actions" />
     </form>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-customer-ai-assistant-form.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-customer-ai-assistant-form.ts
@@ -3,7 +3,7 @@
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { getFullImageUrl } from '@/lib/image-url';
 import { deleteWithAuth, uploadWithAuth } from '@/lib/upload-with-auth';
 import {
@@ -83,10 +83,6 @@ export function useCustomerAiAssistantForm({ settings, onSubmit }: UseCustomerAi
     }
   };
 
-  const quickActions = useFieldArray({ control: form.control, name: 'quickActions' });
-
-  const addQuickAction = () => quickActions.append({ name: '', instructions: '' });
-
   const handleSubmit = form.handleSubmit(values => onSubmit(values));
 
   return {
@@ -94,9 +90,6 @@ export function useCustomerAiAssistantForm({ settings, onSubmit }: UseCustomerAi
     avatarUrl,
     handleAvatarChange,
     handleAvatarRemove,
-    quickActionFields: quickActions.fields,
-    addQuickAction,
-    removeQuickAction: quickActions.remove,
     handleSubmit,
   };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/customer-ai-assistant.types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/customer-ai-assistant.types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { FaeSettings } from './fae-settings';
+import { quickActionSchema } from './quick-action.types';
 
 export const CUSTOMER_AI_ASSISTANT_FORM_ID = 'ai-settings-customer-ai-assistant-form';
 
@@ -12,13 +13,7 @@ export const customerAiAssistantSchema = z
     accentColor: z.string().regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, 'Enter a valid hex color (e.g. #F357BB)'),
     answerStyle: z.enum(['SHORT', 'STANDARD', 'DETAILED', 'CUSTOM']),
     customPrompt: z.string().optional(),
-    quickActions: z.array(
-      z.object({
-        id: z.string().optional(),
-        name: z.string().min(1, 'Action name is required'),
-        instructions: z.string().min(1, 'Action instructions are required'),
-      }),
-    ),
+    quickActions: z.array(quickActionSchema),
   })
   .refine(data => data.answerStyle !== 'CUSTOM' || (data.customPrompt?.trim().length ?? 0) > 0, {
     message: 'Custom prompt is required',

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/mingo-ai-chat.types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/mingo-ai-chat.types.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import type { FaeSettings } from './fae-settings';
+import { quickActionSchema } from './quick-action.types';
+
+export const MINGO_AI_CHAT_FORM_ID = 'ai-settings-mingo-ai-chat-form';
+
+export const mingoAiChatSchema = z.object({
+  quickActions: z.array(quickActionSchema),
+});
+
+export type MingoAiChatFormValues = z.infer<typeof mingoAiChatSchema>;
+
+// DEMO: Mingo reads the shared Fae quickActions until its own settings
+// query/mutation exists on the BE.
+export function getMingoAiChatDefaults(settings: FaeSettings): MingoAiChatFormValues {
+  return {
+    quickActions: settings.quickActions ?? [],
+  };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/quick-action.types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/types/quick-action.types.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/** Quick action form shape shared by the Fae and Mingo settings forms. */
+export const quickActionSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1, 'Action name is required'),
+  instructions: z.string().min(1, 'Action instructions are required'),
+});
+
+export type QuickActionFormValue = z.infer<typeof quickActionSchema>;
+
+/** Minimal form-values contract required by AiSettingsQuickActionsEditor. */
+export interface QuickActionsFormValues {
+  quickActions: QuickActionFormValue[];
+}


### PR DESCRIPTION
## Description
Add configurable Quick Actions to the Mingo AI Chat tab and extract shared AI settings components for reuse across tabs.

## Improvements
- Extracted read-only view into AiSettingsOverview: renders assistant card, previews and quick actions only when their data is provided, so each tab composes just the sections it needs (Mingo shows quick actions only)
- Extracted quick actions form editor into AiSettingsQuickActionsEditor, reused by both Customer AI Assistant and Mingo AI Chat edit modes
- Shared quick action zod schema moved to quick-action.types.ts
- Mingo tab: read-only list + edit form with add/remove/validation, wired into the existing tab-level Save flow via MINGO_AI_CHAT_FORM_ID

## Task
[Customizable Quick Actions for Fae and Mingo](https://app.clickup.com/t/86ahjjw4v)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Settings overview component to display assistant details and previews.
  * Added a Quick Actions editor UI for creating and managing custom AI actions.

* **Refactor**
  * Unified AI settings to use the shared overview in read-only mode across tabs.
  * Moved quick-action and Mingo chat form definitions into shared schemas/types.
  * Simplified form hook responsibilities by delegating quick-action list management to the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->