### PR TITLE
Fix: Remove deprecated Tier column from Customers table

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table-columns.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table-columns.tsx
@@ -23,7 +23,6 @@ export interface UiCustomerEntry {
   organizationId: string;
   name: string;
   email: string;
-  tier: string;
   deviceCount: number | null;
   numberOfEmployees: number;
   lastActivityDate: string;
@@ -56,7 +55,6 @@ export function transformCustomerToEntry(org: Customer, deviceCount: number | nu
     organizationId: org.organizationId,
     name: org.name,
     email: org.contact.email,
-    tier: org.tier,
     deviceCount,
     numberOfEmployees: org.numberOfEmployees,
     lastActivityDate: new Date(org.lastActivity).toLocaleString(),
@@ -72,12 +70,6 @@ export const CUSTOMERS_COLUMNS: ColumnDef<UiCustomerEntry>[] = [
     header: 'Name',
     cell: ({ row }: { row: Row<UiCustomerEntry> }) => <CustomerNameCell org={row.original} />,
     meta: { width: 'flex-1 min-w-0' },
-  },
-  {
-    accessorKey: 'tier',
-    header: 'Tier',
-    cell: ({ row }: { row: Row<UiCustomerEntry> }) => <TruncateText>{row.original.tier}</TruncateText>,
-    meta: { width: 'w-[200px] shrink-0', hideAt: 'md' },
   },
   {
     accessorKey: 'deviceCount',

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/hooks/use-customers.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/hooks/use-customers.ts
@@ -17,7 +17,6 @@ export interface Customer {
     name: string;
     email: string;
   };
-  tier: 'Basic' | 'Premium' | 'Enterprise';
   industry: string;
   mrrUsd: number;
   numberOfEmployees: number;
@@ -55,7 +54,6 @@ export function mapOrganizationNode(node: OrganizationNode): Customer {
       name: primaryContact?.contactName ?? '',
       email: primaryContact?.email ?? '',
     },
-    tier: 'Basic',
     industry: node.category ?? '-',
     mrrUsd: node.monthlyRevenue ?? 0,
     numberOfEmployees: node.numberOfEmployees ?? 0,


### PR DESCRIPTION
## Improvements
The tier parameter has been deprecated in the latest system update. Removes the Tier column from the Customers table and cleans up the now-unused tier field from UiCustomerEntry, transformCustomerToEntry, the Customer type, and mapOrganizationNode.

## Task
[Remove "Tier" Column from Customers Table](https://app.clickup.com/t/86ahhndqp)
