### PR TITLE
fix(Logs Page): updated the 'Empty State' display condition

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
@@ -486,7 +486,7 @@ function LogsTableContent({
     !isPending &&
     transformedLogs.length === 0;
 
-  if (!showEmptyState) {
+  if (showEmptyState) {
     return (
       <EmptyState
         icon={<ClipboardListIcon />}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect display of the empty state in the logs view—the "No logs yet" message now appears properly when there are no logs available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->