### PR TITLE
Add knowledge-base page mobile tags filter modal

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
@@ -439,7 +439,7 @@ function KnowledgeBaseBodyShell({
                 addMorePlaceholder="Search for Articles"
               />
             </div>
-            {isMdUp === false && (
+            {!isMdUp && (
               <Button
                 variant="outline"
                 size="icon"
@@ -450,7 +450,7 @@ function KnowledgeBaseBodyShell({
             )}
           </div>
 
-          {isMdUp === true && <KnowledgeBaseTagsRow parentId={parentId} selectedIds={tagIds} onAdd={addTag} />}
+          {isMdUp && <KnowledgeBaseTagsRow parentId={parentId} selectedIds={tagIds} onAdd={addTag} />}
         </div>
 
         <Suspense fallback={<KnowledgeBaseTableSkeleton />}>
@@ -479,7 +479,7 @@ function KnowledgeBaseBodyShell({
         parentConnectionId={newFolderConnectionId}
       />
 
-      {isMdUp === false && (
+      {!isMdUp && (
         <KnowledgeBaseTagsFilterModal
           isOpen={isTagsModalOpen}
           onClose={() => setIsTagsModalOpen(false)}

--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
@@ -3,14 +3,16 @@
 import {
   BookBookmarkIcon,
   BoxArchiveIcon,
+  Filter02Icon,
   PlusCircleIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import {
+  Button,
   type PageActionButton,
   PageLayout,
   TagSearchInput,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
-import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useMdUp, useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { notFound } from 'next/navigation';
 import { Suspense, useCallback, useMemo, useState } from 'react';
 import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
@@ -39,6 +41,7 @@ import {
   KnowledgeBaseTableSkeleton,
   readKnowledgeBaseItems,
 } from './knowledge-base-table';
+import { KnowledgeBaseTagsFilterModal } from './knowledge-base-tags-filter-modal';
 import { KnowledgeBaseTagsRow } from './knowledge-base-tags-row';
 import { NewFolderModal } from './new-folder-modal';
 
@@ -380,9 +383,13 @@ function KnowledgeBaseBodyShell({
   currentFolder,
   onCurrentFolderDeleted,
 }: KnowledgeBaseBodyShellProps) {
-  const { search, debouncedSearch, setSearch, tagIds, tagSearchOptions, addTag, removeTag, clearAll } =
+  const { search, debouncedSearch, setSearch, tagIds, tagSearchOptions, addTag, removeTag, setTags, clearAll } =
     useTagSearchState();
   const [isNewFolderOpen, setIsNewFolderOpen] = useState(false);
+  const [isTagsModalOpen, setIsTagsModalOpen] = useState(false);
+  // Below `md` (phones) the inline tags row is hidden and a filter button next
+  // to the search opens the tags modal instead; tablet/desktop keep the row.
+  const isMdUp = useMdUp();
   const { toolbarRef, containerStyle, stickyHeaderOffset } = useStickyToolbar();
 
   const isSubtreeMode = parentId !== null && tagIds.length > 0;
@@ -420,17 +427,30 @@ function KnowledgeBaseBodyShell({
           ref={toolbarRef}
           className="sticky top-0 z-20 flex flex-col gap-[var(--spacing-system-xxs)] bg-ods-bg -mx-[var(--spacing-system-l)] px-[var(--spacing-system-l)] pt-[var(--spacing-system-l)] pb-[var(--spacing-system-m)] -mt-[var(--spacing-system-l)]"
         >
-          <TagSearchInput<string>
-            tags={tagSearchOptions}
-            searchValue={search}
-            onSearchChange={setSearch}
-            onTagRemove={removeTag}
-            onClearAll={clearAll}
-            placeholder="Search for Articles"
-            addMorePlaceholder="Search for Articles"
-          />
+          <div className="flex items-center gap-[var(--spacing-system-m)]">
+            <div className="min-w-0 flex-1">
+              <TagSearchInput<string>
+                tags={tagSearchOptions}
+                searchValue={search}
+                onSearchChange={setSearch}
+                onTagRemove={removeTag}
+                onClearAll={clearAll}
+                placeholder="Search for Articles"
+                addMorePlaceholder="Search for Articles"
+              />
+            </div>
+            {isMdUp === false && (
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => setIsTagsModalOpen(true)}
+                aria-label="Filter by tags"
+                leftIcon={<Filter02Icon />}
+              />
+            )}
+          </div>
 
-          <KnowledgeBaseTagsRow parentId={parentId} selectedIds={tagIds} onAdd={addTag} />
+          {isMdUp === true && <KnowledgeBaseTagsRow parentId={parentId} selectedIds={tagIds} onAdd={addTag} />}
         </div>
 
         <Suspense fallback={<KnowledgeBaseTableSkeleton />}>
@@ -458,6 +478,16 @@ function KnowledgeBaseBodyShell({
         parentFolderId={parentId}
         parentConnectionId={newFolderConnectionId}
       />
+
+      {isMdUp === false && (
+        <KnowledgeBaseTagsFilterModal
+          isOpen={isTagsModalOpen}
+          onClose={() => setIsTagsModalOpen(false)}
+          parentId={parentId}
+          selectedIds={tagIds}
+          onApply={setTags}
+        />
+      )}
 
       {currentFolder && folderActions.modals}
     </PageLayout>

--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-tags-filter-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-tags-filter-modal.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { FilterModal } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Suspense, useMemo } from 'react';
+import { useKnowledgeBaseTags } from '../hooks/use-knowledge-base-tags';
+import type { SelectedKnowledgeBaseTag } from './knowledge-base-tags-row';
+
+// Single FilterModal group id under which all knowledge-base tags are listed as
+// checkbox options. Knowledge Base tags are flat (no key:value), so one group is enough.
+const TAGS_GROUP_ID = 'tags';
+
+interface KnowledgeBaseTagsFilterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  parentId: string | null;
+  /** Currently-applied tag ids (pre-checked when the modal opens). */
+  selectedIds: ReadonlyArray<string>;
+  archived?: boolean;
+  /** Called on Apply with the full new selection (replace semantics). */
+  onApply: (tags: SelectedKnowledgeBaseTag[]) => void;
+}
+
+function KnowledgeBaseTagsFilterModalContent({
+  isOpen,
+  onClose,
+  parentId,
+  selectedIds,
+  archived,
+  onApply,
+}: KnowledgeBaseTagsFilterModalProps) {
+  const tags = useKnowledgeBaseTags({ folderId: parentId, archived });
+
+  const filterGroups = useMemo(
+    () => [
+      {
+        id: TAGS_GROUP_ID,
+        title: 'Tags',
+        options: tags.map(tag => ({ id: tag.id, label: tag.key })),
+      },
+    ],
+    [tags],
+  );
+
+  // FilterModal re-seeds its checkboxes from `currentFilters` each time it opens.
+  const currentFilters = useMemo(() => ({ [TAGS_GROUP_ID]: [...selectedIds] }), [selectedIds]);
+
+  const handleFilterChange = (filters: Record<string, string[]>) => {
+    const selectedSet = new Set(filters[TAGS_GROUP_ID] ?? []);
+    onApply(tags.filter(tag => selectedSet.has(tag.id)).map(tag => ({ id: tag.id, key: tag.key })));
+  };
+
+  return (
+    <FilterModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Filter by Tags"
+      filterGroups={filterGroups}
+      currentFilters={currentFilters}
+      onFilterChange={handleFilterChange}
+      applyButtonText="Apply"
+      resetButtonText="Reset"
+      className="max-w-[600px]"
+    />
+  );
+}
+
+/**
+ * Mobile tags filter for the knowledge base: a FilterModal listing all KnowledgeBase tags.
+ * On Apply the selected tags replace the current selection and surface as chips in
+ * the search field. Tag loading suspends, so the content is gated behind
+ * Suspense (fallback null — the modal is hidden until tags resolve).
+ */
+export function KnowledgeBaseTagsFilterModal(props: KnowledgeBaseTagsFilterModalProps) {
+  return (
+    <Suspense fallback={null}>
+      <KnowledgeBaseTagsFilterModalContent {...props} />
+    </Suspense>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/hooks/use-tag-search-state.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/hooks/use-tag-search-state.ts
@@ -14,6 +14,8 @@ export interface TagSearchState {
   tagSearchOptions: TagSearchOption<string>[];
   addTag: (tag: SelectedKnowledgeBaseTag) => void;
   removeTag: (id: string) => void;
+  /** Replace the whole selected-tag set (search text is preserved). */
+  setTags: (tags: SelectedKnowledgeBaseTag[]) => void;
   clearAll: () => void;
 }
 
@@ -37,6 +39,10 @@ export function useTagSearchState(): TagSearchState {
     setSelectedTags(prev => prev.filter(t => t.id !== id));
   }, []);
 
+  const setTags = useCallback((tags: SelectedKnowledgeBaseTag[]) => {
+    setSelectedTags(tags);
+  }, []);
+
   const clearAll = useCallback(() => {
     setSearch('');
     setSelectedTags([]);
@@ -51,6 +57,7 @@ export function useTagSearchState(): TagSearchState {
     tagSearchOptions,
     addTag,
     removeTag,
+    setTags,
     clearAll,
   };
 }


### PR DESCRIPTION
mobile tags filter modal, hide inline tag row on mobile devices

## Description
Below md the inline KnowledgeBaseTagsRow is hidden and a filter button next to the search opens a FilterModal listing all KB tags as a single checkbox group (mirrors the /devices pattern). Applying replaces the selected tags, which surface as chips in the search field; tablet/desktop keep the inline row.

## Improvements
- new knowledge-base-tags-filter-modal.tsx (FilterModal + useKnowledgeBaseTags,
  Suspense-gated; pre-checks current tags, replace-on-apply)
- use-tag-search-state: add setTags() to replace the selection, preserving search
- knowledge-base-body: useMdUp gating, mobile filter button, modal wiring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive tag filtering: Knowledge-base tag filtering now adapts to different screen sizes. On mobile and tablet devices, tags are filtered through a dedicated dialog; on desktop, inline controls are displayed. All filtering and search capabilities work consistently across devices.
  * Improved tag updates: Applying tag selections via the dialog updates the tag set while preserving any existing tag-search text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->