### PR TITLE
fix(tactical-rmm): TACTICAL_READY_FILE points at non-existent subdir, breaking fresh backend init

### DIFF
--- a/manifests/integrated-tools/tactical-rmm/templates/celery/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/celery/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           exec:
             command:
             - cat
-            - /opt/tactical/tmp/tactical/ready
+            - /opt/tactical/tmp/tactical.ready
           initialDelaySeconds: 30
           periodSeconds: 10
 

--- a/manifests/integrated-tools/tactical-rmm/templates/celerybeat/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/celerybeat/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           exec:
             command:
             - cat
-            - /opt/tactical/tmp/tactical/ready
+            - /opt/tactical/tmp/tactical.ready
           initialDelaySeconds: 30
           periodSeconds: 10
 

--- a/manifests/integrated-tools/tactical-rmm/templates/configmap.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/configmap.yaml
@@ -42,6 +42,10 @@ data:
   WEBSOCKETS_BIND_HOST: "tactical-websockets"
   WEBSOCKET_PORT: "8383"
   PUBLIC_DIR: "/usr/share/nginx/html"
-  TACTICAL_READY_FILE: "/opt/tactical/tmp/tactical/ready"
+  # Must match the marker file the upstream image's entrypoint touches in
+  # set_ready_status(). The image's create_directories() only creates
+  # ${TACTICAL_DIR}/tmp (not a tmp/tactical/ subdir), so this is a file in
+  # tmp/, not a path with an extra directory component.
+  TACTICAL_READY_FILE: "/opt/tactical/tmp/tactical.ready"
   NGINX_HOST_IP: "tactical-nginx-0.tactical-nginx.integrated-tools.svc.cluster.local"
   NGINX_HOST_PORT: "8080"

--- a/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
           exec:
             command:
             - cat
-            - /opt/tactical/tmp/tactical/ready
+            - /opt/tactical/tmp/tactical.ready
           initialDelaySeconds: 30
           periodSeconds: 15
 

--- a/manifests/integrated-tools/tactical-rmm/templates/websockets/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/websockets/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           exec:
             command:
             - cat
-            - /opt/tactical/tmp/tactical/ready
+            - /opt/tactical/tmp/tactical.ready
           initialDelaySeconds: 30
           periodSeconds: 10
 


### PR DESCRIPTION
## Summary

`tactical-backend-0` ends every fresh-deploy init in `CrashLoopBackOff` at the very last step:

```
Creating dashboard user if it doesn't exist
Creating default organization and API key
Setting ready status
touch: cannot touch '/opt/tactical/tmp/tactical/ready': No such file or directory
```

The chart's `tactical-default` ConfigMap overrode `TACTICAL_READY_FILE` to a path under a `tmp/tactical/` subdirectory, but the upstream image's `docker/containers/tactical/entrypoint.sh` `create_directories()` only `mkdir -p`s `${TACTICAL_DIR}/tmp` — it never creates the extra `tactical/` directory, so `set_ready_status` always fails when it tries to `touch` the marker.

The image's own default for that variable is a single file in `tmp/`, not a directory + file:

```sh
: "${TACTICAL_READY_FILE:=${TACTICAL_DIR}/tmp/tactical.ready}"
```

This PR drops the extraneous subdirectory from the override and updates the livenessProbe paths in the celery, celerybeat, websockets, and nats StatefulSets so they keep matching the marker the entrypoint touches. No image change required.

## Verified on

A single-node k3d cluster running this chart at `ffdb16cac25bb0561a888e44ed5f99f10b6b4f7e`, image `ghcr.io/flamingo-stack/tacticalrmm/tactical:0.0.23`. With the fix in place (and the missing dir back-filled on the existing PVC as a one-time workaround), `tactical-backend-0` reaches `1/1 Running` and `set_ready_status` succeeds.

## Workaround for already-deployed clusters

The PVC is `whenDeleted: Retain`, so the directory only needs to exist once on the PVC. For an already-deployed cluster, you can `mkdir -p` the missing path directly and restart the pod (on k3d / local-path):

```sh
NODE=$(kubectl -n integrated-tools get pod tactical-backend-0 -o jsonpath='{.spec.nodeName}')
PVC_PATH=$(kubectl get pv $(kubectl -n integrated-tools get pvc tactical-backend -o jsonpath='{.spec.volumeName}') -o jsonpath='{.spec.hostPath.path}')
docker exec "$NODE" sh -c "mkdir -p $PVC_PATH/tmp/tactical && chown 1000:1000 $PVC_PATH/tmp/tactical"
kubectl -n integrated-tools delete pod tactical-backend-0
```

After that — and on every future deploy with this PR applied — the marker file lands in the right place on first run.

## Notes

Found while bringing up OpenFrame OSS on a fresh DigitalOcean droplet. Happy to iterate on this PR if you'd prefer the alternative (add `mkdir -p "${TACTICAL_DIR}/tmp/tactical"` in `flamingo-stack/tacticalrmm` `create_directories()` instead and keep the directory-style path here); chart-side felt like the smaller surface change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized readiness probe file path checks across all services to ensure consistent health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->