### PR TITLE
hotfix(frontend): Mingo entity-context picker + Guide empty-state

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.279",
+        "@flamingo-stack/openframe-frontend-core": "0.0.284",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.279",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.279.tgz",
-      "integrity": "sha512-NRfr9giCU+lZUpH1YeHYY0iv5jQl2QYqmrjUDOqWEZ4A0SYhzKqUHyAhsa5Rh34kHwYoaPDuDrkKMc8WkfXZWg==",
+      "version": "0.0.284",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.284.tgz",
+      "integrity": "sha512-xguCwufGDrQHvMkX8dtssdnw8O7YW8NSJev0dYu08Iww/hSH61yfmMBKbteYgYj4QeHqRuqE3kxMIUuRUsvpyA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.279",
+    "@flamingo-stack/openframe-frontend-core": "0.0.284",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
@@ -21,6 +21,8 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { getFullImageUrl } from '@/lib/image-url';
+import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
+import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import { useCustomerArchive } from '../hooks/use-customer-archive';
 import { customerDetailsQueryKeys, useCustomerDetails } from '../hooks/use-customer-details';
 import { customersQueryKeys } from '../hooks/use-customers';
@@ -57,6 +59,10 @@ export function CustomerDetailsView({ id }: CustomerDetailsViewProps) {
   );
 
   const { organization, isLoading, error } = useCustomerDetails(id);
+  // Register this organization as the Mingo "open view".
+  useTrackOpenView(
+    organization ? { type: CONTEXT_ENTITY_KIND.ORGANIZATION, id, label: organization.name || id } : null,
+  );
   const { checkCanArchive, archiveOrganization, restoreOrganization } = useCustomerArchive();
   const queryClient = useQueryClient();
   const { toast } = useToast();

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
@@ -17,6 +17,8 @@ import {
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
+import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import { useDeviceActionsMenu } from '../hooks/use-device-actions-menu';
 import { useDeviceDetails } from '../hooks/use-device-details';
 import type { Device } from '../types/device.types';
@@ -123,6 +125,18 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
   }, [searchParams, isLoading, deviceId, router]);
 
   const normalizedDevice = deviceDetails;
+
+  // Register this device as the Mingo "open view" so the agent gets the user's
+  // working context on the next message (cleared on unmount → recent views).
+  useTrackOpenView(
+    normalizedDevice
+      ? {
+          type: CONTEXT_ENTITY_KIND.DEVICE,
+          id: deviceId,
+          label: normalizedDevice.displayName || normalizedDevice.hostname || deviceId,
+        }
+      : null,
+  );
 
   const handleBack = useSafeBack('/devices');
 

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/batch-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/batch-items.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * Batch context items — Tactical scripts and core users are fetched as ONE full
+ * batch (cached via TanStack suspense), then SEARCHED and PAGED entirely on the
+ * client. Their sources have no usable server-side search for this picker.
+ */
+
+import type { ChatContextItem } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { ContextItemsList } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { tacticalApiClient } from '@/lib/tactical-api-client';
+import { CONTEXT_ENTITY_KIND } from './context-types';
+import { type ContextItemsProps, matches, useClientPaging } from './items-shared';
+
+// ───────────────────────────── Script ───────────────────────────────────────
+
+async function fetchAllScripts(): Promise<ChatContextItem[]> {
+  const res = await tacticalApiClient.getScripts();
+  if (!res.ok) throw new Error(res.error || 'Failed to load scripts');
+  const list = (Array.isArray(res.data) ? res.data : []) as Array<{
+    id: number | string;
+    name?: string;
+    description?: string;
+  }>;
+  return list.map(s => ({
+    type: CONTEXT_ENTITY_KIND.SCRIPT,
+    id: String(s.id),
+    label: s.name || String(s.id),
+    description: s.description || undefined,
+  }));
+}
+
+export function ScriptItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const { data } = useSuspenseQuery({
+    queryKey: ['mingo-context', 'scripts-all'],
+    queryFn: fetchAllScripts,
+    staleTime: 5 * 60 * 1000,
+  });
+  const filtered = useMemo(
+    () => data.filter(s => matches(s.label, query) || matches(s.description, query)),
+    [data, query],
+  );
+  const { items, hasMore, loadMore } = useClientPaging(filtered);
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasMore}
+      onLoadMore={loadMore}
+      emptyLabel="No scripts"
+    />
+  );
+}
+
+// ───────────────────────────── User ─────────────────────────────────────────
+
+interface UserRow {
+  id: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  status?: string;
+}
+
+async function fetchAllUsers(): Promise<ChatContextItem[]> {
+  const acc: UserRow[] = [];
+  const size = 200;
+  for (let page = 0; page < 100; page++) {
+    const res = await apiClient.get<{ items?: UserRow[]; hasNext?: boolean }>(`/api/users?page=${page}&size=${size}`);
+    if (!res.ok) throw new Error(res.error || 'Failed to load users');
+    const items = res.data?.items ?? [];
+    acc.push(...items);
+    if (!res.data?.hasNext || items.length === 0) break;
+  }
+  return acc.map(u => {
+    const fullName = [u.firstName, u.lastName].filter(Boolean).join(' ');
+    return {
+      type: CONTEXT_ENTITY_KIND.USER,
+      id: u.id,
+      label: fullName || u.email || u.id,
+      description: fullName ? u.email : u.status,
+    };
+  });
+}
+
+export function UserItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const { data } = useSuspenseQuery({
+    queryKey: ['mingo-context', 'users-all'],
+    queryFn: fetchAllUsers,
+    staleTime: 5 * 60 * 1000,
+  });
+  const filtered = useMemo(
+    () => data.filter(u => matches(u.label, query) || matches(u.description, query)),
+    [data, query],
+  );
+  const { items, hasMore, loadMore } = useClientPaging(filtered);
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasMore}
+      onLoadMore={loadMore}
+      emptyLabel="No users"
+    />
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-sources.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-sources.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+/**
+ * Mingo entity-context types — the picker's first-level list (Figma 31:28708).
+ * `type` is the backend discriminator (also stamped onto each `ChatContextItem.
+ * type`); `icon` is the lead glyph. The DATA for each type is fetched by its
+ * per-type component (`relay-items` / `rest-items` / `batch-items`), dispatched
+ * by `renderMingoContextItems`.
+ */
+
+import type { ChatContextEntityType } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import {
+  BookBookmarkIcon,
+  BracketCurlyEllipsisVrIcon,
+  BracketCurlyIcon,
+  FolderShieldIcon,
+  IdCardIcon,
+  MonitorIcon,
+  TagIcon,
+  UserIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { CONTEXT_ENTITY_KIND } from './context-types';
+
+/**
+ * Entity types in picker display order.
+ *
+ * POLICY and QUERY are offered alongside the rest. ⚠️ The backend
+ * `ContextItemReference.type` enum (POST /chat/api/v1/messages) did not include
+ * them as of the last verified spec — they are exposed ahead of the backend
+ * landing the enum values (expected imminently). Until then, attaching a
+ * Policy/Query and sending may 400 the whole message; if the backend rollout
+ * slips, drop these two rows again.
+ */
+export const MINGO_CONTEXT_ENTITY_TYPES: ChatContextEntityType[] = [
+  { type: CONTEXT_ENTITY_KIND.DEVICE, label: 'Device', icon: <MonitorIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.SCRIPT, label: 'Script', icon: <BracketCurlyIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.TICKET, label: 'Ticket', icon: <TagIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.ORGANIZATION, label: 'Customer', icon: <IdCardIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.USER, label: 'User', icon: <UserIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.KB_ARTICLE, label: 'Knowledge Article', icon: <BookBookmarkIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.POLICY, label: 'Policy', icon: <FolderShieldIcon size={24} /> },
+  { type: CONTEXT_ENTITY_KIND.QUERY, label: 'Query', icon: <BracketCurlyEllipsisVrIcon size={24} /> },
+];

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Mingo entity-context types shared across the host's context layer (the
+ * picker config, the recent-views store, and the send payload).
+ *
+ * The backend message payload (POST /chat/api/v1/messages) carries context as
+ * `{ type, id }` pairs — see `ContextRef`. The picker/store keep a `label`
+ * alongside for display (chips + the dev window); the label is stripped when
+ * building the wire payload.
+ *
+ * `CONTEXT_ENTITY_KIND` originally mirrored the `ContextItemReference.type`
+ * enum in the chat service's OpenAPI contract (`GET /chat/v3/api-docs`) —
+ * DEVICE / SCRIPT / TICKET / ORGANIZATION / USER / KB_ARTICLE. POLICY and QUERY
+ * were added later on product request (Figma 31:28708 lists them). ⚠️ As of the
+ * last verified spec the backend enum did NOT include POLICY/QUERY, so sending
+ * a message whose `contextItems[].type` is POLICY/QUERY may be rejected by
+ * `POST /chat/api/v1/messages` until the backend enum is extended. They are
+ * searchable/selectable in the picker regardless.
+ *
+ * SINGLE SOURCE OF TRUTH — to add a kind: add one entry here, then wire its
+ * label/icon in `MINGO_CONTEXT_ENTITY_TYPES` and its fetcher in `FETCHERS`
+ * (both in `context-sources.tsx`). The TS `Record<ContextEntityKind, …>` on
+ * `FETCHERS` makes a missing fetcher a compile error.
+ */
+
+export const CONTEXT_ENTITY_KIND = {
+  DEVICE: 'DEVICE',
+  SCRIPT: 'SCRIPT',
+  TICKET: 'TICKET',
+  ORGANIZATION: 'ORGANIZATION',
+  USER: 'USER',
+  KB_ARTICLE: 'KB_ARTICLE',
+  POLICY: 'POLICY',
+  QUERY: 'QUERY',
+} as const;
+
+export type ContextEntityKind = (typeof CONTEXT_ENTITY_KIND)[keyof typeof CONTEXT_ENTITY_KIND];
+
+/** All kinds as a runtime list, in declaration order. */
+export const CONTEXT_ENTITY_KINDS = Object.values(CONTEXT_ENTITY_KIND) as ContextEntityKind[];
+
+/** Minimal wire shape for `contextItems` / `currentView` / `recentViews`. */
+export interface ContextRef {
+  type: ContextEntityKind;
+  id: string;
+}
+
+/** A context ref enriched with display metadata (label + optional secondary
+ *  line). Persisted in the recent-views store and rendered in the dev window. */
+export interface ContextRefWithLabel extends ContextRef {
+  label: string;
+  description?: string;
+}
+
+/** Limits from the spec. */
+export const CONTEXT_ITEMS_MAX = 10;
+export const RECENT_VIEWS_MAX = 5;

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/items-shared.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/items-shared.ts
@@ -1,0 +1,49 @@
+'use client';
+
+/**
+ * Shared bits for the per-type context-item components (the host data layer
+ * behind the lib's `ChatContextPickerConfig.renderItems`). Each component
+ * fetches with its own hook (react-relay / TanStack) and renders the lib's
+ * `<ContextItemsList>`.
+ */
+
+import type { ChatContextItem } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { useState } from 'react';
+
+/** Page size for every source (matches the picker's skeleton count). */
+export const MINGO_CONTEXT_PAGE_SIZE = 10;
+
+/** Props every per-type items component receives from `renderItems`. */
+export interface ContextItemsProps {
+  /** Debounced search text from the picker. */
+  query: string;
+  selectedKeys: Set<string>;
+  onToggle: (item: ChatContextItem) => void;
+  atLimit: boolean;
+}
+
+/** Case-insensitive substring match for the client-filtered (batch) sources. */
+export function matches(haystack: string | undefined, needle: string): boolean {
+  if (!needle) return true;
+  return (haystack ?? '').toLowerCase().includes(needle.toLowerCase());
+}
+
+/**
+ * Client-side incremental paging over a fully-loaded list (the batch sources:
+ * scripts / users / policies). Reveals `pageSize` more on each `loadMore`, and
+ * resets when the source list changes (new search) — via the
+ * adjust-state-during-render pattern so there's no flash.
+ */
+export function useClientPaging<T>(all: T[], pageSize: number = MINGO_CONTEXT_PAGE_SIZE) {
+  const [count, setCount] = useState(pageSize);
+  const [prevAll, setPrevAll] = useState(all);
+  if (all !== prevAll) {
+    setPrevAll(all);
+    setCount(pageSize);
+  }
+  return {
+    items: all.slice(0, count),
+    hasMore: count < all.length,
+    loadMore: () => setCount(c => Math.min(c + pageSize, all.length)),
+  };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mingo-context-debug-window.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mingo-context-debug-window.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+/**
+ * Mingo context dev window — a floating, draggable debug panel that surfaces
+ * the live `openView` and `recentViews` from the navigation-context store (the
+ * values carried on every Mingo message). Lets you eyeball what the agent will
+ * receive and clear the recents while testing.
+ *
+ * Visibility is opt-in via a console command — hidden by default in every env:
+ *
+ *   mingoDebug()       // toggle on/off
+ *   mingoDebug(true)   // force on
+ *   mingoDebug(false)  // force off
+ *
+ * The choice persists in `localStorage 'mingo-context-debug'` ('1' on / '0'
+ * off). Hidden by default in every env until explicitly turned on. The panel
+ * position is remembered in `localStorage 'mingo-context-debug-pos'`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMingoContextStore } from '../stores/mingo-context-store';
+import type { ContextRefWithLabel } from './context-types';
+
+const DEBUG_FLAG_KEY = 'mingo-context-debug';
+const DEBUG_POS_KEY = 'mingo-context-debug-pos';
+// Pointer travel (px) past which a header press counts as a drag, not a click.
+const DRAG_THRESHOLD = 4;
+
+declare global {
+  interface Window {
+    mingoDebug?: (next?: boolean) => boolean;
+  }
+}
+
+function resolveEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  // Hidden by default in every env — only the explicit console opt-in shows it.
+  return window.localStorage.getItem(DEBUG_FLAG_KEY) === '1';
+}
+
+function useDebugEnabled(): boolean {
+  // Resolve on the client only (localStorage + env), after mount, to avoid an
+  // SSR/CSR mismatch.
+  const [enabled, setEnabled] = useState(false);
+  useEffect(() => {
+    setEnabled(resolveEnabled());
+
+    // Expose a console command so the panel can be summoned in any env.
+    const mingoDebug = (next?: boolean): boolean => {
+      const value = typeof next === 'boolean' ? next : !resolveEnabled();
+      window.localStorage.setItem(DEBUG_FLAG_KEY, value ? '1' : '0');
+      setEnabled(value);
+      console.info(`[mingo] context debug panel ${value ? 'ON' : 'OFF'}`);
+      return value;
+    };
+    window.mingoDebug = mingoDebug;
+
+    // Keep multiple tabs / instances in sync when the flag changes.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === DEBUG_FLAG_KEY) setEnabled(resolveEnabled());
+    };
+    window.addEventListener('storage', onStorage);
+
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      if (window.mingoDebug === mingoDebug) window.mingoDebug = undefined;
+    };
+  }, []);
+  return enabled;
+}
+
+type Position = { x: number; y: number };
+
+function readStoredPosition(): Position | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(DEBUG_POS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Position>;
+    if (typeof parsed?.x === 'number' && typeof parsed?.y === 'number') {
+      return { x: parsed.x, y: parsed.y };
+    }
+  } catch {
+    // ignore malformed value
+  }
+  return null;
+}
+
+export function MingoContextDebugWindow() {
+  const enabled = useDebugEnabled();
+  const [collapsed, setCollapsed] = useState(true);
+  const [position, setPosition] = useState<Position | null>(null);
+  const openView = useMingoContextStore(s => s.openView);
+  const recentViews = useMingoContextStore(s => s.recentViews);
+  const clearOpenView = useMingoContextStore(s => s.clearOpenView);
+  const clearRecentViews = useMingoContextStore(s => s.clearRecentViews);
+
+  // Restore the saved position once on mount (client-only).
+  useEffect(() => {
+    setPosition(readStoredPosition());
+  }, []);
+
+  // Drag state lives in a ref so pointer-move handlers don't re-render per frame.
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+    moved: boolean;
+  } | null>(null);
+  const draggedRef = useRef(false);
+
+  const onHeaderPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.parentElement?.getBoundingClientRect();
+    if (!rect) return;
+    draggedRef.current = false;
+    dragRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top,
+      moved: false,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }, []);
+
+  const onHeaderPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    // Ignore jitter until the pointer travels past the threshold, so a normal
+    // click still toggles the panel instead of nudging it.
+    if (!drag.moved && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < DRAG_THRESHOLD) {
+      return;
+    }
+    drag.moved = true;
+    draggedRef.current = true;
+    // Clamp inside the viewport so the panel can't be dragged off-screen.
+    const maxX = window.innerWidth - 120;
+    const maxY = window.innerHeight - 40;
+    setPosition({
+      x: Math.max(0, Math.min(e.clientX - drag.offsetX, maxX)),
+      y: Math.max(0, Math.min(e.clientY - drag.offsetY, maxY)),
+    });
+  }, []);
+
+  const onHeaderPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    dragRef.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    if (drag.moved) {
+      setPosition(prev => {
+        if (prev) window.localStorage.setItem(DEBUG_POS_KEY, JSON.stringify(prev));
+        return prev;
+      });
+    }
+  }, []);
+
+  const onHeaderClick = useCallback(() => {
+    // Suppress the collapse toggle if this press was actually a drag.
+    if (draggedRef.current) {
+      draggedRef.current = false;
+      return;
+    }
+    setCollapsed(v => !v);
+  }, []);
+
+  if (!enabled) return null;
+
+  const positioned = position !== null;
+
+  return (
+    <div
+      className="fixed z-[9999] w-[320px] select-none rounded-md border border-ods-border bg-ods-card text-ods-text-primary shadow-lg"
+      style={positioned ? { left: position.x, top: position.y } : { left: 12, bottom: 12 }}
+    >
+      <div
+        onPointerDown={onHeaderPointerDown}
+        onPointerMove={onHeaderPointerMove}
+        onPointerUp={onHeaderPointerUp}
+        onClick={onHeaderClick}
+        className="flex w-full cursor-grab items-center justify-between gap-2 px-3 py-2 text-left text-h5 font-medium outline-none active:cursor-grabbing"
+      >
+        <span>Mingo context · debug</span>
+        <span className="text-ods-text-secondary">{collapsed ? '▸' : '▾'}</span>
+      </div>
+
+      {!collapsed && (
+        <div className="max-h-[50vh] overflow-y-auto border-t border-ods-border px-3 py-2 text-h5">
+          <Section title="openView">
+            {openView ? <RefRow refItem={openView} /> : <p className="text-ods-text-muted">— none —</p>}
+          </Section>
+
+          <Section
+            title={`recentViews (${recentViews.length}/5)`}
+            action={recentViews.length > 0 ? { label: 'Clear', onClick: clearRecentViews } : undefined}
+          >
+            {recentViews.length === 0 ? (
+              <p className="text-ods-text-muted">— empty —</p>
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {recentViews.map(r => (
+                  <li key={`${r.type}:${r.id}`}>
+                    <RefRow refItem={r} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {openView && (
+            <button
+              type="button"
+              // Call with no arg — `clearOpenView(ref?)` treats a passed ref as
+              // a guard key; handing it the click event would no-op the button.
+              onClick={() => clearOpenView()}
+              className="mt-2 rounded border border-ods-border px-2 py-1 text-h5 text-ods-text-secondary hover:text-ods-text-primary"
+            >
+              Roll openView → recent
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: { label: string; onClick: () => void };
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 last:mb-0">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="font-mono text-ods-text-secondary">{title}</span>
+        {action && (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="text-ods-text-muted hover:text-ods-attention-red-error"
+          >
+            {action.label}
+          </button>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function RefRow({ refItem }: { refItem: ContextRefWithLabel }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="shrink-0 rounded bg-ods-bg px-1 font-mono text-xs uppercase text-ods-text-secondary">
+        {refItem.type}
+      </span>
+      <span className="truncate" title={`${refItem.label} (${refItem.id})`}>
+        {refItem.label}
+      </span>
+      <span className="ml-auto shrink-0 font-mono text-xs text-ods-text-muted">{refItem.id}</span>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/relay-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/relay-items.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+/**
+ * Relay-backed context items for the GraphQL sources on OUR endpoint
+ * (`/api/graphql`): Device, Organization, Knowledge Article.
+ *
+ * Idiomatic Relay cursor pagination: a `@refetchable` fragment with
+ * `@connection` + `useLazyLoadQuery` (suspends on initial load → the picker's
+ * Suspense skeleton) + `usePaginationFragment` (`loadNext` on scroll). No manual
+ * cursors / `hasMore` — Relay manages the connection in its store.
+ */
+
+import { ContextItemsList } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { useMemo } from 'react';
+import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
+import type { relayItemsDevices_query$key } from '@/__generated__/relayItemsDevices_query.graphql';
+import type { relayItemsDevicesListQuery } from '@/__generated__/relayItemsDevicesListQuery.graphql';
+import type { relayItemsKb_query$key } from '@/__generated__/relayItemsKb_query.graphql';
+import type { relayItemsKbListQuery } from '@/__generated__/relayItemsKbListQuery.graphql';
+import type { relayItemsOrgs_query$key } from '@/__generated__/relayItemsOrgs_query.graphql';
+import type { relayItemsOrgsListQuery } from '@/__generated__/relayItemsOrgsListQuery.graphql';
+import { CONTEXT_ENTITY_KIND } from './context-types';
+import { type ContextItemsProps, MINGO_CONTEXT_PAGE_SIZE } from './items-shared';
+
+// ───────────────────────────── Device ───────────────────────────────────────
+
+const DEVICES_FRAGMENT = graphql`
+  fragment relayItemsDevices_query on Query
+  @refetchable(queryName: "relayItemsDevicesPaginationQuery")
+  @argumentDefinitions(search: { type: "String" }, first: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+    devices(search: $search, first: $first, after: $after) @connection(key: "relayItemsDevices_devices") {
+      edges { node { id hostname displayName status } }
+    }
+  }
+`;
+
+const DEVICES_LIST_QUERY = graphql`
+  query relayItemsDevicesListQuery($search: String, $first: Int) {
+    ...relayItemsDevices_query @arguments(search: $search, first: $first)
+  }
+`;
+
+export function DeviceItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const root = useLazyLoadQuery<relayItemsDevicesListQuery>(DEVICES_LIST_QUERY, {
+    search: query || null,
+    first: MINGO_CONTEXT_PAGE_SIZE,
+  });
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment(
+    DEVICES_FRAGMENT,
+    root as relayItemsDevices_query$key,
+  );
+  const items = useMemo(
+    () =>
+      (data.devices?.edges ?? []).flatMap(e =>
+        e?.node
+          ? [
+              {
+                type: CONTEXT_ENTITY_KIND.DEVICE,
+                id: e.node.id,
+                label: e.node.displayName || e.node.hostname || e.node.id,
+                description: e.node.status ?? undefined,
+              },
+            ]
+          : [],
+      ),
+    [data],
+  );
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasNext}
+      onLoadMore={() => loadNext(MINGO_CONTEXT_PAGE_SIZE)}
+      loadingMore={isLoadingNext}
+      emptyLabel="No devices"
+    />
+  );
+}
+
+// ─────────────────────────── Organization ───────────────────────────────────
+
+const ORGS_FRAGMENT = graphql`
+  fragment relayItemsOrgs_query on Query
+  @refetchable(queryName: "relayItemsOrgsPaginationQuery")
+  @argumentDefinitions(search: { type: "String" }, first: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+    organizations(search: $search, first: $first, after: $after) @connection(key: "relayItemsOrgs_organizations") {
+      edges { node { id name category } }
+    }
+  }
+`;
+
+const ORGS_LIST_QUERY = graphql`
+  query relayItemsOrgsListQuery($search: String, $first: Int) {
+    ...relayItemsOrgs_query @arguments(search: $search, first: $first)
+  }
+`;
+
+export function OrganizationItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const root = useLazyLoadQuery<relayItemsOrgsListQuery>(ORGS_LIST_QUERY, {
+    search: query || null,
+    first: MINGO_CONTEXT_PAGE_SIZE,
+  });
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment(
+    ORGS_FRAGMENT,
+    root as relayItemsOrgs_query$key,
+  );
+  const items = useMemo(
+    () =>
+      (data.organizations?.edges ?? []).flatMap(e =>
+        e?.node
+          ? [
+              {
+                type: CONTEXT_ENTITY_KIND.ORGANIZATION,
+                id: e.node.id,
+                label: e.node.name || e.node.id,
+                description: e.node.category ?? undefined,
+              },
+            ]
+          : [],
+      ),
+    [data],
+  );
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasNext}
+      onLoadMore={() => loadNext(MINGO_CONTEXT_PAGE_SIZE)}
+      loadingMore={isLoadingNext}
+      emptyLabel="No customers"
+    />
+  );
+}
+
+// ─────────────────────────── Knowledge Article ──────────────────────────────
+
+const KB_FRAGMENT = graphql`
+  fragment relayItemsKb_query on Query
+  @refetchable(queryName: "relayItemsKbPaginationQuery")
+  @argumentDefinitions(search: { type: "String" }, first: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+    knowledgeBaseItems(filter: { type: ARTICLE }, search: $search, first: $first, after: $after)
+      @connection(key: "relayItemsKb_knowledgeBaseItems") {
+      edges { node { id name type } }
+    }
+  }
+`;
+
+const KB_LIST_QUERY = graphql`
+  query relayItemsKbListQuery($search: String, $first: Int) {
+    ...relayItemsKb_query @arguments(search: $search, first: $first)
+  }
+`;
+
+export function KnowledgeBaseItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const root = useLazyLoadQuery<relayItemsKbListQuery>(KB_LIST_QUERY, {
+    search: query || null,
+    first: MINGO_CONTEXT_PAGE_SIZE,
+  });
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment(KB_FRAGMENT, root as relayItemsKb_query$key);
+  const items = useMemo(
+    () =>
+      (data.knowledgeBaseItems?.edges ?? []).flatMap(e =>
+        e?.node
+          ? [
+              {
+                type: CONTEXT_ENTITY_KIND.KB_ARTICLE,
+                id: e.node.id,
+                label: e.node.name || e.node.id,
+                description: e.node.type ?? undefined,
+              },
+            ]
+          : [],
+      ),
+    [data],
+  );
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasNext}
+      onLoadMore={() => loadNext(MINGO_CONTEXT_PAGE_SIZE)}
+      loadingMore={isLoadingNext}
+      emptyLabel="No knowledge articles"
+    />
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/render-context-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/render-context-items.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+/**
+ * Dispatcher wired into `ChatContextPickerConfig.renderItems`. Maps the active
+ * entity type to its per-type items component (which owns data via its own
+ * hooks). The lib calls this INSIDE its `<Suspense>` + error boundary, so the
+ * returned component may suspend on initial load.
+ *
+ * Must return a JSX ELEMENT (not call the component as a function) so the
+ * component's hooks run correctly; `key={type}` remounts on type switch so each
+ * type's hook state is isolated.
+ */
+
+import type { ContextItemsRenderArgs } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import type { ReactNode } from 'react';
+import { ScriptItems, UserItems } from './batch-items';
+import { CONTEXT_ENTITY_KIND } from './context-types';
+import type { ContextItemsProps } from './items-shared';
+import { DeviceItems, KnowledgeBaseItems, OrganizationItems } from './relay-items';
+import { PolicyItems, QueryItems, TicketItems } from './rest-items';
+
+const COMPONENTS: Record<string, (p: ContextItemsProps) => ReactNode> = {
+  [CONTEXT_ENTITY_KIND.DEVICE]: DeviceItems,
+  [CONTEXT_ENTITY_KIND.ORGANIZATION]: OrganizationItems,
+  [CONTEXT_ENTITY_KIND.KB_ARTICLE]: KnowledgeBaseItems,
+  [CONTEXT_ENTITY_KIND.TICKET]: TicketItems,
+  [CONTEXT_ENTITY_KIND.POLICY]: PolicyItems,
+  [CONTEXT_ENTITY_KIND.QUERY]: QueryItems,
+  [CONTEXT_ENTITY_KIND.SCRIPT]: ScriptItems,
+  [CONTEXT_ENTITY_KIND.USER]: UserItems,
+};
+
+export function renderMingoContextItems({
+  type,
+  query,
+  selectedKeys,
+  onToggle,
+  atLimit,
+}: ContextItemsRenderArgs): ReactNode {
+  const Component = COMPONENTS[type];
+  if (!Component) return null;
+  return <Component key={type} query={query} selectedKeys={selectedKeys} onToggle={onToggle} atLimit={atLimit} />;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/rest-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/rest-items.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * REST / ai-agent-GraphQL context items via TanStack Query suspense hooks:
+ *   • Ticket — `/chat/graphql` (ai-agent), cursor pagination.
+ *   • Policy — Fleet REST, server-side search, full list → client paging.
+ *   • Query  — Fleet REST, server-side search + `page`/`per_page` paging.
+ *
+ * Suspense hooks suspend on initial load (→ the picker's skeleton) and throw on
+ * error (→ the picker's error boundary).
+ */
+
+import type { ChatContextItem } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { ContextItemsList } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { fleetApiClient } from '@/lib/fleet-api-client';
+import { CONTEXT_ENTITY_KIND } from './context-types';
+import { type ContextItemsProps, MINGO_CONTEXT_PAGE_SIZE, useClientPaging } from './items-shared';
+
+// ───────────────────────────── Ticket ───────────────────────────────────────
+
+const TICKETS_QUERY = `
+  query MingoContextTickets($search: String, $pagination: CursorPaginationInput) {
+    tickets(search: $search, pagination: $pagination) {
+      edges { node { id ticketNumber title status } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+interface GraphQlEnvelope<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+interface TicketsData {
+  tickets?: {
+    edges?: Array<{ node: { id: string; ticketNumber?: number; title?: string; status?: string } }>;
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  };
+}
+
+async function fetchTicketsPage(
+  query: string,
+  cursor: string | null,
+): Promise<{ items: ChatContextItem[]; nextCursor: string | null }> {
+  const res = await apiClient.post<GraphQlEnvelope<TicketsData>>('/chat/graphql', {
+    query: TICKETS_QUERY,
+    variables: {
+      search: query || undefined,
+      pagination: { limit: MINGO_CONTEXT_PAGE_SIZE, ...(cursor ? { cursor } : {}) },
+    },
+  });
+  if (!res.ok) throw new Error(res.error || 'Failed to load tickets');
+  if (res.data?.errors?.length) throw new Error(res.data.errors[0].message);
+  const conn = res.data?.data?.tickets;
+  const items = (conn?.edges ?? []).map(e => ({
+    type: CONTEXT_ENTITY_KIND.TICKET,
+    id: e.node.id,
+    label: e.node.title || (e.node.ticketNumber != null ? `#${e.node.ticketNumber}` : e.node.id),
+    description:
+      [e.node.ticketNumber != null ? `#${e.node.ticketNumber}` : null, e.node.status].filter(Boolean).join(' · ') ||
+      undefined,
+  }));
+  return { items, nextCursor: conn?.pageInfo?.hasNextPage ? (conn.pageInfo.endCursor ?? null) : null };
+}
+
+export function TicketItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const q = useSuspenseInfiniteQuery({
+    queryKey: ['mingo-context', 'tickets', query],
+    queryFn: ({ pageParam }) => fetchTicketsPage(query, pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: last => last.nextCursor,
+    staleTime: 30 * 1000,
+  });
+  const items = useMemo(() => q.data.pages.flatMap(p => p.items), [q.data]);
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={q.hasNextPage}
+      onLoadMore={() => q.fetchNextPage()}
+      loadingMore={q.isFetchingNextPage}
+      emptyLabel="No tickets"
+    />
+  );
+}
+
+// ───────────────────────────── Policy ───────────────────────────────────────
+
+async function fetchPolicies(query: string): Promise<ChatContextItem[]> {
+  const res = await fleetApiClient.getPolicies(query ? { query } : undefined);
+  if (!res.ok) throw new Error(res.error || 'Failed to load policies');
+  return (res.data?.policies ?? []).map(pol => ({
+    type: CONTEXT_ENTITY_KIND.POLICY,
+    id: String(pol.id),
+    label: pol.name || String(pol.id),
+    description: pol.description || undefined,
+  }));
+}
+
+export function PolicyItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const { data } = useSuspenseQuery({
+    queryKey: ['mingo-context', 'policies', query],
+    queryFn: () => fetchPolicies(query),
+    staleTime: 30 * 1000,
+  });
+  const { items, hasMore, loadMore } = useClientPaging(data);
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={hasMore}
+      onLoadMore={loadMore}
+      emptyLabel="No policies"
+    />
+  );
+}
+
+// ───────────────────────────── Query ────────────────────────────────────────
+
+async function fetchQueriesPage(query: string, page: number): Promise<{ items: ChatContextItem[]; hasMore: boolean }> {
+  const res = await fleetApiClient.getQueries({ ...(query ? { query } : {}), page, per_page: MINGO_CONTEXT_PAGE_SIZE });
+  if (!res.ok) throw new Error(res.error || 'Failed to load queries');
+  const items = (res.data?.queries ?? []).map(q => ({
+    type: CONTEXT_ENTITY_KIND.QUERY,
+    id: String(q.id),
+    label: q.name || String(q.id),
+    description: q.description || undefined,
+  }));
+  return { items, hasMore: items.length === MINGO_CONTEXT_PAGE_SIZE };
+}
+
+export function QueryItems({ query, selectedKeys, onToggle, atLimit }: ContextItemsProps) {
+  const q = useSuspenseInfiniteQuery({
+    queryKey: ['mingo-context', 'queries', query],
+    queryFn: ({ pageParam }) => fetchQueriesPage(query, pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (last, all) => (last.hasMore ? all.length : undefined),
+    staleTime: 30 * 1000,
+  });
+  const items = useMemo(() => q.data.pages.flatMap(p => p.items), [q.data]);
+  return (
+    <ContextItemsList
+      items={items}
+      selectedKeys={selectedKeys}
+      onToggle={onToggle}
+      atLimit={atLimit}
+      hasMore={q.hasNextPage}
+      onLoadMore={() => q.fetchNextPage()}
+      loadingMore={q.isFetchingNextPage}
+      emptyLabel="No queries"
+    />
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/use-track-open-view.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/use-track-open-view.ts
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * `useTrackOpenView` — call from an entity detail page to register it as the
+ * Mingo "open view". Sets `openView` on mount / id-change and clears it on
+ * unmount (rolling it into `recentViews`). The cleared/replaced view feeds the
+ * `openView` + `recentViews` carried on every Mingo message.
+ *
+ * Pass `null`/`undefined` (e.g. while the entity is still loading) to skip
+ * tracking until the data resolves.
+ *
+ * @example
+ *   useTrackOpenView(device ? { type: 'DEVICE', id: device.id, label: device.hostname } : null);
+ */
+
+import { useEffect } from 'react';
+import { useMingoContextStore } from '../stores/mingo-context-store';
+import type { ContextEntityKind } from './context-types';
+
+export interface TrackOpenViewInput {
+  type: ContextEntityKind;
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export function useTrackOpenView(ref: TrackOpenViewInput | null | undefined): void {
+  const setOpenView = useMingoContextStore(s => s.setOpenView);
+  const clearOpenView = useMingoContextStore(s => s.clearOpenView);
+
+  // Depend on the primitive fields (not the object identity) so a fresh ref
+  // object each render doesn't re-fire. Label/description changes update in
+  // place via `setOpenView`'s same-entity refresh branch.
+  const type = ref?.type;
+  const id = ref?.id;
+  const label = ref?.label;
+  const description = ref?.description;
+
+  useEffect(() => {
+    if (!type || !id) return;
+    setOpenView({ type, id, label: label ?? id, description });
+    // Clear only if THIS entity is still the open view — a newer detail page
+    // mounting during a route transition may already have set its own.
+    return () => clearOpenView({ type, id });
+  }, [type, id, label, description, setOpenView, clearOpenView]);
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-chat.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-chat.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { AuthorType, type MessageSegment } from '@flamingo-stack/openframe-frontend-core';
+import type { ChatContextItem } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef } from 'react';
@@ -15,11 +16,22 @@ import {
 import { useMingoMessagesStore } from '../stores/mingo-messages-store';
 import type { CoreMessage } from '../types/message.types';
 
+/** Context attached to an outgoing message: the picker selection plus the
+ *  current navigation context (resolved by the caller from the context store).
+ *  `openView`/`recentViews` carry the minimal `{ type, id }` wire shape. */
+export interface MingoSendContext {
+  contextItems?: ChatContextItem[];
+  openView?: { type: string; id: string } | null;
+  recentViews?: Array<{ type: string; id: string }>;
+}
+
 interface ProcessedMessage {
   id: string;
   content: string | MessageSegment[];
   role: 'user' | 'assistant' | 'error';
   name: string;
+  /** Entity-context chips for user bubbles (optimistic send only). */
+  contextItems?: ChatContextItem[];
   /** Author avatar, resolved to a full/absolute URL (relative `imageUrl`s from
    *  GraphQL/the auth store are prefixed via `getFullImageUrl`). */
   avatar?: string | null;
@@ -35,7 +47,7 @@ interface UseMingoChat {
 
   // Actions
   createDialog: () => Promise<string | null>;
-  sendMessage: (content: string, targetDialogId?: string) => Promise<boolean>;
+  sendMessage: (content: string, targetDialogId?: string, context?: MingoSendContext) => Promise<boolean>;
   stopGeneration: () => Promise<void>;
 
   // Approval system
@@ -71,6 +83,9 @@ function isSameProcessedMessage(a: ProcessedMessage, b: ProcessedMessage): boole
     a.authorType === b.authorType &&
     a.assistantType === b.assistantType &&
     a.timestamp.getTime() === b.timestamp.getTime() &&
+    // Reference equality — contextItems is set once on the optimistic send and
+    // never mutated, so a stable reference means the chips are unchanged.
+    a.contextItems === b.contextItems &&
     isContentEqual(a.content, b.content)
   );
 }
@@ -166,6 +181,7 @@ export function useMingoChat(dialogId: string | null): UseMingoChat {
         avatar: getFullImageUrl(msg.avatar) ?? null,
         assistantType: msg.assistantType as 'fae' | 'mingo' | undefined,
         timestamp: msg.timestamp || new Date(),
+        contextItems: msg.contextItems,
       });
     }
 
@@ -241,7 +257,7 @@ export function useMingoChat(dialogId: string | null): UseMingoChat {
   }, [isCreatingDialog, setCreatingDialog, createDialogMutation, queryClient]);
 
   const sendMessage = useCallback(
-    async (content: string, targetDialogId?: string): Promise<boolean> => {
+    async (content: string, targetDialogId?: string, context?: MingoSendContext): Promise<boolean> => {
       const effectiveDialogId = targetDialogId || dialogId;
       if (!effectiveDialogId || !content.trim()) return false;
       if (isTyping) return false;
@@ -268,10 +284,20 @@ export function useMingoChat(dialogId: string | null): UseMingoChat {
           // Relative `imageUrl` with cache-bust hash; resolved to a full URL in the processed mapping.
           avatar: appendImageHash(user?.image?.imageUrl, user?.image?.hash) ?? null,
           timestamp: new Date(),
+          // Attach the picked context so the optimistic bubble renders its chips.
+          contextItems: context?.contextItems?.length ? context.contextItems : undefined,
         };
 
         addMessage(effectiveDialogId, optimisticMessage);
-        await sendMessageMutation.mutateAsync({ dialogId: effectiveDialogId, content: content.trim() });
+        await sendMessageMutation.mutateAsync({
+          dialogId: effectiveDialogId,
+          content: content.trim(),
+          // Strip to the `{ type, id }` wire shape; mutation omits empties.
+          // Internal `openView` maps to the API's `currentView` field.
+          contextItems: context?.contextItems?.map(i => ({ type: i.type, id: i.id })),
+          currentView: context?.openView ?? undefined,
+          recentViews: context?.recentViews,
+        });
 
         return true;
       } catch (error) {

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
@@ -31,11 +31,15 @@ import type {
   StreamingPhase,
   UnifiedChatMessage,
   UnifiedChatState,
+  UnifiedSendMessageOptions,
 } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useAiModelStatus } from '@/app/hooks/use-ai-model';
+import { featureFlags } from '@/lib/feature-flags';
+import { CONTEXT_ITEMS_MAX, RECENT_VIEWS_MAX } from '../context/context-types';
+import { useMingoContextStore } from '../stores/mingo-context-store';
 import { useMingoMessagesStore } from '../stores/mingo-messages-store';
-import { useMingoChat } from './use-mingo-chat';
+import { type MingoSendContext, useMingoChat } from './use-mingo-chat';
 import { useMingoDialogSelection } from './use-mingo-dialog-selection';
 import { useMingoDialogs } from './use-mingo-dialogs';
 import { useMingoRealtimeSubscription } from './use-mingo-realtime-subscription';
@@ -217,7 +221,7 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
   // Shared by the draft branch of `sendMessage` and external launchers that
   // want a brand-new conversation regardless of what's currently active.
   const sendInNewDialog = useCallback(
-    async (text: string) => {
+    async (text: string, context?: MingoSendContext) => {
       const trimmed = text.trim();
       if (!trimmed) return;
 
@@ -235,25 +239,55 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
       resetUnread(newId);
       subscribeToDialog(newId);
       selectDialogMut(newId);
-      await sendMingoMessage(trimmed, newId);
+      await sendMingoMessage(trimmed, newId, context);
     },
     [createDialog, addMessage, setActiveDialogId, resetUnread, subscribeToDialog, selectDialogMut, sendMingoMessage],
   );
 
+  // Snapshot the live navigation context (open view + recent views) from the
+  // store and fold in the picker selection from the lib's send options. Read
+  // imperatively (`getState`) so `sendMessage` doesn't re-create on every
+  // navigation — it only needs the value at send time.
+  const buildSendContext = useCallback((options?: UnifiedSendMessageOptions): MingoSendContext => {
+    // The entire entity-context feature is gated behind `mingo-sidebar-context`.
+    // When off, send NO context at all — not the picker selection, and not the
+    // background navigation context (`openView` / `recentViews`). The store keeps
+    // tracking views (harmless); it just never rides out on the message.
+    if (!featureFlags.mingoSidebarContext.enabled()) {
+      return { contextItems: undefined, openView: undefined, recentViews: [] };
+    }
+    const { openView, recentViews } = useMingoContextStore.getState();
+    return {
+      // Defense-in-depth: hard-cap at the backend's contextItems limit (10) so a
+      // selection that slipped past the picker's `atLimit` (e.g. the @-mention
+      // path) can't 400 the whole message.
+      contextItems: options?.contextItems?.slice(0, CONTEXT_ITEMS_MAX),
+      openView: openView ? { type: openView.type, id: openView.id } : undefined,
+      // Defense-in-depth: hard-cap at the backend's recentViews limit (5),
+      // mirroring the contextItems cap above — a corrupted persisted store blob
+      // with >5 entries must not 400 the whole message.
+      recentViews: recentViews.slice(0, RECENT_VIEWS_MAX).map(r => ({ type: r.type, id: r.id })),
+    };
+  }, []);
+
   // ─── Send: create-on-first-send when no dialog is active (draft) ──────────
+  // `options.contextItems` carries the composer's picker selection; the open
+  // view + recent views come from the navigation store via `buildSendContext`.
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, options?: UnifiedSendMessageOptions) => {
       const trimmed = text.trim();
       if (!trimmed) return;
 
+      const context = buildSendContext(options);
+
       if (!activeDialogId) {
-        await sendInNewDialog(trimmed);
+        await sendInNewDialog(trimmed, context);
         return;
       }
 
-      await sendMingoMessage(trimmed);
+      await sendMingoMessage(trimmed, undefined, context);
     },
-    [activeDialogId, sendInNewDialog, sendMingoMessage],
+    [activeDialogId, sendInNewDialog, sendMingoMessage, buildSendContext],
   );
 
   const stopMessage = useCallback(() => {

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/services/mingo-api-service.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/services/mingo-api-service.ts
@@ -27,10 +27,24 @@ export interface CreateDialogRequest {
   agentType: 'ADMIN';
 }
 
+/** Minimal entity ref carried in the message payload. */
+export interface MessageContextRef {
+  type: string;
+  id: string;
+}
+
 export interface SendMessageRequest {
   dialogId: string;
   content: string;
   chatType: 'ADMIN_AI_CHAT';
+  // Field names mirror the chat service OpenAPI `SendMessageRequest`
+  // (GET /chat/v3/api-docs): contextItems[≤10], currentView, recentViews[≤5].
+  /** Entity-context items the user attached via the composer (max 10). */
+  contextItems?: MessageContextRef[];
+  /** The entity page currently open when the message was sent (or omitted). */
+  currentView?: MessageContextRef;
+  /** Up to 5 previously-open entity views, most-recent-first. */
+  recentViews?: MessageContextRef[];
 }
 
 /**
@@ -66,11 +80,28 @@ export function useCreateDialogMutation() {
  */
 export function useSendMessageMutation() {
   return useMutation({
-    mutationFn: async ({ dialogId, content }: { dialogId: string; content: string }) => {
+    mutationFn: async ({
+      dialogId,
+      content,
+      contextItems,
+      currentView,
+      recentViews,
+    }: {
+      dialogId: string;
+      content: string;
+      contextItems?: MessageContextRef[];
+      currentView?: MessageContextRef;
+      recentViews?: MessageContextRef[];
+    }) => {
+      // Omit the context fields entirely when empty so the payload stays the
+      // legacy shape for plain messages.
       const response = await apiClient.post('/chat/api/v1/messages', {
         dialogId,
         content,
         chatType: 'ADMIN_AI_CHAT',
+        ...(contextItems && contextItems.length > 0 ? { contextItems } : {}),
+        ...(currentView ? { currentView } : {}),
+        ...(recentViews && recentViews.length > 0 ? { recentViews } : {}),
       } as SendMessageRequest);
 
       if (!response.ok) {

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/stores/mingo-context-store.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/stores/mingo-context-store.ts
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * Mingo navigation-context store — tracks the entity the user is currently
+ * viewing (`openView`) and the up-to-5 entities they viewed before it
+ * (`recentViews`). Both ride out on every Mingo message so the agent has the
+ * user's working context (POST /chat/api/v1/messages → `openView` /
+ * `recentViews`, see `mingo-api-service.ts`).
+ *
+ * `openView` is set by `useTrackOpenView` from each entity detail page and
+ * cleared on unmount; when an open view is replaced or cleared it rolls into
+ * `recentViews` (deduped by `type:id`, most-recent-first, capped at
+ * `RECENT_VIEWS_MAX`). Persisted to localStorage so the working context
+ * survives reloads.
+ */
+
+import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { type ContextRefWithLabel, RECENT_VIEWS_MAX } from '../context/context-types';
+
+const refKey = (r: { type: string; id: string }) => `${r.type}:${r.id}`;
+
+/** Prepend `ref` to `recents`, drop any existing duplicate, cap the length. */
+function rollIntoRecents(recents: ContextRefWithLabel[], ref: ContextRefWithLabel): ContextRefWithLabel[] {
+  const key = refKey(ref);
+  const withoutDup = recents.filter(r => refKey(r) !== key);
+  return [ref, ...withoutDup].slice(0, RECENT_VIEWS_MAX);
+}
+
+interface MingoContextState {
+  openView: ContextRefWithLabel | null;
+  recentViews: ContextRefWithLabel[];
+  /** Set the currently-open entity. Rolls the previous open view (if any and
+   *  different) into `recentViews`. */
+  setOpenView: (ref: ContextRefWithLabel) => void;
+  /** Clear the open view (e.g. navigating to a non-entity page), rolling it
+   *  into `recentViews`. Idempotent when already null. Pass the `{ type, id }`
+   *  the caller set so a stale unmount-cleanup can't clobber a newer open view
+   *  that a just-mounted page already set (navigation ordering race). */
+  clearOpenView: (ref?: { type: string; id: string }) => void;
+  /** Wipe recent views (dev-window debug action). */
+  clearRecentViews: () => void;
+}
+
+export const useMingoContextStore = create<MingoContextState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        openView: null,
+        recentViews: [],
+
+        setOpenView: ref => {
+          const { openView, recentViews } = get();
+          if (openView && refKey(openView) === refKey(ref)) {
+            // Re-opening the same entity: just refresh its label/desc.
+            set({ openView: ref }, false, 'setOpenView/refresh');
+            return;
+          }
+          set(
+            {
+              openView: ref,
+              // Previous open view becomes recent; the newly-open entity is
+              // removed from recents (it's "open", not "recent").
+              recentViews: (openView ? rollIntoRecents(recentViews, openView) : recentViews).filter(
+                r => refKey(r) !== refKey(ref),
+              ),
+            },
+            false,
+            'setOpenView',
+          );
+        },
+
+        clearOpenView: ref => {
+          const { openView, recentViews } = get();
+          if (!openView) return;
+          // Guard against the navigation race: if a newer page already set a
+          // different open view, our stale cleanup must not null it out.
+          if (ref && refKey(openView) !== refKey(ref)) return;
+          set({ openView: null, recentViews: rollIntoRecents(recentViews, openView) }, false, 'clearOpenView');
+        },
+
+        clearRecentViews: () => set({ recentViews: [] }, false, 'clearRecentViews'),
+      }),
+      {
+        name: 'mingo-context-store',
+        // Persist ONLY `recentViews`. `openView` must not survive a reload: it
+        // means "the entity whose detail page is mounted right now", and after
+        // a reload no detail page is mounted to re-assert or clear it — a
+        // persisted value would ride out on messages as a phantom current view.
+        partialize: state => ({ recentViews: state.recentViews }),
+      },
+    ),
+    { name: 'mingo-context-store' },
+  ),
+);

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/types/message.types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/types/message.types.ts
@@ -1,4 +1,5 @@
 import type { AssistantType, AuthorType, MessageContent } from '@flamingo-stack/openframe-frontend-core';
+import type { ChatContextItem } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import type { ChatType, OwnerType } from '../../tickets/constants';
 
 export interface GraphQlMessage {
@@ -27,6 +28,9 @@ export interface CoreMessage {
   /** Highest content chunk streamSeq that composed this message; stamped on
    *  realtime synthetics for per-message history-coverage dedup. */
   streamSeq?: number;
+  /** Entity-context items attached to this (user) message via the composer's
+   *  context picker. Rendered as read-only chips under the bubble. */
+  contextItems?: ChatContextItem[];
 }
 
 export type Message = CoreMessage;

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-view.tsx
@@ -9,6 +9,8 @@ import {
 import { ArrowRightUpIcon, PenEditIcon, PlayIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { useMemo } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
 import { useScriptDetails } from '../../hooks/use-script-details';
 import { ScriptArgumentsCard } from './script-arguments-card';
 import { ScriptDetailsSkeleton } from './script-details-skeleton';
@@ -21,6 +23,11 @@ interface ScriptDetailsViewProps {
 export function ScriptDetailsView({ scriptId }: ScriptDetailsViewProps) {
   const { scriptDetails, isLoading, error } = useScriptDetails(scriptId);
   const handleBack = useSafeBack('/scripts');
+
+  // Register this script as the Mingo "open view" (cleared → recent on unmount).
+  useTrackOpenView(
+    scriptDetails ? { type: CONTEXT_ENTITY_KIND.SCRIPT, id: scriptId, label: scriptDetails.name || scriptId } : null,
+  );
 
   const editHref = `/scripts/edit/${scriptId}`;
   const runHref = scriptDetails?.id ? `/scripts/details/${scriptDetails.id}/run` : undefined;

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -18,6 +18,7 @@ import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
 import { isAuthOnlyMode, isOssTenantMode, isSaasTenantMode } from '../../lib/app-mode';
 import { getNavigationItems } from '../../lib/navigation-config';
+import { MingoContextDebugWindow } from '../(app)/mingo/context/mingo-context-debug-window';
 import { AppShellSkeleton } from './app-shell-skeleton';
 import { type UnreadCountsByCategory, UnreadCountsHydrator } from './notifications/unread-counts-hydrator';
 import { OpenframeEmbeddableChatEntry } from './openframe-embeddable-chat-entry';
@@ -211,6 +212,9 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
       >
         {showLockContent ? <SubscriptionLockContent /> : children}
       </CoreAppLayout>
+      {/* Floating debug panel for the live Mingo openView/recentViews. Hidden in
+          every env by default; opt-in via the `mingoDebug()` console command. */}
+      <MingoContextDebugWindow />
     </>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
@@ -166,6 +166,13 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
         ticketActionUrl: content('/api/chat/agent/ticket-action'),
         listEngagementsUrl: content('/api/chat/agent/list-engagements'),
         commandsUrl: content('/api/docs/commands'),
+        // Per-platform empty-state config (greeting + try-asking quick-action
+        // chips + RAG-source filter), admin-edited in MPH's `/admin/chat-config`.
+        // Same-origin relative `/content/*` path (see `commandsUrl`), proxied to
+        // MPH. The lib fetches it at runtime because, as a cross-origin embedder,
+        // we have no SSR hop to inject these as props the way MPH's in-app chat
+        // does. Drives `emptyStateGreeting` + the Guide/Mingo quick-action chips.
+        emptyStateUrl: content('/api/docs/empty-state'),
         // Fetch-mode entity cards (blog, roadmap, case study, release,
         // podcast/webinar/event, …) expand their `[card://<type>:<id>]`
         // markers by GETting the type's list endpoint. The lib owns the

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -27,9 +27,14 @@
  * Coexists with the old `/mingo` page route during migration.
  */
 
+import type { ChatContextPickerConfig } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useLocalStorage } from '@flamingo-stack/openframe-frontend-core/hooks';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+import { featureFlags } from '@/lib/feature-flags';
+import { MINGO_CONTEXT_ENTITY_TYPES } from '../(app)/mingo/context/context-sources';
+import { CONTEXT_ITEMS_MAX } from '../(app)/mingo/context/context-types';
+import { renderMingoContextItems } from '../(app)/mingo/context/render-context-items';
 import { DialogSubscription } from '../(app)/mingo/hooks/use-mingo-realtime-subscription';
 import { useMingoUnifiedChatState } from '../(app)/mingo/hooks/use-mingo-unified-chat-state';
 import { useMingoLauncherStore } from '../(app)/mingo/stores/mingo-launcher-store';
@@ -77,6 +82,25 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
   // stored value synchronously on remount, so we reopen on the same transport.
   const [activeMode, setActiveMode] = useLocalStorage<ChatMode>(ACTIVE_MODE_KEY, 'mingo');
 
+  // Entity-context picker config (the `+` "Assign Item" menu + `@` trigger).
+  // Stable so the lib's composer doesn't re-derive its icon map each render.
+  // `renderMingoContextItems` maps each entity type to its data component
+  // (Relay / TanStack hooks); the store-backed openView/recentViews are folded
+  // in at send time by the unified hook.
+  const contextPicker = useMemo<ChatContextPickerConfig>(
+    () => ({
+      entityTypes: MINGO_CONTEXT_ENTITY_TYPES,
+      renderItems: renderMingoContextItems,
+      maxItems: CONTEXT_ITEMS_MAX,
+    }),
+    [],
+  );
+
+  // Entity-context picker (the `+` / `@`-mention flow + selected chips) is
+  // gated behind the `mingo-sidebar-context` flag. Passing `contextPicker`
+  // undefined makes the lib's composer inert (no `+`, no `@`, no chips).
+  const contextEnabled = featureFlags.mingoSidebarContext.enabled();
+
   return (
     <>
       {/* Realtime tail for the active dialog — writes chunks into the shared
@@ -115,7 +139,12 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
         // the user left on instead of always snapping back to Mingo.
         activeMode={activeMode}
         onActiveModeChange={setActiveMode}
-        emptyStateGreeting="Ask Mingo anything about your fleet."
+        // Greeting + try-asking quick-action chips are now per-platform,
+        // admin-driven: the lib fetches them from `endpoints.emptyStateUrl`
+        // (`/content/api/docs/empty-state`) configured in the runtime provider.
+        // No hardcoded greeting here — a blank admin value falls back to the
+        // lib's own default copy.
+        contextPicker={contextEnabled ? contextPicker : undefined}
       />
     </>
   );

--- a/openframe/services/openframe-frontend/src/lib/feature-flags.ts
+++ b/openframe/services/openframe-frontend/src/lib/feature-flags.ts
@@ -15,6 +15,7 @@ export const FEATURE_FLAG_NAMES = [
   'ai-streaming-jetstream',
   'debug-nats-chunks',
   'mingo-sidebar',
+  'mingo-sidebar-context',
   'ticket-statuses',
   'mingo-ai-chat-settings',
   'customer-ai-assistant-settings',
@@ -86,6 +87,11 @@ export const featureFlags = {
   mingoSidebar: {
     enabled(): boolean {
       return getFlagValue('mingo-sidebar', () => false);
+    },
+  },
+  mingoSidebarContext: {
+    enabled(): boolean {
+      return getFlagValue('mingo-sidebar-context', () => false);
     },
   },
   ticketStatuses: {

--- a/openframe/services/openframe-frontend/src/lib/fleet-api-client.ts
+++ b/openframe/services/openframe-frontend/src/lib/fleet-api-client.ts
@@ -205,7 +205,9 @@ class FleetApiClient {
     if (params?.order_key) queryParams.append('order_key', params.order_key);
     if (params?.order_direction) queryParams.append('order_direction', params.order_direction);
     if (params?.per_page) queryParams.append('per_page', params.per_page.toString());
-    if (params?.page) queryParams.append('page', params.page.toString());
+    // `!== undefined` (not truthiness): page 0 is a valid first page — `if (page)`
+    // would drop it and silently fall back to Fleet's default page.
+    if (params?.page !== undefined) queryParams.append('page', params.page.toString());
 
     const queryString = queryParams.toString();
     const path = queryString ? `/api/latest/fleet/queries?${queryString}` : '/api/latest/fleet/queries';


### PR DESCRIPTION
## What

Lands the **Mingo chat entity-context picker** + **Guide-mode empty-state** wiring, and applies the fixes from a two-repo code review of the feature.

The whole context feature is gated behind the `mingo-sidebar-context` feature flag.

### Feature

- **Context picker** — the `+` / `@` entity-context picker in the Mingo composer. Types: Device, Script, Ticket, Customer, User, Knowledge Article, **Policy**, **Query**. Searchable per-type item lists (relay / rest / batch fetchers), removable chips, single-select `@`-mention. `contextItems` / `currentView` / `recentViews` ride out on `POST /chat/api/v1/messages`.
- **Navigation context** — `useTrackOpenView` wired into device / script / customer detail pages → persisted `openView` + `recentViews` store (recents capped at 5).
- **Empty state** — `emptyStateUrl` threaded to the Guide chat for the admin-curated greeting + quick actions.
- Bumps `@flamingo-stack/openframe-frontend-core` `0.0.276` → `0.0.284`.

### Review hardening (host)

- **`getQueries` page 0** — the `page` param was dropped by a truthiness check (`if (params?.page)`), so page 0 silently fell back to Fleet's default page. Now sent on `!== undefined`. Matters now that Query is offered in the picker.
- **`recentViews` cap** — hard-capped to 5 on the send path (defense-in-depth mirroring the `contextItems ≤ 10` cap) so a corrupted persisted store blob can't 400 the whole message.
- **Context store** — persists only `recentViews` (not `openView`, which is a phantom "current view" after reload); `clearOpenView(ref)` guards the navigation unmount race so a stale cleanup can't clobber a newer page's open view.
- **Debug window** — the "Roll openView → recent" button no longer no-ops (the click event was being passed as the guard ref); raw `text-[10px]` → `text-xs`; corrected the misleading "Dev-only" comment (it's opt-in via the `mingoDebug()` console command in any env, hidden by default).

## ⚠️ Notes for reviewers

- **Policy / Query are exposed ahead of the backend.** The chat service `ContextItemReference.type` enum did not include `POLICY` / `QUERY` as of the last verified spec. They're shown in the picker now per product request ("backend is landing the enum imminently"). Until the backend ships those values, attaching a Policy/Query and sending **may 400 the whole message** — if the rollout slips, drop those two rows in `context-sources.tsx`.
- **Companion lib fixes are NOT in this PR.** Five fixes live in `@flamingo-stack/openframe-frontend-core` and need a separate release + a `package.json` version bump to take effect:
  1. Staged context items leaked across dialog switch / Guide↔Mingo toggle.
  2. The picker rendered in Guide mode, where the SSE transport silently drops `contextItems`.
  3. The `@`-mention regex couldn't parse base64 Relay global IDs (orphaned token text / dropped chip).
  4. The context error boundary had no retry on the same type+query.
  5. The empty-state fetch swallowed 5xx indistinguishably from "admin configured nothing".

## Test

- `npm run lint:biome` — clean on changed files.
- `npm run type-check` — clean on changed files (pre-existing yalc `TS7016` env noise unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added context picker to chat, allowing users to attach entities (devices, organizations, scripts, policies, tickets, users, knowledge base items) as context to messages
  * Automatic tracking of viewed entity details for navigation history

* **Bug Fixes**
  * Fixed page parameter handling in Fleet API queries

* **Chores**
  * Updated frontend core dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->