### PR TITLE
Fix: widen NotificationNodeShape ticketId to accept null

### DIFF
--- a/openframe/services/openframe-frontend/src/graphql/notifications/notifications-helpers.ts
+++ b/openframe/services/openframe-frontend/src/graphql/notifications/notifications-helpers.ts
@@ -257,7 +257,7 @@ export interface NotificationNodeShape {
     readonly approvalRequestId?: string;
     readonly approvalType?: string;
     readonly dialogId?: string;
-    readonly ticketId?: string;
+    readonly ticketId?: string | null;
     readonly approvalTicketId?: string | null;
     readonly resolution?: string | null;
     readonly toolCalls?: ReadonlyArray<ApprovalToolCallShape>;


### PR DESCRIPTION
Relay emits context.ticketId as `string | null | undefined`, but the shape typed it as `string | undefined`, so mapNotificationNode failed type-check (TS2345) at both call sites. Widen ticketId to `string | null` to match sibling fields (approvalTicketId, resolution); the mapper already coerces null via `??`.
