### PR TITLE
Settings Page: add Log Out button with confirmation modal

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.289",
+        "@flamingo-stack/openframe-frontend-core": "0.0.291",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.289",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.289.tgz",
-      "integrity": "sha512-T4dgJrJ4infx+CgQ8ThsdiXASvHBGxiaFbkajzHo1diWMDKEX52Ag5OyQMqAoAyLMBsF+/JBd6k5vUCGQjXqVg==",
+      "version": "0.0.291",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.291.tgz",
+      "integrity": "sha512-/wUu3+4n3GvSlYomOQW5ZyH6oKfZxlllVJCv/4erIFLYLYIgJOJbEKJWEaFuV20gGsuFwMN+SoOKkoEsPBkkNw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.289",
+    "@flamingo-stack/openframe-frontend-core": "0.0.291",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/layout.tsx
@@ -9,6 +9,7 @@ function getMainClassNameOverride(pathname: string | null): string | undefined {
   if (pathname.startsWith('/mingo')) return 'p-0 md:p-0';
   if (/^\/devices\/details\/[^/]+\/file-manager/.test(pathname)) return 'pb-0 md:pb-0';
   if (pathname.startsWith('/tickets')) return 'pb-0 md:pb-0';
+  if (pathname.startsWith('/settings')) return 'pb-0 md:pb-0';
   return undefined;
 }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import {
   CreditCardIcon,
   Hierarchy02Icon,
+  Logout01Icon,
   PasscodeIcon,
   PiggyBankIcon,
   ShieldCheckIcon,
@@ -11,9 +12,11 @@ import {
   UsersGroupIcon,
   WrenchScrewdiverIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback, useEffect, useState } from 'react';
 import { useAuthStore } from '@/app/(auth)/auth/stores';
+import { useLogoutConfirmStore } from '@/app/(auth)/auth/stores/logout-confirm-store';
 import { apiClient } from '@/lib/api-client';
 import { isOssTenantMode } from '@/lib/app-mode';
 import { authApiClient } from '@/lib/auth-api-client';
@@ -65,6 +68,7 @@ const SETTINGS_NAV_ITEMS = [
 
 export function SettingsHub() {
   const { toast } = useToast();
+  const openLogoutConfirm = useLogoutConfirmStore(state => state.open);
   const user = useAuthStore(state => state.user);
   const updateUser = useAuthStore(state => state.updateUser);
   const fetchFullProfile = useAuthStore(state => state.fetchFullProfile);
@@ -136,7 +140,7 @@ export function SettingsHub() {
   }, [fetchFullProfile]);
 
   return (
-    <PageLayout title="Settings" className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]">
+    <PageLayout title="Settings" className="min-h-full px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]">
       {/* Profile Card */}
       <ProfileCard
         onEditProfile={() => setIsEditModalOpen(true)}
@@ -158,6 +162,13 @@ export function SettingsHub() {
               description={item.description}
             />
           ))}
+      </div>
+
+      {/* Log Out — pinned to the bottom-left of the page */}
+      <div className="mt-auto">
+        <Button variant="outline" onClick={openLogoutConfirm} leftIcon={<Logout01Icon className="text-ods-error" />}>
+          Log Out
+        </Button>
       </div>
 
       {/* Modals */}

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/stores/logout-confirm-store.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/stores/logout-confirm-store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+/**
+ * Owns the open state of the logout confirmation modal, lifted into a store so
+ * it can be triggered from anywhere — the Settings page "Log Out" button and
+ * the navigation user menu both live in separate subtrees but must open the
+ * same confirmation dialog (mounted once in `AppShell`).
+ *
+ * Mirrors the `mingo-launcher-store` "open from anywhere" pattern.
+ */
+interface LogoutConfirmStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  setOpen: (open: boolean) => void;
+}
+
+export const useLogoutConfirmStore = create<LogoutConfirmStore>()(
+  devtools(
+    set => ({
+      isOpen: false,
+      open: () => set({ isOpen: true }, false, 'open'),
+      close: () => set({ isOpen: false }, false, 'close'),
+      setOpen: open => set({ isOpen: open }, false, 'setOpen'),
+    }),
+    { name: 'logout-confirm-store' },
+  ),
+);

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -13,7 +13,8 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useMingoLauncherStore } from '@/app/(app)/mingo/stores/mingo-launcher-store';
 import { useAuthSession } from '@/app/(auth)/auth/hooks/use-auth-session';
 import { useAuthStore } from '@/app/(auth)/auth/stores/auth-store';
-import { performLogout } from '@/app/(auth)/auth/utils/auth-actions';
+import { useLogoutConfirmStore } from '@/app/(auth)/auth/stores/logout-confirm-store';
+import { LogoutConfirmModal } from '@/app/components/shared/logout-confirm-modal';
 import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
 import { isAuthOnlyMode, isOssTenantMode, isSaasTenantMode } from '../../lib/app-mode';
@@ -62,9 +63,11 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
     [router],
   );
 
+  const openLogoutConfirm = useLogoutConfirmStore(state => state.open);
+
   const handleLogout = useCallback(() => {
-    performLogout();
-  }, []);
+    openLogoutConfirm();
+  }, [openLogoutConfirm]);
 
   const handleProfile = useCallback(() => {
     router.push('/settings');
@@ -212,6 +215,9 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
       >
         {showLockContent ? <SubscriptionLockContent /> : children}
       </CoreAppLayout>
+      {/* Logout confirmation modal — opened from the nav user menu and the
+          Settings "Log Out" button via `useLogoutConfirmStore`. */}
+      <LogoutConfirmModal />
       {/* Floating debug panel for the live Mingo openView/recentViews. Hidden in
           every env by default; opt-in via the `mingoDebug()` console command. */}
       <MingoContextDebugWindow />

--- a/openframe/services/openframe-frontend/src/app/components/shared/logout-confirm-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/logout-confirm-modal.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback, useState } from 'react';
 import { useLogoutConfirmStore } from '@/app/(auth)/auth/stores/logout-confirm-store';
 import { performLogout } from '@/app/(auth)/auth/utils/auth-actions';
 import { ConfirmDialog } from '@/app/components/shared/confirm-dialog';
+import { handleApiError } from '@/lib/handle-api-error';
 
 /**
  * Logout confirmation dialog. Reads its open state from `useLogoutConfirmStore`
@@ -14,14 +16,22 @@ import { ConfirmDialog } from '@/app/components/shared/confirm-dialog';
  * manually after confirm — the pending state stays visible until navigation.
  */
 export function LogoutConfirmModal() {
+  const { toast } = useToast();
   const isOpen = useLogoutConfirmStore(state => state.isOpen);
   const setOpen = useLogoutConfirmStore(state => state.setOpen);
   const [isPending, setIsPending] = useState(false);
 
-  const handleConfirm = useCallback(() => {
+  const handleConfirm = useCallback(async () => {
     setIsPending(true);
-    performLogout();
-  }, []);
+    try {
+      await performLogout();
+    } catch (error) {
+      // performLogout normally redirects on success; on failure re-enable the
+      // action so the modal isn't stuck, and surface the error to the user.
+      setIsPending(false);
+      handleApiError(error, toast, 'Failed to log out');
+    }
+  }, [toast]);
 
   return (
     <ConfirmDialog

--- a/openframe/services/openframe-frontend/src/app/components/shared/logout-confirm-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/logout-confirm-modal.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useLogoutConfirmStore } from '@/app/(auth)/auth/stores/logout-confirm-store';
+import { performLogout } from '@/app/(auth)/auth/utils/auth-actions';
+import { ConfirmDialog } from '@/app/components/shared/confirm-dialog';
+
+/**
+ * Logout confirmation dialog. Reads its open state from `useLogoutConfirmStore`
+ * so any trigger (Settings "Log Out" button, navigation user menu) can open it.
+ * Mounted once in `AppShell`.
+ *
+ * `performLogout` redirects the browser on success, so the modal is not closed
+ * manually after confirm — the pending state stays visible until navigation.
+ */
+export function LogoutConfirmModal() {
+  const isOpen = useLogoutConfirmStore(state => state.isOpen);
+  const setOpen = useLogoutConfirmStore(state => state.setOpen);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleConfirm = useCallback(() => {
+    setIsPending(true);
+    performLogout();
+  }, []);
+
+  return (
+    <ConfirmDialog
+      open={isOpen}
+      onOpenChange={setOpen}
+      title="Log Out"
+      description="You'll be signed out of your OpenFrame account on this device."
+      confirmLabel="Confirm"
+      cancelLabel="Cancel"
+      variant="destructive"
+      isPending={isPending}
+      pendingLabel="Logging Out..."
+      onConfirm={handleConfirm}
+    />
+  );
+}


### PR DESCRIPTION
## Improvements
Add a logout confirmation flow shared across the app:

- New logout-confirm Zustand store ("open from anywhere" pattern) so the Settings page button and the navigation user menu open one shared modal
- New LogoutConfirmModal built on ConfirmDialog (centered on desktop/tablet, bottom-anchored on mobile); confirm calls performLogout()
- AppShell: mount the modal once and route handleLogout through the store instead of logging out immediately (covers header dropdown + mobile menu)
- Settings: add a bottom-left "Log Out" button (outline + red logout icon); pin it to the bottom via min-h-full + mt-auto and drop the page's bottom padding on /settings

## Task
[User Logout Design Aligning](https://app.clickup.com/t/86ahuab4e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logout now requires confirmation via a modal dialog before completing, providing an extra safeguard against accidental logouts.
  * Added a "Log Out" button directly in the Settings page for convenient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->