### PR TITLE
fix(): notifications history tabs split

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-page-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-page-view.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { CheckCircleIcon, TrashIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { type TabItem, TabNavigation } from '@flamingo-stack/openframe-frontend-core';
+import {
+  BellIcon,
+  CheckCircleIcon,
+  ClockHistoryIcon,
+  TrashIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { type PageActionButton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useApiParams, useDebounce, useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryLoader } from 'react-relay';
@@ -16,13 +22,21 @@ import { NOTIFICATIONS_SECTION_PAGE_SIZE, NotificationsSection } from './notific
 
 const SEARCH_DEBOUNCE_MS = 300;
 
+const NOTIFICATIONS_TABS: TabItem[] = [
+  { id: 'new', label: 'New Notifications', icon: BellIcon },
+  { id: 'history', label: 'Notifications History', icon: ClockHistoryIcon },
+];
+
 export function NotificationsPageView() {
   const { toast } = useToast();
 
   const { params, setParam } = useApiParams({
+    tab: { type: 'string', default: 'new' },
     searchNew: { type: 'string', default: '' },
     searchHistory: { type: 'string', default: '' },
   });
+
+  const handleTabChange = useCallback((tabId: string) => setParam('tab', tabId), [setParam]);
 
   const [searchNewInput, setSearchNewInput] = useState(params.searchNew);
   const [searchHistoryInput, setSearchHistoryInput] = useState(params.searchHistory);
@@ -90,49 +104,61 @@ export function NotificationsPageView() {
       onDeleteAllReadCompleted,
     });
 
+  const newActions: PageActionButton[] = [
+    {
+      label: 'Mark All as Done',
+      icon: <CheckCircleIcon className="text-ods-text-secondary" />,
+      onClick: markAllRead,
+      variant: 'outline',
+      disabled: isMarkingAllRead,
+    },
+  ];
+
+  const historyActions: PageActionButton[] = [
+    {
+      label: 'Delete All',
+      icon: <TrashIcon className="text-ods-text-secondary" />,
+      onClick: removeAllRead,
+      variant: 'outline',
+      disabled: isDeletingAllRead,
+    },
+  ];
+
+  const activeTab = params.tab === 'history' ? 'history' : 'new';
+
   return (
-    <div className="flex h-full flex-col gap-[var(--spacing-system-l)]">
-      <NotificationsSection
-        title="New Notifications"
-        queryRef={newQueryRef}
-        searchValue={searchNewInput}
-        onSearchChange={setSearchNewInput}
-        rowVariant="unread"
-        onMarkRead={markRead}
-        rightAction={
-          <Button
-            variant="outline"
-            disabled={isMarkingAllRead}
-            leftIcon={<CheckCircleIcon className="size-[var(--icon-size-icon-size)] text-ods-text-secondary" />}
-            onClick={markAllRead}
-          >
-            Mark All as Done
-          </Button>
-        }
+    <div className="flex w-full flex-col -mt-4">
+      <TabNavigation
+        tabs={NOTIFICATIONS_TABS}
+        activeTab={activeTab}
+        urlSync={false}
+        onTabChange={handleTabChange}
+        showRightGradient
       />
 
-      <NotificationsSection
-        title="Notifications History"
-        queryRef={historyQueryRef}
-        searchValue={searchHistoryInput}
-        onSearchChange={setSearchHistoryInput}
-        rowVariant="read"
-        onDelete={removeNotification}
-        rightAction={
-          <Button
-            variant="outline"
-            disabled={isDeletingAllRead}
-            leftIcon={<TrashIcon className="size-[var(--icon-size-icon-size)] text-ods-text-secondary" />}
-            onClick={removeAllRead}
-          >
-            Delete All
-          </Button>
-        }
-      />
-
-      <p className="text-center text-h6 text-ods-text-secondary">
-        Notification history is retained for 30 days, then permanently deleted.
-      </p>
+      {activeTab === 'history' ? (
+        <NotificationsSection
+          key="history"
+          title="Notifications History"
+          queryRef={historyQueryRef}
+          searchValue={searchHistoryInput}
+          onSearchChange={setSearchHistoryInput}
+          rowVariant="read"
+          onDelete={removeNotification}
+          actions={historyActions}
+        />
+      ) : (
+        <NotificationsSection
+          key="new"
+          title="New Notifications"
+          queryRef={newQueryRef}
+          searchValue={searchNewInput}
+          onSearchChange={setSearchNewInput}
+          rowVariant="unread"
+          onMarkRead={markRead}
+          actions={newActions}
+        />
+      )}
     </div>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-section.tsx
@@ -1,14 +1,22 @@
 'use client';
 
 import { getApprovalMeta, isApprovalNotification } from '@flamingo-stack/openframe-frontend-core';
-import { BellOffIcon, ClockHistoryIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { DataTable, SearchInput, useDataTable } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { BellCheckIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  DataTable,
+  type NoDataProps,
+  type PageActionButton,
+  PageLayout,
+  SearchInput,
+  useDataTable,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
-import { type ReactNode, Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { type PreloadedQuery, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 import type { notificationsSectionRelay_query$key as NotificationsSectionFragmentKey } from '@/__generated__/notificationsSectionRelay_query.graphql';
 import type { notificationsSectionRelayPaginationQuery as NotificationsSectionPaginationQueryType } from '@/__generated__/notificationsSectionRelayPaginationQuery.graphql';
 import type { notificationsSectionRelayQuery as NotificationsSectionRelayQueryType } from '@/__generated__/notificationsSectionRelayQuery.graphql';
+import { EmptyState } from '@/app/components/shared';
 import { mapNotificationNode, parseCreatedAt } from '@/graphql/notifications/notifications-helpers';
 import {
   notificationsSectionRelayFragment,
@@ -19,13 +27,14 @@ import { buildNotificationColumns, type NotificationRow } from './notifications-
 
 export const NOTIFICATIONS_SECTION_PAGE_SIZE = 50;
 const EMPTY_ROWS: NotificationRow[] = [];
+const HISTORY_RETENTION_NOTE = 'Notification history is retained for 30 days, then permanently deleted.';
 
 interface NotificationsSectionProps {
   title: string;
   queryRef: PreloadedQuery<NotificationsSectionRelayQueryType> | null | undefined;
   searchValue: string;
   onSearchChange: (value: string) => void;
-  rightAction?: ReactNode;
+  actions?: PageActionButton[];
   rowVariant: 'unread' | 'read';
   onMarkRead?: (id: string) => void;
   onDelete?: (id: string) => void;
@@ -36,41 +45,45 @@ export function NotificationsSection({
   queryRef,
   searchValue,
   onSearchChange,
-  rightAction,
+  actions,
   rowVariant,
   onMarkRead,
   onDelete,
 }: NotificationsSectionProps) {
-  return (
-    <section className="flex min-h-0 flex-1 flex-col gap-[var(--spacing-system-m)]">
-      <div className="flex flex-wrap items-baseline justify-between gap-[var(--spacing-system-m)]">
-        <h2 className="text-h2 text-ods-text-primary">{title}</h2>
-        {rightAction}
-      </div>
+  const [isEmpty, setIsEmpty] = useState(true);
 
+  return (
+    <PageLayout title={title} actions={isEmpty ? undefined : actions}>
       <SearchInput placeholder="Search for Notification" value={searchValue} onChange={onSearchChange} debounceMs={0} />
 
-      <div className="flex min-h-0 flex-1 flex-col">
-        <Suspense fallback={<SectionTableSkeleton rowVariant={rowVariant} />}>
-          {queryRef ? (
-            <SectionTable queryRef={queryRef} rowVariant={rowVariant} onMarkRead={onMarkRead} onDelete={onDelete} />
-          ) : (
-            <SectionTableSkeleton rowVariant={rowVariant} />
-          )}
-        </Suspense>
-      </div>
-    </section>
+      <Suspense fallback={<SectionTableSkeleton rowVariant={rowVariant} />}>
+        {queryRef ? (
+          <SectionTable
+            queryRef={queryRef}
+            rowVariant={rowVariant}
+            searchValue={searchValue}
+            onMarkRead={onMarkRead}
+            onDelete={onDelete}
+            onEmptyChange={setIsEmpty}
+          />
+        ) : (
+          <SectionTableSkeleton rowVariant={rowVariant} />
+        )}
+      </Suspense>
+    </PageLayout>
   );
 }
 
 interface SectionTableProps {
   queryRef: PreloadedQuery<NotificationsSectionRelayQueryType>;
   rowVariant: 'unread' | 'read';
+  searchValue: string;
   onMarkRead?: (id: string) => void;
   onDelete?: (id: string) => void;
+  onEmptyChange: (isEmpty: boolean) => void;
 }
 
-function SectionTable({ queryRef, rowVariant, onMarkRead, onDelete }: SectionTableProps) {
+function SectionTable({ queryRef, rowVariant, searchValue, onMarkRead, onDelete, onEmptyChange }: SectionTableProps) {
   const { toast } = useToast();
   const queryData = usePreloadedQuery(notificationsSectionRelayQuery, queryRef);
   const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment<
@@ -127,33 +140,41 @@ function SectionTable({ queryRef, rowVariant, onMarkRead, onDelete }: SectionTab
   }, [hasNext, isLoadingNext, loadNext, toast]);
 
   const isEmpty = rows.length === 0;
-  const emptyIcon =
-    rowVariant === 'unread' ? (
-      <BellOffIcon size={24} className="text-ods-text-secondary" />
-    ) : (
-      <ClockHistoryIcon size={24} className="text-ods-text-secondary" />
-    );
-  const emptyMessage = rowVariant === 'unread' ? 'No new notifications' : 'No notification history';
+  useEffect(() => {
+    onEmptyChange(isEmpty);
+  }, [isEmpty, onEmptyChange]);
+
+  const trimmedSearch = searchValue.trim();
+  const emptyState: NoDataProps = trimmedSearch
+    ? {
+        title: `No notifications found matching "${trimmedSearch}".`,
+        description: 'Try adjusting your search.',
+      }
+    : {
+        icon: <BellCheckIcon size={24} className="text-ods-text-secondary" />,
+        title: rowVariant === 'unread' ? 'No new notifications' : 'No notifications history',
+        description:
+          rowVariant === 'read' ? HISTORY_RETENTION_NOTE : "You're all up to date with system alerts and messages.",
+      };
+
+  if (isEmpty) {
+    return <EmptyState {...emptyState} />;
+  }
 
   return (
-    <DataTable table={table} className="flex min-h-0 flex-1 flex-col">
-      <DataTable.Header rightSlot={<DataTable.RowCount itemName="result" />} />
-      {isEmpty ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center">
-          <DataTable.Empty icon={emptyIcon} title={emptyMessage} description={undefined} className="w-full" />
-        </div>
-      ) : (
-        <>
-          <DataTable.Body rowClassName="mb-1" renderSubRow={renderSubRow} />
-          <DataTable.InfiniteFooter
-            hasNextPage={hasNext}
-            isFetchingNextPage={isLoadingNext}
-            onLoadMore={onLoadMore}
-            skeletonRows={2}
-          />
-        </>
-      )}
-    </DataTable>
+    <>
+      <DataTable table={table}>
+        <DataTable.Header rightSlot={<DataTable.RowCount itemName="result" />} />
+        <DataTable.Body rowClassName="mb-1" renderSubRow={renderSubRow} />
+        <DataTable.InfiniteFooter
+          hasNextPage={hasNext}
+          isFetchingNextPage={isLoadingNext}
+          onLoadMore={onLoadMore}
+          skeletonRows={2}
+        />
+      </DataTable>
+      {rowVariant === 'read' && <p className="text-center text-h6 text-ods-text-secondary">{HISTORY_RETENTION_NOTE}</p>}
+    </>
   );
 }
 
@@ -166,7 +187,7 @@ function SectionTableSkeleton({ rowVariant }: { rowVariant: 'unread' | 'read' })
   });
 
   return (
-    <DataTable table={table} className="flex min-h-0 flex-1 flex-col">
+    <DataTable table={table}>
       <DataTable.Header rightSlot={<DataTable.RowCount itemName="result" />} />
       <DataTable.Body loading skeletonRows={4} />
     </DataTable>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tabbed interface to browse new notifications and history separately with dynamic data loading based on the selected tab

* **Improvements**
  * Consolidated notification action buttons into a unified, cleaner layout
  * Enhanced empty state messaging for better user guidance when no notifications are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->