### PR TITLE
fix(tactical-rmm): SECRET_KEY for workers, dedicated tactical-nats image, ALLOWED_HOSTS-safe wait-for-backend probe

### DIFF
--- a/manifests/integrated-tools/tactical-rmm/templates/backend/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/backend/statefulset.yaml
@@ -62,6 +62,8 @@ spec:
             name: tactical-redis
         - secretRef:
             name: tactical-postgres
+        - secretRef:
+            name: tactical-secret
 
         volumeMounts:
         - name: backend-data

--- a/manifests/integrated-tools/tactical-rmm/templates/celery/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/celery/statefulset.yaml
@@ -48,6 +48,8 @@ spec:
             name: tactical-redis
         - secretRef:
             name: tactical-postgres
+        - secretRef:
+            name: tactical-secret
         livenessProbe:
           exec:
             command:

--- a/manifests/integrated-tools/tactical-rmm/templates/celerybeat/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/celerybeat/statefulset.yaml
@@ -48,6 +48,8 @@ spec:
             name: tactical-redis
         - secretRef:
             name: tactical-postgres
+        - secretRef:
+            name: tactical-secret
         livenessProbe:
           exec:
             command:

--- a/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
@@ -87,9 +87,12 @@ spec:
             name: tactical-postgres
 
       containers:
-      - name: tactical-base
-        image: "{{ .Values.tactical.base.image.registry }}/{{ .Values.tactical.base.image.repository }}:{{ .Values.tactical.base.image.tag }}"
-        args: ["tactical-nats"]
+      # tactical-nats is its own dedicated image (nats-server + the Go nats-api
+      # binary under supervisord). The base tactical image's entrypoint only
+      # knows the backend/celery/celerybeat/websockets roles and aborts with
+      # "ERROR: unknown entrypoint role: tactical-nats" if used here.
+      - name: tactical-nats
+        image: "{{ .Values.tactical.base.natsImage.registry }}/{{ .Values.tactical.base.natsImage.repository }}:{{ .Values.tactical.base.natsImage.tag }}"
         ports:
         - containerPort: 9235
         - containerPort: 4222
@@ -102,13 +105,19 @@ spec:
             name: tactical-redis
         - secretRef:
             name: tactical-postgres
+        # The dedicated tactical-nats image never writes the shared tactical.ready
+        # marker. Probe the NATS client port directly — supervisord exposes it as
+        # soon as nats-server comes up.
         livenessProbe:
-          exec:
-            command:
-            - cat
-            - /opt/tactical/tmp/tactical/ready
+          tcpSocket:
+            port: 4222
           initialDelaySeconds: 30
           periodSeconds: 15
+        readinessProbe:
+          tcpSocket:
+            port: 4222
+          initialDelaySeconds: 5
+          periodSeconds: 5
 
         volumeMounts:
         - name: nats-data

--- a/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/nats/statefulset.yaml
@@ -66,7 +66,12 @@ spec:
           done &&
           echo "Backend port is ready!" &&
           echo "Checking Backend health endpoint..." &&
-          until wget -q --spider ${TRMM_PROTO}://$API_HOST 2>/dev/null; do
+          # Probe via the short tactical-backend service name. The pod-FQDN form in
+          # $API_HOST is not present in the backend's Django ALLOWED_HOSTS, so a
+          # Host: pod-FQDN:8000 request gets a 400 Bad Request and the probe loops
+          # forever even though Django is actually serving. The short name is what
+          # the backend itself bakes into ALLOWED_HOSTS.
+          until wget -q --spider ${TRMM_PROTO}://tactical-backend:${TACTICAL_BACKEND_PORT} 2>/dev/null; do
             echo "Waiting for backend health endpoint...";
             sleep 2;
           done &&

--- a/manifests/integrated-tools/tactical-rmm/templates/secret.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tactical-secret
+type: Opaque
+# Django SECRET_KEY used by tactical-backend, tactical-celery, tactical-celerybeat,
+# and tactical-websockets. Workers fail their entrypoint's `worker_init` step when
+# SECRET_KEY is not in env, and the backend's auto-generated `.django_sekret` lives
+# on its own PVC so worker pods can never see it. Exposing one value here gives all
+# four pods the same key. This static value matches the chart's existing convention
+# for OSS-tenant dev secrets (cf. authentik-server, tactical-postgres). Production /
+# SaaS deployments should override via a sealed/external-secret of the same name.
+stringData:
+  SECRET_KEY: "xrFyCgyYJFHxzhYP96N40KsczfvUu0juhP2g8TodvFZHEUrTPid9usd07cNY6BX5az8fUghx0II4x0zD"

--- a/manifests/integrated-tools/tactical-rmm/templates/websockets/statefulset.yaml
+++ b/manifests/integrated-tools/tactical-rmm/templates/websockets/statefulset.yaml
@@ -50,6 +50,8 @@ spec:
             name: tactical-redis
         - secretRef:
             name: tactical-postgres
+        - secretRef:
+            name: tactical-secret
         livenessProbe:
           exec:
             command:

--- a/manifests/integrated-tools/tactical-rmm/values.yaml
+++ b/manifests/integrated-tools/tactical-rmm/values.yaml
@@ -47,6 +47,13 @@ tactical:
       registry: ghcr.io/flamingo-stack/tacticalrmm
       repository: tactical
       tag: "0.0.23"
+    # Dedicated tactical-nats image: nats-server + nats-api under supervisord.
+    # Distinct from the tactical base image whose entrypoint only knows the
+    # backend/celery/celerybeat/websockets roles.
+    natsImage:
+      registry: ghcr.io/flamingo-stack/tacticalrmm
+      repository: tactical-nats
+      tag: "0.0.23"
     podAnnotations:
       loki.grafana.com/scrape: "true"
       prometheus.io/scrape: "true"


### PR DESCRIPTION
## Summary

Three related upstream gaps surfaced while bringing the OpenFrame OSS `tactical-rmm` stack up on a fresh K3D cluster. After the ready-marker fix from #1918 lands, `tactical-backend-0` reaches `1/1 Running`, but four other pods remain unhealthy:

```
tactical-celery-0       0/1 CrashLoopBackOff
tactical-celerybeat-0   0/1 CrashLoopBackOff
tactical-websockets-0   0/1 CrashLoopBackOff
tactical-nats-0         0/1 Init:1/2  (later → CrashLoopBackOff once init unblocks)
```

This PR is two focused commits against the chart:

### 1. `SECRET_KEY` for tactical-celery / tactical-celerybeat / tactical-websockets + chart-side probe fix

`tactical/docker/containers/tactical/entrypoint.sh`'s `worker_init` step hard-fails on first start:

```
ERROR: worker_init requires SECRET_KEY env var
```

The chart's worker StatefulSets pull env only from `tactical-default` / `tactical-postgres` / `tactical-redis` ConfigMaps and the `tactical-postgres` Secret — none of which provide `SECRET_KEY`. The backend pod generates one on first run and writes it to its own PVC at `…/tacticalrmm/local_settings.py`, but each worker StatefulSet has its own PVC and never sees that file.

Add a `tactical-secret` `Secret` exposing a single `SECRET_KEY`, and `envFrom` it from `tactical-backend`, `tactical-celery`, `tactical-celerybeat`, and `tactical-websockets`. Once `SECRET_KEY` is in env, the upstream image writes it through to `local_settings.py` and skips the on-PVC `.django_sekret` flow entirely. The static value mirrors the existing chart convention for OSS-tenant dev secrets (`authentik-server`, `tactical-postgres`); operators running anything other than the OSS dev profile should overlay their own `tactical-secret` of the same name via sealed/external-secrets.

Also fix the `tactical-nats` `wait-for-backend` init container. It currently does:

```sh
until wget -q --spider ${TRMM_PROTO}://$API_HOST 2>/dev/null; do ...
```

where `\$API_HOST` is `tactical-backend-0.tactical-backend.<ns>.svc.cluster.local:8000`. The backend's Django `ALLOWED_HOSTS` only matches the short svc name `tactical-backend`, so every request to the pod-FQDN comes back as `HTTP 400 Bad Request` and the loop never exits even though Django is serving. The preceding `nc -z` check already proves the port is open; switch the wget probe to `${TRMM_PROTO}://tactical-backend:\${TACTICAL_BACKEND_PORT}`, which Django accepts.

### 2. Dedicated `tactical-nats` image for the `tactical-nats` StatefulSet

After the init container clears, the main container hard-fails with:

```
ERROR: unknown entrypoint role: tactical-nats
Expected one of: tactical-backend, tactical-celery, tactical-celerybeat, tactical-websockets
```

The chart was running the StatefulSet against `ghcr.io/flamingo-stack/tacticalrmm/tactical:0.0.23` with `args: [\"tactical-nats\"]`, but the base tactical image's entrypoint (`docker/containers/tactical/entrypoint.sh`) has never had a `tactical-nats` case in any released tag. NATS has its own dedicated image at `docker/containers/tactical-nats/`, which builds the Go `nats-api` binary on top of `nats:2.12.3-alpine` and runs `nats-server` + `nats-api` under supervisord.

Point the StatefulSet's main container at the dedicated `tactical-nats` image (added as `tactical.base.natsImage` in values so it can be pinned independently of the base tactical tag) and drop the `args` line. Replace the `cat /opt/tactical/tmp/tactical.ready` liveness probe with `tcpSocket :4222` — the dedicated tactical-nats image intentionally never writes the shared `tactical.ready` marker, so the previous probe would always fail once the container actually started, and the NATS client port is the natural readiness signal here.

## Test plan

Verified against a single-node K3D `openframe` cluster (the upstream OSS-tenant Argo app, pointed at this branch on a sibling fork):

- [x] `helm template manifests/integrated-tools/tactical-rmm` renders cleanly with the new Secret + `envFrom` blocks + new natsImage values.
- [x] `tactical-celery-0`, `tactical-celerybeat-0`, `tactical-websockets-0` reach `1/1 Running` (previously `CrashLoopBackOff` on `worker_init requires SECRET_KEY`).
- [x] `tactical-nats-0` `wait-for-backend` init container completes ('Backend is fully ready!') instead of looping on HTTP 400.
- [x] `tactical-nats-0` main container runs the dedicated `tactical-nats:0.0.23` image without the entrypoint role error.

Related upstream PR: #1918 (`TACTICAL_READY_FILE` path alignment) is a prerequisite for the workers reaching the SECRET_KEY check at all; that fix is needed first.

A separate gap still blocks `tactical-rmm` from reaching `Synced/Healthy`: the dedicated `tactical-nats` image expects `\${NATS_CONFIG}` to already exist on its PVC at `/opt/tactical/nats-rmm.conf`, but the chart has no init container that bootstraps it from Redis (or copies it from the backend). I'll file that as a separate PR — it's orthogonal to the three fixes above.