### PR TITLE
Empty State: add accent CTA buttons on empty states

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
@@ -62,19 +62,24 @@ export function CustomersTable({ status }: CustomersTableProps) {
     router.push('/customers/edit/new');
   }, [router]);
 
+  const showEmptyState = !isLoading && !debouncedSearch && customers.length === 0;
+
   const actions = useMemo(
     () => [
       {
         label: 'Add Customer',
-        icon: <PlusCircleIcon size={24} className="text-ods-text-secondary" />,
+        icon: (
+          <PlusCircleIcon
+            size={24}
+            className={showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}
+          />
+        ),
         onClick: handleAddCustomer,
-        variant: 'outline' as const,
+        variant: (showEmptyState ? 'accent' : 'outline') as 'accent' | 'outline',
       },
     ],
-    [handleAddCustomer],
+    [handleAddCustomer, showEmptyState],
   );
-
-  const showEmptyState = !isLoading && !debouncedSearch && customers.length === 0;
 
   return (
     <PageLayout

--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/knowledge-base-body.tsx
@@ -14,7 +14,7 @@ import {
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useMdUp, useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { notFound } from 'next/navigation';
-import { Suspense, useCallback, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import type { knowledgeBaseBodyArticlesRelay_query$key as ArticlesFragmentKey } from '@/__generated__/knowledgeBaseBodyArticlesRelay_query.graphql';
 import type { knowledgeBaseBodyArticlesRelayPaginationQuery as ArticlesPaginationQueryType } from '@/__generated__/knowledgeBaseBodyArticlesRelayPaginationQuery.graphql';
@@ -73,7 +73,11 @@ const ROOT_TITLE = 'Knowledge Base';
 // so this is a safe ceiling rather than a real page size.
 const FOLDERS_PAGE_SIZE = 100;
 
-function buildActions(parentId: string | null, onNewFolder: () => void): PageActionButton[] {
+function buildActions(
+  parentId: string | null,
+  onNewFolder: () => void,
+  emphasizeAddArticle = false,
+): PageActionButton[] {
   const newArticleHref = parentId ? `/knowledge-base/new?folderId=${parentId}` : '/knowledge-base/new';
   const actions: PageActionButton[] = [
     {
@@ -85,8 +89,13 @@ function buildActions(parentId: string | null, onNewFolder: () => void): PageAct
     {
       label: 'Add Article',
       href: newArticleHref,
-      icon: <PlusCircleIcon size={24} className="size-[var(--icon-size-icon-size)] text-ods-text-secondary" />,
-      variant: 'outline',
+      icon: (
+        <PlusCircleIcon
+          size={24}
+          className={`size-[var(--icon-size-icon-size)] ${emphasizeAddArticle ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}`}
+        />
+      ),
+      variant: emphasizeAddArticle ? 'accent' : 'outline',
     },
   ];
   if (parentId === null) {
@@ -209,9 +218,11 @@ interface ContentProps {
   search: string;
   tagIds: ReadonlyArray<string>;
   stickyHeaderOffset: string;
+  /** Reports whether the onboarding empty state is showing, so the shell can accent the CTA. */
+  onEmptyChange?: (isEmpty: boolean) => void;
 }
 
-function FoldersAndArticlesContent({ parentId, search, tagIds, stickyHeaderOffset }: ContentProps) {
+function FoldersAndArticlesContent({ parentId, search, tagIds, stickyHeaderOffset, onEmptyChange }: ContentProps) {
   const { toast } = useToast();
   const normalizedTagIds = tagIds.length > 0 ? [...tagIds] : null;
   const normalizedSearch = search || null;
@@ -286,7 +297,13 @@ function FoldersAndArticlesContent({ parentId, search, tagIds, stickyHeaderOffse
   // Genuinely empty (no items, no search, no tags): show the onboarding empty
   // state instead of the list. A search/tag filter with no results keeps the
   // inline "No knowledge base items found." message below.
-  if (items.length === 0 && !search && tagIds.length === 0) {
+  const isEmpty = items.length === 0 && !search && tagIds.length === 0;
+
+  useEffect(() => {
+    onEmptyChange?.(isEmpty);
+  }, [isEmpty, onEmptyChange]);
+
+  if (isEmpty) {
     return (
       <EmptyState
         icon={<BookBookmarkIcon />}
@@ -387,6 +404,8 @@ function KnowledgeBaseBodyShell({
     useTagSearchState();
   const [isNewFolderOpen, setIsNewFolderOpen] = useState(false);
   const [isTagsModalOpen, setIsTagsModalOpen] = useState(false);
+  // Reported by the content Suspense child; drives the accent CTA on the empty state.
+  const [isContentEmpty, setIsContentEmpty] = useState(false);
   // Below `md` (phones) the inline tags row is hidden and a filter button next
   // to the search opens the tags modal instead; tablet/desktop keep the row.
   const isMdUp = useMdUp();
@@ -419,7 +438,7 @@ function KnowledgeBaseBodyShell({
       backButton={backButton}
       actionsVariant="menu-primary"
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
-      actions={buildActions(parentId, () => setIsNewFolderOpen(true))}
+      actions={buildActions(parentId, () => setIsNewFolderOpen(true), !isSubtreeMode && isContentEmpty)}
       menuActions={menuActions}
     >
       <div style={containerStyle} className="flex flex-col">
@@ -467,6 +486,7 @@ function KnowledgeBaseBodyShell({
               search={debouncedSearch}
               tagIds={tagIds}
               stickyHeaderOffset={stickyHeaderOffset}
+              onEmptyChange={setIsContentEmpty}
             />
           )}
         </Suspense>

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/policies.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/policies.tsx
@@ -222,12 +222,17 @@ export function Policies() {
     () => [
       {
         label: 'Add Policy',
-        variant: 'outline' as const,
-        icon: <PlusCircleIcon size={24} className="text-ods-text-secondary" />,
+        variant: (showEmptyState ? 'accent' : 'outline') as 'accent' | 'outline',
+        icon: (
+          <PlusCircleIcon
+            size={24}
+            className={showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}
+          />
+        ),
         onClick: handleAddPolicy,
       },
     ],
-    [handleAddPolicy],
+    [handleAddPolicy, showEmptyState],
   );
 
   if (error) {

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/queries.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/queries.tsx
@@ -161,21 +161,26 @@ export function Queries() {
     router.push('/monitoring/query/edit/new');
   }, [router]);
 
+  // Show the empty state instead of the search bar + table only when there is
+  // genuinely no data: loading finished, no active search, and no queries.
+  const showEmptyState = !isLoading && !params.search.trim() && queries.length === 0;
+
   const actions = useMemo(
     () => [
       {
         label: 'Add Query',
-        variant: 'outline' as const,
-        icon: <PlusCircleIcon size={24} className="text-ods-text-secondary" />,
+        variant: (showEmptyState ? 'accent' : 'outline') as 'accent' | 'outline',
+        icon: (
+          <PlusCircleIcon
+            size={24}
+            className={showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}
+          />
+        ),
         onClick: handleAddQuery,
       },
     ],
-    [handleAddQuery],
+    [handleAddQuery, showEmptyState],
   );
-
-  // Show the empty state instead of the search bar + table only when there is
-  // genuinely no data: loading finished, no active search, and no queries.
-  const showEmptyState = !isLoading && !params.search.trim() && queries.length === 0;
 
   if (error) {
     return <PageError message={error} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script-schedules-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script-schedules-table.tsx
@@ -225,21 +225,26 @@ export function ScriptSchedulesTable() {
     router.push('/scripts/schedules/create');
   }, [router]);
 
+  // Show the empty state instead of the search bar + table only when there is
+  // genuinely no data: loading finished, no active search, and no schedules.
+  const showEmptyState = !isLoading && !params.search.trim() && schedules.length === 0;
+
   const actions = useMemo(
     () => [
       {
         label: 'Add Schedule',
-        variant: 'outline' as const,
-        icon: <PlusCircleIcon size={24} className="text-ods-text-secondary" />,
+        variant: (showEmptyState ? 'accent' : 'outline') as 'accent' | 'outline',
+        icon: (
+          <PlusCircleIcon
+            size={24}
+            className={showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}
+          />
+        ),
         onClick: handleAddSchedule,
       },
     ],
-    [handleAddSchedule],
+    [handleAddSchedule, showEmptyState],
   );
-
-  // Show the empty state instead of the search bar + table only when there is
-  // genuinely no data: loading finished, no active search, and no schedules.
-  const showEmptyState = !isLoading && !params.search.trim() && schedules.length === 0;
 
   if (error) {
     return <PageError message={error} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-table.tsx
@@ -396,16 +396,31 @@ export function ScriptsTable() {
     [params.shellType, params.category, params.supportedPlatforms],
   );
 
+  // Show the empty state instead of the search bar + table only when there is
+  // genuinely no data: loading finished, no active search/filters, and no scripts.
+  const showEmptyState =
+    !isLoading &&
+    !params.search.trim() &&
+    params.shellType.length === 0 &&
+    params.category.length === 0 &&
+    params.supportedPlatforms.length === 0 &&
+    scripts.length === 0;
+
   const actions = useMemo(
     () => [
       {
         label: 'Add Script',
-        variant: 'outline' as const,
-        icon: <PlusCircleIcon size={24} className="text-ods-text-secondary" />,
+        variant: (showEmptyState ? 'accent' : 'outline') as 'accent' | 'outline',
+        icon: (
+          <PlusCircleIcon
+            size={24}
+            className={showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}
+          />
+        ),
         onClick: handleNewScript,
       },
     ],
-    [handleNewScript],
+    [handleNewScript, showEmptyState],
   );
 
   const filterGroups = useMemo(
@@ -418,16 +433,6 @@ export function ScriptsTable() {
   );
 
   const hasMobileFilter = filterGroups.length > 0;
-
-  // Show the empty state instead of the search bar + table only when there is
-  // genuinely no data: loading finished, no active search/filters, and no scripts.
-  const showEmptyState =
-    !isLoading &&
-    !params.search.trim() &&
-    params.shellType.length === 0 &&
-    params.category.length === 0 &&
-    params.supportedPlatforms.length === 0 &&
-    scripts.length === 0;
 
   if (error) {
     return <PageError message={error} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-board-lifecycle.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-board-lifecycle.tsx
@@ -15,7 +15,7 @@ import { EmptyState } from '@/app/components/shared';
 import { appendImageHash } from '@/lib/image-url';
 import { useMoveTicketLifecycle, useMovingTicketIdsLifecycle } from '../hooks/use-move-ticket-lifecycle';
 import { useTicketStatusTransitionRules } from '../hooks/use-ticket-status-transition-rules';
-import { useTicketsActions } from '../hooks/use-tickets-actions';
+import { emphasizeNewTicketAction, useTicketsActions } from '../hooks/use-tickets-actions';
 import { useTicketStatusesQuery } from '../statuses/hooks/use-ticket-statuses-query';
 import { mapDefinitionToSystem, usesCanonicalStatusStyle } from '../statuses/types/ticket-statuses.types';
 import type { Dialog } from '../types/dialog.types';
@@ -98,7 +98,7 @@ export function TicketsBoardLifecycle({
     return ids;
   }, [notifications?.notifications]);
   const {
-    actions,
+    actions: baseActions,
     menuActions,
     dialog: ticketsActionsDialog,
     canArchiveResolved,
@@ -192,6 +192,8 @@ export function TicketsBoardLifecycle({
     (labelIds?.length ?? 0) === 0 &&
     boardColumns.length > 0 &&
     boardColumns.every(column => column.tickets.length === 0);
+
+  const actions = useMemo(() => emphasizeNewTicketAction(baseActions, showEmptyState), [baseActions, showEmptyState]);
 
   if (statusesError) {
     return <PageError message={statusesError.message} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-board.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-board.tsx
@@ -16,7 +16,7 @@ import { EmptyState } from '@/app/components/shared';
 import { appendImageHash } from '@/lib/image-url';
 import { useMoveTicket, useMovingTicketIds } from '../hooks/use-move-ticket';
 import { useTicketStatusTransitions } from '../hooks/use-ticket-status-transitions';
-import { useTicketsActions } from '../hooks/use-tickets-actions';
+import { emphasizeNewTicketAction, useTicketsActions } from '../hooks/use-tickets-actions';
 import { BOARD_STATUSES, useTicketsBoardQuery } from '../hooks/use-tickets-board-query';
 import type { BoardStatus } from '../services/ticket-service.types';
 import type { Dialog } from '../types/dialog.types';
@@ -102,7 +102,7 @@ export function TicketsBoard({
   }, [notifications?.notifications]);
   const { data: statusTransitions } = useTicketStatusTransitions();
   const {
-    actions,
+    actions: baseActions,
     menuActions,
     dialog: ticketsActionsDialog,
     canArchiveResolved,
@@ -165,6 +165,8 @@ export function TicketsBoard({
     (assigneeIds?.length ?? 0) === 0 &&
     (labelIds?.length ?? 0) === 0 &&
     BOARD_STATUSES.every(status => columns[status].tickets.length === 0);
+
+  const actions = useMemo(() => emphasizeNewTicketAction(baseActions, showEmptyState), [baseActions, showEmptyState]);
 
   if (error) {
     return <PageError message={error} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-table.tsx
@@ -16,7 +16,7 @@ import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import { EmptyState } from '@/app/components/shared';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import { featureFlags } from '@/lib/feature-flags';
-import { useTicketsActions } from '../hooks/use-tickets-actions';
+import { emphasizeNewTicketAction, useTicketsActions } from '../hooks/use-tickets-actions';
 import { useTicketsQuery } from '../hooks/use-tickets-query';
 import { useTicketStatusesQuery } from '../statuses/hooks/use-ticket-statuses-query';
 import type { Dialog } from '../types/dialog.types';
@@ -64,7 +64,11 @@ export function TicketsTable({
     labelIds,
   });
 
-  const { actions, menuActions, dialog: ticketsActionsDialog } = useTicketsActions({ isLoading, enabled: !isArchived });
+  const {
+    actions: baseActions,
+    menuActions,
+    dialog: ticketsActionsDialog,
+  } = useTicketsActions({ isLoading, enabled: !isArchived });
 
   // Tickets have no unread field of their own; the per-row count comes from notifications (a
   // separate entity) matched by ticket id, mirroring how the Mingo sidebar derives per-dialog
@@ -143,6 +147,8 @@ export function TicketsTable({
     (statusFilters?.length ?? 0) === 0 &&
     labelIds.length === 0 &&
     tickets.length === 0;
+
+  const actions = useMemo(() => emphasizeNewTicketAction(baseActions, showEmptyState), [baseActions, showEmptyState]);
 
   if (error) {
     return <PageError message={error} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/hooks/use-tickets-actions.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/hooks/use-tickets-actions.tsx
@@ -23,6 +23,24 @@ interface UseTicketsActionsParams {
   enabled?: boolean;
 }
 
+/**
+ * Promote the "New Ticket" action to the accent (yellow) variant while the page
+ * shows its empty state, so the primary CTA stands out. Re-colors the icon to the
+ * on-accent token to match. No-op when `emphasize` is false (keeps the outline).
+ */
+export function emphasizeNewTicketAction(actions: PageActionButton[], emphasize: boolean): PageActionButton[] {
+  if (!emphasize) return actions;
+  return actions.map(action =>
+    action.label === 'New Ticket'
+      ? {
+          ...action,
+          variant: 'accent',
+          icon: <span className="inline-flex [&_svg]:!text-ods-text-on-accent">{action.icon}</span>,
+        }
+      : action,
+  );
+}
+
 export function useTicketsActions({ isLoading, enabled = true }: UseTicketsActionsParams) {
   const router = useRouter();
   const archiveResolvedMutation = useArchiveResolvedMutation();

--- a/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
@@ -200,8 +200,12 @@ export function DevicesPanel({
           {
             label: 'Add Device',
             onClick: () => router.push(addDeviceHref),
-            icon: <PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />,
-            variant: 'outline',
+            icon: (
+              <PlusCircleIcon
+                className={`w-5 h-5 ${showEmptyState ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}`}
+              />
+            ),
+            variant: showEmptyState ? 'accent' : 'outline',
           },
         ]}
         contentClassName="flex flex-col"


### PR DESCRIPTION
## Description
Accent CTA buttons on empty states

When a page shows its empty state, its primary "create" button now uses the
accent (yellow) variant; it reverts to the default outline once data exists.

Pages and buttons:
- Devices - Add Device
- Customers (active + archived tabs) - Add Customer
- Scripts - Scripts tab: Add Script; Scripts Schedules tab: Add Schedule
- Monitoring - Policies tab: Add Policy; Queries tab: Add Query
- Tickets (table + both board views) - New Ticket
- Knowledge Base - Add Article

## Task
[Extended Empty State Placeholders for Main Sections](https://app.clickup.com/t/86ahu652e)
