### PR TITLE
fix(): gate doctor healthcheck admin check to linux only

### DIFF
--- a/clients/openframe-client/src/doctor/mod.rs
+++ b/clients/openframe-client/src/doctor/mod.rs
@@ -124,9 +124,13 @@ pub async fn run_preinstall(params: &InstallConfigParams) -> DoctorReport {
 pub async fn run_healthcheck() -> DoctorReport {
     let mut results = Vec::new();
 
-    results.push(check_admin_privileges());
-    if results.last().unwrap().status == CheckStatus::Fail {
-        return DoctorReport { results, title: "health check" };
+    // The Linux secured dir is root-only (0o700 root:root); reading the config requires root.
+    #[cfg(target_os = "linux")]
+    {
+        results.push(check_admin_privileges());
+        if results.last().unwrap().status == CheckStatus::Fail {
+            return DoctorReport { results, title: "health check" };
+        }
     }
 
     let dir_manager = DirectoryManager::new();


### PR DESCRIPTION
## What

The post-install `doctor` healthcheck (`run_healthcheck`) only does two things: read `initial_config.json` and run outbound network checks (DNS / TCP / TLS / WebSocket). None of that needs admin on macOS or Windows, where the secured config dir is readable by normal user processes.

Previously an upfront `check_admin_privileges()` gate blocked **all** platforms, so non-admins couldn't get network diagnostics even though they had read access to the config.

This change gates the admin check to **Linux only**, where the secured dir is `0o700 root:root` and reading the config genuinely requires root.

## Why per-platform

- **macOS** — `/Library/Application Support/OpenFrame/secured/` has no restrictive chmod (`set_secured_directory_permissions` is a no-op; files are readable by user processes), parent is `755`, file written `644`. → readable without admin.
- **Windows** — `%ProgramData%\OpenFrame\secured\` uses default ProgramData ACLs (Users have Read by inheritance). → readable by standard users.
- **Linux** — `/var/lib/openframe/secured/` is `0o700 root:root`. → read requires root.

Without the Linux gate, a non-root run would fail the config read and the `Err(_)` arm would report the misleading *"Config not found … Is the agent installed?"* (the agent **is** installed; the file just isn't readable). Keeping the admin check on Linux gives the correct *"run with sudo"* hint and an early return.

## Behavior after this change

| Platform | Non-admin `doctor` run |
|----------|------------------------|
| macOS / Windows | Proceeds; reads config + runs network diagnostics |
| Linux | Early return with clear "run with sudo / Administrator" hint |

The block is `#[cfg(target_os = "linux")]`, so it compiles out entirely on mac/win. `check_admin_privileges` is still referenced unconditionally by `run_preinstall`, so no unused-import fallout. `cargo check` passes on the mac target with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced healthcheck with improved platform-specific privilege verification. The diagnostic now includes a dedicated Linux-specific verification step that ensures admin privileges are available before attempting to read configuration files. This change addresses important platform-specific permission requirements on Linux while maintaining standard behavior and ensuring full compatibility across all supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->