### PR TITLE
Empty state ask mingo

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
@@ -13,6 +13,7 @@ import { useApiParams, useDebounce } from '@flamingo-stack/openframe-frontend-co
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { useCustomers } from '../hooks/use-customers';
 import { CustomersSearchInput, CustomersTableBody } from './customers-table-columns';
@@ -23,6 +24,7 @@ interface CustomersTableProps {
 
 export function CustomersTable({ status }: CustomersTableProps) {
   const router = useRouter();
+  const askMingo = useAskMingo();
 
   const { params, setParam } = useApiParams({
     search: { type: 'string', default: '' },
@@ -100,6 +102,7 @@ export function CustomersTable({ status }: CustomersTableProps) {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('customers')}
         />
       ) : (
         <div>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/page.tsx
@@ -9,9 +9,11 @@ import {
   MonitorIcon,
   TerminalIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { DevicesPanel, EmptyState } from '@/app/components/shared';
 
 export default function Devices() {
+  const askMingo = useAskMingo();
   return (
     <DevicesPanel
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
@@ -33,6 +35,7 @@ export default function Devices() {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('devices')}
         />
       }
     />

--- a/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
@@ -39,6 +39,7 @@ import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import type { logsTableRelay_query$key as LogsFragmentKey } from '@/__generated__/logsTableRelay_query.graphql';
 import type { logsTableRelayPaginationQuery as LogsPaginationQueryType } from '@/__generated__/logsTableRelayPaginationQuery.graphql';
 import type { logsTableRelayQuery as LogsQueryType } from '@/__generated__/logsTableRelayQuery.graphql';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState, LogDrawer } from '@/app/components/shared';
 import { transformOrganizationFilters } from '@/lib/filter-utils';
 import { formatDateTime } from '@/lib/format-date';
@@ -169,6 +170,7 @@ function LogsTableContent({
   onRefreshRef,
 }: LogsTableContentProps) {
   const { toast } = useToast();
+  const askMingo = useAskMingo();
   const [isPending, startTransition] = useTransition();
   const [selectedLog, setSelectedLog] = useState<UiLogEntry | null>(null);
 
@@ -503,6 +505,7 @@ function LogsTableContent({
             cornerColor="var(--ods-flamingo-cyan-base)"
           />
         }
+        onButtonClick={() => askMingo('logs')}
       />
     );
   }

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-ask-mingo.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-ask-mingo.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useMingoLauncherStore } from '../stores/mingo-launcher-store';
+
+/**
+ * Launcher hook for opening the Mingo chat with a context prompt. Returns the
+ * store's `askMingo(source, promptOverride?)` action so call sites import one
+ * thing:
+ *
+ *   const askMingo = useAskMingo();
+ *   <EmptyState ... onButtonClick={() => askMingo('queries')} />
+ */
+export function useAskMingo() {
+  return useMingoLauncherStore(s => s.askMingo);
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
@@ -68,6 +68,12 @@ export interface MingoSubscriptionBindings {
 export interface MingoUnifiedChat {
   state: UnifiedChatState;
   subscription: MingoSubscriptionBindings;
+  /**
+   * Create a brand-new dialog and send `text` into it, regardless of any
+   * currently-active dialog. Used by external launchers (e.g. the "Ask Mingo
+   * about X" EmptyState buttons) that always want a fresh conversation.
+   */
+  sendInNewDialog: (text: string) => Promise<void>;
 }
 
 export function useMingoUnifiedChatState(): MingoUnifiedChat {
@@ -207,6 +213,33 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
     [activeDialogId, setActiveDialogId, resetUnread, subscribeToDialog, selectDialogMut],
   );
 
+  // ─── Create a fresh dialog and send into it (always-new) ──────────────────
+  // Shared by the draft branch of `sendMessage` and external launchers that
+  // want a brand-new conversation regardless of what's currently active.
+  const sendInNewDialog = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      const newId = await createDialog();
+      if (!newId) return;
+      addMessage(newId, {
+        id: `welcome-${newId}`,
+        role: 'assistant',
+        name: 'Mingo',
+        timestamp: new Date(),
+        content: WELCOME_TEXT,
+        assistantType: 'mingo',
+      });
+      setActiveDialogId(newId);
+      resetUnread(newId);
+      subscribeToDialog(newId);
+      selectDialogMut(newId);
+      await sendMingoMessage(trimmed, newId);
+    },
+    [createDialog, addMessage, setActiveDialogId, resetUnread, subscribeToDialog, selectDialogMut, sendMingoMessage],
+  );
+
   // ─── Send: create-on-first-send when no dialog is active (draft) ──────────
   const sendMessage = useCallback(
     async (text: string) => {
@@ -214,36 +247,13 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
       if (!trimmed) return;
 
       if (!activeDialogId) {
-        const newId = await createDialog();
-        if (!newId) return;
-        addMessage(newId, {
-          id: `welcome-${newId}`,
-          role: 'assistant',
-          name: 'Mingo',
-          timestamp: new Date(),
-          content: WELCOME_TEXT,
-          assistantType: 'mingo',
-        });
-        setActiveDialogId(newId);
-        resetUnread(newId);
-        subscribeToDialog(newId);
-        selectDialogMut(newId);
-        await sendMingoMessage(trimmed, newId);
+        await sendInNewDialog(trimmed);
         return;
       }
 
       await sendMingoMessage(trimmed);
     },
-    [
-      activeDialogId,
-      createDialog,
-      addMessage,
-      setActiveDialogId,
-      resetUnread,
-      subscribeToDialog,
-      selectDialogMut,
-      sendMingoMessage,
-    ],
+    [activeDialogId, sendInNewDialog, sendMingoMessage],
   );
 
   const stopMessage = useCallback(() => {
@@ -387,5 +397,5 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
     ],
   );
 
-  return { state, subscription };
+  return { state, subscription, sendInNewDialog };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/prompts/mingo-prompts.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/prompts/mingo-prompts.ts
@@ -1,0 +1,32 @@
+/**
+ * Central registry of the prompts Mingo is launched with from across the app.
+ * Each key is a `MingoPromptSource` - the place the chat was invoked from (an
+ * EmptyState "Ask Mingo about X" button today). Keeping every prompt here means
+ * copy lives in one place and new entry points are a one-line addition.
+ */
+
+export type MingoPromptSource =
+  | 'queries'
+  | 'customers'
+  | 'policies'
+  | 'scripts'
+  | 'script-schedules'
+  | 'logs'
+  | 'devices';
+
+/** One prompt per invocation source. Edit copy here only. */
+export const MINGO_PROMPTS: Record<MingoPromptSource, string> = {
+  queries:
+    'Help me build a query across my fleet. For example, which devices have Chrome installed, who is on an outdated OS, or which machines are low on disk space.',
+  customers:
+    'Help me organize my customers - grouping devices and users by client, and tracking their security posture.',
+  policies: 'Help me create a policy to apply settings across many devices at once.',
+  scripts: 'Help me write and run a script on one device or push it to many at once.',
+  'script-schedules': 'Help me schedule a script to run hourly, daily, weekly, or on a custom cron.',
+  logs: 'Help me explore my logs - who did what, when, and on which device.',
+  devices: 'Help me monitor device health - CPU, memory, and disk usage in real time.',
+};
+
+export function getMingoPrompt(source: MingoPromptSource): string {
+  return MINGO_PROMPTS[source];
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/stores/mingo-launcher-store.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/stores/mingo-launcher-store.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { getMingoPrompt, type MingoPromptSource } from '../prompts/mingo-prompts';
+
+/**
+ * Owns the Mingo chat drawer's open state (lifted out of `AppShell` so any page
+ * can open it) plus a one-shot `pendingPrompt` that the chat embedder consumes
+ * on open to auto-send a context prompt.
+ *
+ * `askMingo(source)` is the single entry point used by EmptyState "Ask Mingo
+ * about X" buttons: it resolves the source's prompt and opens the drawer. The
+ * embedder (`OpenframeEmbeddableChatEntry`) drains `pendingPrompt` via
+ * `consumePendingPrompt()` once it mounts, starting a fresh dialog with the
+ * prompt already sent.
+ */
+interface MingoLauncherStore {
+  isOpen: boolean;
+  /** One-shot prompt to auto-send on the next drawer open; null once consumed. */
+  pendingPrompt: string | null;
+
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  close: () => void;
+  /** Open the drawer and queue the source's prompt (or an override) for auto-send. */
+  askMingo: (source: MingoPromptSource, promptOverride?: string) => void;
+  /** Read and clear the pending prompt in one step (safe against double-consume). */
+  consumePendingPrompt: () => string | null;
+}
+
+export const useMingoLauncherStore = create<MingoLauncherStore>()(
+  devtools(
+    (set, get) => ({
+      isOpen: false,
+      pendingPrompt: null,
+
+      setOpen: open => set({ isOpen: open }, false, 'setOpen'),
+      toggle: () => set(state => ({ isOpen: !state.isOpen }), false, 'toggle'),
+      close: () => set({ isOpen: false }, false, 'close'),
+
+      askMingo: (source, promptOverride) =>
+        set({ isOpen: true, pendingPrompt: promptOverride ?? getMingoPrompt(source) }, false, 'askMingo'),
+
+      consumePendingPrompt: () => {
+        const { pendingPrompt } = get();
+        if (pendingPrompt !== null) set({ pendingPrompt: null }, false, 'consumePendingPrompt');
+        return pendingPrompt;
+      },
+    }),
+    { name: 'mingo-launcher-store' },
+  ),
+);

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/policies.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/policies.tsx
@@ -33,6 +33,7 @@ import { useApiParams } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { formatDistanceToNow } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { openInNewTab } from '@/lib/open-in-new-tab';
 import { ConfirmDeleteMonitoringModal } from '../../components/confirm-delete-monitoring-modal';
@@ -76,6 +77,7 @@ function PolicyStatusCell({ policy }: { policy: Policy }) {
 
 export function Policies() {
   const router = useRouter();
+  const askMingo = useAskMingo();
 
   const { params, setParams } = useApiParams({
     search: { type: 'string', default: '' },
@@ -289,6 +291,7 @@ export function Policies() {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('policies')}
         />
       ) : (
         <>

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/queries.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/queries.tsx
@@ -26,6 +26,7 @@ import {
 import { useApiParams } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { openInNewTab } from '@/lib/open-in-new-tab';
 import { ConfirmDeleteMonitoringModal } from '../../components/confirm-delete-monitoring-modal';
@@ -44,6 +45,7 @@ function formatInterval(seconds: number): string {
 
 export function Queries() {
   const router = useRouter();
+  const askMingo = useAskMingo();
 
   const { params, setParams } = useApiParams({
     search: { type: 'string', default: '' },
@@ -197,6 +199,7 @@ export function Queries() {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('queries')}
         />
       ) : (
         <>

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script-schedules-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script-schedules-table.tsx
@@ -29,6 +29,7 @@ import {
 import { useApiParams, useDebounce } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { openInNewTab } from '@/lib/open-in-new-tab';
 import { useScriptSchedules } from '../hooks/use-script-schedule';
@@ -53,6 +54,7 @@ function getRepeatLabelFromTaskType(taskType: ScriptScheduleTaskType): string {
 
 export function ScriptSchedulesTable() {
   const router = useRouter();
+  const askMingo = useAskMingo();
 
   const { params, setParam } = useApiParams({
     search: { type: 'string', default: '' },
@@ -261,6 +263,7 @@ export function ScriptSchedulesTable() {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('script-schedules')}
         />
       ) : (
         <>

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-table.tsx
@@ -41,6 +41,7 @@ import { useApiParams, useDebounce } from '@flamingo-stack/openframe-frontend-co
 import { getOSLabel, normalizeToolTypeWithFallback } from '@flamingo-stack/openframe-frontend-core/utils';
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { openInNewTab } from '@/lib/open-in-new-tab';
 import { useScripts } from '../hooks/use-scripts';
@@ -61,6 +62,7 @@ interface UiScriptEntry {
  */
 export function ScriptsTable() {
   const router = useRouter();
+  const askMingo = useAskMingo();
 
   // URL state management - search, filters, and pagination persist in URL
   const { params, setParam, setParams } = useApiParams({
@@ -431,7 +433,7 @@ export function ScriptsTable() {
 
   return (
     <PageLayout title="Scripts" actions={actions}>
-      {!showEmptyState ? (
+      {showEmptyState ? (
         <EmptyState
           icon={<BracketCurlyIcon />}
           title="No scripts yet"
@@ -458,6 +460,7 @@ export function ScriptsTable() {
               cornerColor="var(--ods-flamingo-cyan-base)"
             />
           }
+          onButtonClick={() => askMingo('scripts')}
         />
       ) : (
         <>

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -10,6 +10,7 @@ import { CompactPageLoader } from '@flamingo-stack/openframe-frontend-core/compo
 import type { NavigationSidebarConfig } from '@flamingo-stack/openframe-frontend-core/types/navigation';
 import { usePathname, useRouter } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useMingoLauncherStore } from '@/app/(app)/mingo/stores/mingo-launcher-store';
 import { useAuthSession } from '@/app/(auth)/auth/hooks/use-auth-session';
 import { useAuthStore } from '@/app/(auth)/auth/stores/auth-store';
 import { performLogout } from '@/app/(auth)/auth/utils/auth-actions';
@@ -44,7 +45,14 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
   // in-layout `AppLayoutDrawer` + `OpenframeEmbeddableChatEntry` in the
   // `drawer` slot. The chat runs shell-less inside the drawer, so the drawer
   // (not the chat) owns the panel chrome.
-  const [chatOpen, setChatOpen] = useState(false);
+  //
+  // Lifted into a global store (`mingo-launcher-store`) so pages can open the
+  // drawer from anywhere — e.g. the EmptyState "Ask Mingo about X" buttons call
+  // `askMingo(source)`, which flips `isOpen` here and queues a prompt the chat
+  // embedder auto-sends on open.
+  const chatOpen = useMingoLauncherStore(state => state.isOpen);
+  const setChatOpen = useMingoLauncherStore(state => state.setOpen);
+  const toggleChat = useMingoLauncherStore(state => state.toggle);
 
   const handleNavigate = useCallback(
     (path: string) => {
@@ -61,9 +69,6 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
     router.push('/settings');
   }, [router]);
 
-  // Toggle the Mingo chat drawer from the header's "Mingo AI" launcher.
-  const toggleChat = useCallback(() => setChatOpen(prev => !prev), []);
-
   // Close the drawer on route navigation. The drawer is non-modal (header +
   // sidebar stay interactive while it's open), so clicking a nav link or an
   // in-chat link that routes should land the user on the new page rather than
@@ -72,7 +77,9 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
   // here. Runs on `pathname` change; the initial no-op (already closed) is
   // harmless — React bails on a same-value `setState`.
   useEffect(() => {
-    setChatOpen(false);
+    // Read the action off the store imperatively so this effect's only
+    // dependency stays `pathname` (the trigger) — matches the original shape.
+    useMingoLauncherStore.getState().close();
   }, [pathname]);
 
   const { isLocked } = useSubscriptionLock();

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -75,10 +75,13 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
   // leaving the panel covering it. The lib's EmbeddableChat leaves this
   // pathname-driven close to the embedder (it has no router), so we own it
   // here. Runs on `pathname` change; the initial no-op (already closed) is
-  // harmless — React bails on a same-value `setState`.
+  // harmless - React bails on a same-value `setState`.
+  //
+  // `pathname` is the intentional trigger but isn't read in the body (we pull
+  // the store action imperatively via getState() so it isn't a dependency), so
+  // biome's exhaustive-deps rule sees it as "extra". That's deliberate.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the intentional re-run trigger; the close() action is read imperatively
   useEffect(() => {
-    // Read the action off the store imperatively so this effect's only
-    // dependency stays `pathname` (the trigger) — matches the original shape.
     useMingoLauncherStore.getState().close();
   }, [pathname]);
 

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -29,8 +29,10 @@
 
 import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useLocalStorage } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useEffect } from 'react';
 import { DialogSubscription } from '../(app)/mingo/hooks/use-mingo-realtime-subscription';
 import { useMingoUnifiedChatState } from '../(app)/mingo/hooks/use-mingo-unified-chat-state';
+import { useMingoLauncherStore } from '../(app)/mingo/stores/mingo-launcher-store';
 
 /** The two transports the in-panel toggle switches between. Mirrors the lib's
  *  `ChatMode` (not re-exported from the chat barrel) — structurally identical,
@@ -52,7 +54,22 @@ interface OpenframeEmbeddableChatEntryProps {
 }
 
 export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEmbeddableChatEntryProps) {
-  const { state, subscription } = useMingoUnifiedChatState();
+  const { state, subscription, sendInNewDialog } = useMingoUnifiedChatState();
+
+  // Drain a queued launcher prompt (set by `askMingo(source)` from an EmptyState
+  // "Ask Mingo about X" button). The drawer unmounts this entry on close and
+  // remounts on open, so this effect runs on every open; it also re-fires if a
+  // new prompt is queued while the drawer is already open. `consumePendingPrompt`
+  // nulls the prompt as it reads it, so a manual header open (no prompt) and
+  // React StrictMode's double-invoke are both no-ops.
+  const pendingPrompt = useMingoLauncherStore(s => s.pendingPrompt);
+  const consumePendingPrompt = useMingoLauncherStore(s => s.consumePendingPrompt);
+  useEffect(() => {
+    if (!pendingPrompt) return;
+    const text = consumePendingPrompt();
+    if (!text) return;
+    void sendInNewDialog(text);
+  }, [pendingPrompt, consumePendingPrompt, sendInNewDialog]);
 
   // Controlled active mode persisted across drawer open/close (and reloads):
   // the drawer unmounts its content on close, so an uncontrolled mode would


### PR DESCRIPTION
## Description
Wire EmptyState "Ask Mingo" buttons to open chat with a context prompt

## Improvements
Clicking an "Ask Mingo about X" EmptyState button now opens the Mingo chat
drawer and auto-sends a context-appropriate prompt in a brand-new dialog.
Previously these buttons rendered but had no onButtonClick handler.

New:
- mingo/prompts/mingo-prompts.ts: central MINGO_PROMPTS registry keyed by a
  MingoPromptSource (the place of invocation). Single source of truth for all
  Mingo launch copy; getMingoPrompt(source) resolves a source to its prompt.
- mingo/stores/mingo-launcher-store.ts: zustand store that owns the chat drawer
  open state (lifted out of AppShell so any page can open it) plus a one-shot
  pendingPrompt. askMingo(source, override?) opens the drawer and queues the
  prompt; consumePendingPrompt() reads and clears it in one step.
- mingo/hooks/use-ask-mingo.ts: thin launcher hook returning askMingo for call
  sites.
  
Changed:
- components/app-layout.tsx: drawer open/toggle/setOpen now come from the
  launcher store instead of local useState, so pages can drive the drawer. The
  route-change close effect keeps its original [pathname] dependency shape by
  reading the action via useMingoLauncherStore.getState().close().
- mingo/hooks/use-mingo-unified-chat-state.ts: extracted the existing
  create-dialog-and-send sequence (previously inline in sendMessage's
  no-active-dialog branch) into a reusable sendInNewDialog(text) that always
  creates a fresh dialog; sendMessage's draft branch now delegates to it.
  Exposed sendInNewDialog on the hook's return value.
- components/openframe-embeddable-chat-entry.tsx: on mount/open, an effect
  drains pendingPrompt and calls sendInNewDialog, so the chat opens with a new
  dialog and the prompt already sent. Manual header opens (no pending prompt)
  and StrictMode double-invokes are no-ops.
  
Wired onButtonClick on the 7 Ask-Mingo EmptyStates: Queries, Customers,
Policies, Scripts, Script Schedules, Logs, Devices. devices-panel.tsx needs no
change; it renders the emptyState prop passed from devices/page.tsx, where the
Devices button is wired once.

## Task
[Empty States for Tables](https://app.clickup.com/t/86agtuac6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * "Ask Mingo" buttons now active across Customers, Devices, Logs, Policies, Queries, Scripts, and Script Schedules for context-specific AI assistance
  * Enhanced Mingo chat drawer with improved state management and support for seamless context-aware interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->