### PR TITLE
chore(chat): rename desktop app from "Fae Chat" to "OpenFrame"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
           - **macOS** (Universal): \`openframe-client_macos.tar.gz\`
           - **Windows** (x64): \`openframe-client_windows.zip\`
 
-          ## Fae Chat
+          ## OpenFrame
           - **macOS** (Universal): \`openframe-chat_universal.dmg\`
           - **Windows** (x64): \`openframe-chat_windows.zip\`
 

--- a/clients/openframe-chat/CLAUDE.md
+++ b/clients/openframe-chat/CLAUDE.md
@@ -1,4 +1,4 @@
-# OpenFrame Chat (Fae Chat Desktop Client) — Claude Development Guide
+# OpenFrame Chat Desktop Client — Claude Development Guide
 
 **Tauri 2 + React 19 + TypeScript 5 + Vite 5 + @flamingo-stack/openframe-frontend-core**
 

--- a/clients/openframe-chat/index.html
+++ b/clients/openframe-chat/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@400;500;600;700&family=DM+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <title>Fae Chat</title>
+    <title>OpenFrame</title>
   </head>
   <body>
     <div id="root"></div>

--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "fae-chat-client",
+  "name": "openframe-chat-client",
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "Fae Chat Desktop Client - Tauri + React",
+  "description": "OpenFrame Chat Desktop Client - Tauri + React",
   "scripts": {
     "dev": "tauri dev",
     "frontend:dev": "vite",

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -452,7 +452,7 @@ pub fn run() {
                 .icon_as_template(cfg!(target_os = "macos"))
                 .menu(&menu)
                 .show_menu_on_left_click(false)
-                .tooltip("OpenFrame Chat")
+                .tooltip("OpenFrame")
                 .on_tray_icon_event(|tray, event| {
                     if let TrayIconEvent::Click {
                         button: MouseButton::Left,
@@ -509,7 +509,7 @@ pub fn run() {
                     true,
                     Some("CmdOrCtrl+Q"),
                 )?;
-                let app_submenu = Submenu::with_items(app, "Fae Chat", true, &[
+                let app_submenu = Submenu::with_items(app, "OpenFrame", true, &[
                     &PredefinedMenuItem::about(app, None, None)?,
                     &PredefinedMenuItem::separator(app)?,
                     &quit_to_tray_i,

--- a/clients/openframe-chat/src-tauri/tauri.conf.json
+++ b/clients/openframe-chat/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "Fae Chat",
+  "productName": "OpenFrame",
   "version": "0.1.0",
   "identifier": "com.openframe.chat",
   "build": {
@@ -13,7 +13,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "Fae Chat",
+        "title": "OpenFrame",
         "width": 1000,
         "height": 800,
         "minWidth": 800,


### PR DESCRIPTION
## What

Renames the OpenFrame Chat desktop client's app name from **Fae Chat** to **OpenFrame** across all user-facing surfaces and package metadata.

| Surface | Before | After |
|---|---|---|
| Tauri `productName` | `Fae Chat` | `OpenFrame` |
| Window title (`tauri.conf.json`) | `Fae Chat` | `OpenFrame` |
| macOS app menu (`lib.rs`) | `Fae Chat` | `OpenFrame` |
| Tray tooltip (`lib.rs`) | `OpenFrame Chat` | `OpenFrame` |
| HTML `<title>` | `Fae Chat` | `OpenFrame` |
| `package.json` name | `fae-chat-client` | `openframe-chat-client` |
| `package.json` description | `Fae Chat Desktop Client …` | `OpenFrame Chat Desktop Client …` |
| `CLAUDE.md` heading | dropped stale "Fae Chat" parenthetical | — |

## What is intentionally NOT changed

- **The in-app AI assistant persona "Fae"** (avatar, "Meet Fae, your AI IT assistant", `assistantName ?? 'Fae'`) — that's the assistant's name, not the app name, and stays as-is.
- **The bundle identifier** `com.openframe.chat` — unchanged. All local persistence (auth session/cookie, app data dir, single-instance lock, Windows toast AUMID) is keyed off this, so **existing installs keep their session and data** with no migration.

## Notes

- Dev-mode dock hover shows `openframe-chat` (the Cargo crate name / dev binary); the bundled app shows **OpenFrame** via `productName` → `CFBundleName`. Expected, not a regression.
- The Windows toast `DisplayName` (`lib.rs`) was already `OpenFrame Chat` from a prior pass and is left as a descriptive sender name.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run build` (Vite) succeeds
- [x] `npm run dev` launches; window title bar and macOS app menu read **OpenFrame**
- [ ] `npm run tauri build` produces `OpenFrame.app` (not run in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the desktop application's display name across interface elements including window title, system tray, and menu labels.
  * Updated browser tab title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->