### PR TITLE
feat(frontend): Mingo inline AI mention chips + notification drawer routing + core lib 0.0.294

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * SINGLE SOURCE OF TRUTH for "where does a content entity card go in OpenFrame".
+ *
+ * OpenFrame hosts FOUR of the hub's content types in-app under `/help-center`
+ * (product releases, onboarding guides, roadmap, delivery/bug-fixes); every
+ * other type (blog / podcast / case-study / …) lives only on the Flamingo
+ * content hub. This module encodes that split ONCE so both runtimes agree:
+ *
+ *   - `HelpCenterRuntimeProvider` (the `/help-center` subtree, `mode: 'host'`)
+ *     uses the relative composer directly — same-origin relative hrefs soft-nav.
+ *   - `OpenframeChatRuntimeProvider` (the app-wide Guide/Mingo chat drawer,
+ *     `mode: 'embed'`) wraps it: in-app `/help-center/...` hrefs are absolutized
+ *     to the CURRENT origin so the lib's embed-mode nav recognizes them as
+ *     same-origin in-app and soft-navs there instead of bouncing every card out
+ *     to the hub. Non-hosted types still resolve to their authoritative hub URL.
+ *
+ * Keeping the type→route map in one place means a newly in-app-hosted content
+ * type becomes internal in BOTH the pages and the chat from a single edit.
+ */
+
+import {
+  type ComposeContentUrl,
+  DEFAULT_CONTENT_SUFFIXES,
+  DEV_SECTION_PARAM_KEYS,
+  makeComposeContentUrl,
+} from '@flamingo-stack/openframe-frontend-core/utils';
+import { HELP_CENTER_BASE } from './endpoints';
+
+/** Public origin of the Flamingo content hub — fallback for content types Help
+ *  Center does NOT host in-app (blog / podcast / case-study / …). */
+const CONTENT_HUB_ORIGIN = 'https://www.flamingo.run';
+
+/** Slash-less section base (`'help-center'`) — content suffixes are slash-less. */
+const HC = HELP_CENTER_BASE.replace(/^\//, '');
+
+/** Types Help Center hosts on its own slugged detail routes → relative in-app
+ *  href `/<suffix>/<slug>` (soft-nav). The list-filter types (roadmap, delivery)
+ *  are NOT here — they have no detail route and use `overrides` instead. */
+const HOSTED_TYPES = new Set(['onboarding_guide', 'product_release']);
+
+/**
+ * The unified `composeContentUrl` for OpenFrame. Returns RELATIVE in-app hrefs
+ * for the four hosted types and the hub URL for everything else — exactly what
+ * the `host`-mode help-center subtree needs. The embed-mode chat wraps this via
+ * {@link toSameOriginHelpCenterHref} to absolutize the in-app branch.
+ */
+export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentUrl({
+  hostedTypes: HOSTED_TYPES,
+  // Prefix the two hosted types' suffixes with the section base so their in-app
+  // href is `/help-center/onboarding-guides/<slug>` etc.; keep the lib defaults
+  // for every other type (used with `contentOrigin` for non-hosted fallback).
+  suffixes: {
+    ...DEFAULT_CONTENT_SUFFIXES,
+    onboarding_guide: `${HC}/onboarding-guides`,
+    product_release: `${HC}/releases`,
+  },
+  contentOrigin: CONTENT_HUB_ORIGIN,
+  // List-filter types deep-link into their EXISTING in-app list route with the
+  // `?search=<id>` param `DevSectionView` writes and the views read.
+  overrides: {
+    roadmap_item: id => ({
+      href: `${HELP_CENTER_BASE}/roadmap?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`,
+      targetPlatform: null,
+    }),
+    delivery_item: id => ({
+      href: `${HELP_CENTER_BASE}/bug-fixes-and-enhancements?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`,
+      targetPlatform: null,
+    }),
+  },
+});
+
+/** True when a composed href points at an in-app `/help-center` route (i.e. the
+ *  relative-same-origin branch of {@link composeOpenframeContentUrl}). */
+export function isInAppHelpCenterHref(href: string): boolean {
+  return href === HELP_CENTER_BASE || href.startsWith(`${HELP_CENTER_BASE}/`);
+}
+
+/**
+ * Embed-mode adapter: absolutize an in-app `/help-center/...` href against the
+ * CURRENT origin so the lib's `computeIsNewTab` recognizes it as same-origin
+ * in-app (same-tab soft-nav) instead of absolutizing it against the hub origin
+ * and opening a new tab. Non-hosted (already-absolute hub) hrefs pass through.
+ * SSR-safe: with no `window` it returns the href unchanged (cards only ever
+ * render client-side, so the relative form never reaches the user).
+ */
+export function toSameOriginHelpCenterHref(href: string): string {
+  if (typeof window === 'undefined') return href;
+  if (!isInAppHelpCenterHref(href)) return href;
+  return window.location.origin + href;
+}
+
+/** Embed-mode `composeContentUrl`: same routing as {@link composeOpenframeContentUrl},
+ *  but in-app hrefs are absolutized to the current origin for the embedded chat. */
+export const composeOpenframeChatContentUrl: ComposeContentUrl = input => {
+  const resolved = composeOpenframeContentUrl(input);
+  return { href: toSameOriginHelpCenterHref(resolved.href), targetPlatform: resolved.targetPlatform };
+};

--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-runtime-provider.tsx
@@ -23,15 +23,11 @@ import {
   ChatRuntimeContext,
   EndpointsRuntimeContext,
 } from '@flamingo-stack/openframe-frontend-core/contexts';
-import {
-  DEFAULT_CONTENT_SUFFIXES,
-  DEV_SECTION_PARAM_KEYS,
-  makeComposeContentUrl,
-} from '@flamingo-stack/openframe-frontend-core/utils';
 import { notFound } from 'next/navigation';
 import { type ReactNode, useContext, useMemo } from 'react';
 import { featureFlags } from '@/lib/feature-flags';
-import { HELP_CENTER_BASE, HELP_CENTER_ENDPOINTS } from './endpoints';
+import { HELP_CENTER_ENDPOINTS } from './endpoints';
+import { composeOpenframeContentUrl } from './help-center-content-href';
 
 // NOTE: the lib `PageShell`'s padding is overridden with OpenFrame's host grid
 // spacing via the `--page-shell-*` CSS vars set on the section wrapper in
@@ -42,17 +38,6 @@ import { HELP_CENTER_BASE, HELP_CENTER_ENDPOINTS } from './endpoints';
 // (`openframe-chat-runtime-provider.tsx`) — so `/content/api/*` GET/POSTs carry the
 // same bearer + 401-refresh as the chat with zero help-center-specific setup.
 
-/** Public origin of the Flamingo content hub — fallback for content types Help
- *  Center does NOT host in-app (blog / podcast / case-study / …). */
-const CONTENT_HUB_ORIGIN = 'https://www.flamingo.run';
-
-/** Types Help Center hosts on its own slugged detail routes → relative in-app
- *  href `/<suffix>/<slug>` (soft-nav). The list-filter types (roadmap, delivery)
- *  are NOT here — they have no detail route and use `overrides` instead. */
-const HOSTED_TYPES = new Set(['onboarding_guide', 'product_release']);
-
-const HC = HELP_CENTER_BASE.replace(/^\//, ''); // 'help-center' (suffixes are slash-less)
-
 export function HelpCenterRuntimeProvider({ children }: { children: ReactNode }) {
   const parent = useContext(ChatRuntimeContext);
 
@@ -60,30 +45,11 @@ export function HelpCenterRuntimeProvider({ children }: { children: ReactNode })
     () => ({
       ...(parent as ChatRuntime),
       navigation: { mode: 'host' },
-      composeContentUrl: makeComposeContentUrl({
-        hostedTypes: HOSTED_TYPES,
-        // Prefix the two hosted types' suffixes with the section base so their
-        // in-app href is `/help-center/onboarding-guides/<slug>` etc.; keep the
-        // lib defaults for every other type (used with `contentOrigin` below).
-        suffixes: {
-          ...DEFAULT_CONTENT_SUFFIXES,
-          onboarding_guide: `${HC}/onboarding-guides`,
-          product_release: `${HC}/releases`,
-        },
-        contentOrigin: CONTENT_HUB_ORIGIN,
-        // List-filter types deep-link into their EXISTING in-app list route with
-        // the `?search=<id>` param `DevSectionView` writes and the views read.
-        overrides: {
-          roadmap_item: id => ({
-            href: `${HELP_CENTER_BASE}/roadmap?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`,
-            targetPlatform: null,
-          }),
-          delivery_item: id => ({
-            href: `${HELP_CENTER_BASE}/bug-fixes-and-enhancements?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`,
-            targetPlatform: null,
-          }),
-        },
-      }),
+      // `mode: 'host'` → relative `/help-center/...` hrefs soft-nav in-app. The
+      // type→route map is shared with the app-wide chat runtime (the single
+      // source of truth in `help-center-content-href.ts`) so a card lands in the
+      // SAME place whether it's rendered on a Help Center page or in the chat.
+      composeContentUrl: composeOpenframeContentUrl,
     }),
     [parent],
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-sources.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-sources.tsx
@@ -19,25 +19,56 @@ import {
   TagIcon,
   UserIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { CONTEXT_ENTITY_KIND } from './context-types';
+import { CONTEXT_ENTITY_KIND, CONTEXT_ENTITY_MARKER } from './context-types';
 
 /**
- * Entity types in picker display order.
- *
- * POLICY and QUERY are offered alongside the rest. ⚠️ The backend
- * `ContextItemReference.type` enum (POST /chat/api/v1/messages) did not include
- * them as of the last verified spec — they are exposed ahead of the backend
- * landing the enum values (expected imminently). Until then, attaching a
- * Policy/Query and sending may 400 the whole message; if the backend rollout
- * slips, drop these two rows again.
+ * Entity types in picker display order. `marker` is the backend mention short
+ * form (from `CONTEXT_ENTITY_MARKER`) — the lib uses it to commit `@marker:id`
+ * tokens that match the backend's `MentionParser`. All eight kinds (incl. POLICY
+ * and QUERY) resolve server-side.
  */
 export const MINGO_CONTEXT_ENTITY_TYPES: ChatContextEntityType[] = [
-  { type: CONTEXT_ENTITY_KIND.DEVICE, label: 'Device', icon: <MonitorIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.SCRIPT, label: 'Script', icon: <BracketCurlyIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.TICKET, label: 'Ticket', icon: <TagIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.ORGANIZATION, label: 'Customer', icon: <IdCardIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.USER, label: 'User', icon: <UserIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.KB_ARTICLE, label: 'Knowledge Article', icon: <BookBookmarkIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.POLICY, label: 'Policy', icon: <FolderShieldIcon size={24} /> },
-  { type: CONTEXT_ENTITY_KIND.QUERY, label: 'Query', icon: <BracketCurlyEllipsisVrIcon size={24} /> },
+  {
+    type: CONTEXT_ENTITY_KIND.DEVICE,
+    label: 'Device',
+    marker: CONTEXT_ENTITY_MARKER.DEVICE,
+    icon: <MonitorIcon size={24} />,
+  },
+  {
+    type: CONTEXT_ENTITY_KIND.SCRIPT,
+    label: 'Script',
+    marker: CONTEXT_ENTITY_MARKER.SCRIPT,
+    icon: <BracketCurlyIcon size={24} />,
+  },
+  {
+    type: CONTEXT_ENTITY_KIND.TICKET,
+    label: 'Ticket',
+    marker: CONTEXT_ENTITY_MARKER.TICKET,
+    icon: <TagIcon size={24} />,
+  },
+  {
+    type: CONTEXT_ENTITY_KIND.ORGANIZATION,
+    label: 'Customer',
+    marker: CONTEXT_ENTITY_MARKER.ORGANIZATION,
+    icon: <IdCardIcon size={24} />,
+  },
+  { type: CONTEXT_ENTITY_KIND.USER, label: 'User', marker: CONTEXT_ENTITY_MARKER.USER, icon: <UserIcon size={24} /> },
+  {
+    type: CONTEXT_ENTITY_KIND.KB_ARTICLE,
+    label: 'Knowledge Article',
+    marker: CONTEXT_ENTITY_MARKER.KB_ARTICLE,
+    icon: <BookBookmarkIcon size={24} />,
+  },
+  {
+    type: CONTEXT_ENTITY_KIND.POLICY,
+    label: 'Policy',
+    marker: CONTEXT_ENTITY_MARKER.POLICY,
+    icon: <FolderShieldIcon size={24} />,
+  },
+  {
+    type: CONTEXT_ENTITY_KIND.QUERY,
+    label: 'Query',
+    marker: CONTEXT_ENTITY_MARKER.QUERY,
+    icon: <BracketCurlyEllipsisVrIcon size={24} />,
+  },
 ];

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-types.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/context-types.ts
@@ -7,19 +7,25 @@
  * alongside for display (chips + the dev window); the label is stripped when
  * building the wire payload.
  *
- * `CONTEXT_ENTITY_KIND` originally mirrored the `ContextItemReference.type`
- * enum in the chat service's OpenAPI contract (`GET /chat/v3/api-docs`) —
- * DEVICE / SCRIPT / TICKET / ORGANIZATION / USER / KB_ARTICLE. POLICY and QUERY
- * were added later on product request (Figma 31:28708 lists them). ⚠️ As of the
- * last verified spec the backend enum did NOT include POLICY/QUERY, so sending
- * a message whose `contextItems[].type` is POLICY/QUERY may be rejected by
- * `POST /chat/api/v1/messages` until the backend enum is extended. They are
- * searchable/selectable in the picker regardless.
+ * `CONTEXT_ENTITY_KIND` mirrors the backend `ContextItemType` enum
+ * (`com.openframe.data.document.chat.ContextItemType`) — DEVICE / SCRIPT /
+ * TICKET / ORGANIZATION / USER / KB_ARTICLE / POLICY / QUERY. All eight are
+ * resolved server-side (the ai-agent ships a `*ContextResolver` for each, incl.
+ * `PolicyContextResolver` + `ScheduledQueryContextResolver`).
  *
- * SINGLE SOURCE OF TRUTH — to add a kind: add one entry here, then wire its
- * label/icon in `MINGO_CONTEXT_ENTITY_TYPES` and its fetcher in `FETCHERS`
- * (both in `context-sources.tsx`). The TS `Record<ContextEntityKind, …>` on
- * `FETCHERS` makes a missing fetcher a compile error.
+ * `CONTEXT_ENTITY_MARKER` maps each kind to that enum's `marker()` — the SHORT
+ * token the backend uses for inline `@marker:id` mentions (note `KB_ARTICLE` →
+ * `kb`, not `kb_article`). The structured `contextItems[].type` wire field keeps
+ * the UPPERCASE kind (Jackson deserializes the enum by name); only the inline
+ * `@`-mention token in the message text uses the marker. The picker forwards the
+ * marker to the lib via `ChatContextEntityType.marker`, the single mapper that
+ * brings every mention to the backend's short form.
+ *
+ * SINGLE SOURCE OF TRUTH — to add a kind: add one entry here (+ its marker),
+ * then wire its label/icon in `MINGO_CONTEXT_ENTITY_TYPES` and its fetcher in
+ * `FETCHERS` (both in `context-sources.tsx`). The TS `Record<ContextEntityKind,
+ * …>` on `FETCHERS` + `CONTEXT_ENTITY_MARKER` makes a missing entry a compile
+ * error.
  */
 
 export const CONTEXT_ENTITY_KIND = {
@@ -37,6 +43,24 @@ export type ContextEntityKind = (typeof CONTEXT_ENTITY_KIND)[keyof typeof CONTEX
 
 /** All kinds as a runtime list, in declaration order. */
 export const CONTEXT_ENTITY_KINDS = Object.values(CONTEXT_ENTITY_KIND) as ContextEntityKind[];
+
+/**
+ * Backend mention markers — each kind's `ContextItemType.marker()`. This is the
+ * single mapper that reduces every `@`-mention to the backend's short form
+ * (`@device:…`, `@kb:…`, `@policy:…`). `KB_ARTICLE → 'kb'` is the only entry that
+ * isn't a plain lowercase of the kind. Fed to the lib via the picker so the
+ * committed inline token matches the backend's `MentionParser`.
+ */
+export const CONTEXT_ENTITY_MARKER: Record<ContextEntityKind, string> = {
+  DEVICE: 'device',
+  SCRIPT: 'script',
+  TICKET: 'ticket',
+  ORGANIZATION: 'organization',
+  USER: 'user',
+  KB_ARTICLE: 'kb',
+  POLICY: 'policy',
+  QUERY: 'query',
+};
 
 /** Minimal wire shape for `contextItems` / `currentView` / `recentViews`. */
 export interface ContextRef {

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/mention-tag.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/mention-tag.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * Presentational shell every per-type mention chip renders into — the real lib
+ * `Tag` (variant `badge`: ods-card + ods-border, mono-uppercase), rendered as a
+ * `<span>` via `as="span"` and shrunk to inline height.
+ *
+ * Why `as="span"`: these chips are emitted INLINE inside markdown text, which
+ * react-markdown wraps in a `<p>`. The default `<Tag>` root is a `<div>`, and a
+ * block `<div>` inside `<p>` is invalid HTML (hydration error) — same reason the
+ * lib's inline `card://` pills are spans. `Tag`'s `as` prop renders the same
+ * skin on an inline element.
+ *
+ * When `href` is set the chip is a link that opens the entity's page in a NEW
+ * TAB. Also exports the loading skeleton and an error boundary so a per-type
+ * chip is always: skeleton while fetching → resolved chip → plain id chip if the
+ * fetch throws (never crashes the message).
+ */
+
+import { Tag } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Component, type ReactNode } from 'react';
+
+// Tweaks on top of Tag's `badge` skin so the mention matches the canonical
+// context chip (`ChatContextChipStrip`). We KEEP Tag's natural height (h-8 =
+// 32px) and padding — only adjust for inline flow + a neutral hover:
+//   - `align-middle`         → vertically center the chip in the text line.
+//   - `hover:border-ods-border` → kill the badge variant's default
+//     `hover:border-ods-accent` (bright yellow border) which the context chips
+//     don't have (last hover:border utility wins via tailwind-merge).
+//   - `[&_svg]:size-4`       → 16px lead icon, matching the context chips.
+//   - `[&_svg]:text-ods-text-secondary` → grey lead icon (label stays primary),
+//     matching the context chips' muted glyph.
+// NB: no `cursor-pointer` here — the link cursor comes from the `<a>` wrapper, so
+// a chip WITHOUT an href (e.g. user — no detail page) doesn't look clickable.
+const CHIP_CLASS = 'max-w-[16rem] align-middle [&_svg]:size-4 [&_svg]:text-ods-text-secondary hover:border-ods-border';
+
+interface MentionTagProps {
+  icon?: ReactNode;
+  label: ReactNode;
+  /** Entity detail-page URL. When set, the chip opens it in a new tab. */
+  href?: string;
+}
+
+export function MentionTag({ icon, label, href }: MentionTagProps) {
+  // Wrap the label so it's NOT a string — Tag only sets the native `title`
+  // tooltip for string labels, and that browser tooltip (a grey box on hover)
+  // looks unpolished. Tag still truncates via its own label span.
+  const chip = <Tag as="span" variant="badge" icon={icon} label={<>{label}</>} className={CHIP_CLASS} />;
+  if (!href) return chip;
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="no-underline">
+      {chip}
+    </a>
+  );
+}
+
+/** Loading state — same chip shell with an inline skeleton bar for the label.
+ *  (An inline span, not the lib `Skeleton` div — the chip lives inside a `<p>`.) */
+export function MentionTagSkeleton({ icon }: { icon?: ReactNode }) {
+  return (
+    <MentionTag
+      icon={icon}
+      label={<span className="inline-block h-3 w-20 animate-pulse rounded bg-ods-border align-middle" />}
+    />
+  );
+}
+
+/**
+ * Catches a fetch throw in a per-type chip and renders the fallback (a plain id
+ * chip) instead of letting the error propagate up and blank the whole message.
+ */
+export class MentionErrorBoundary extends Component<{ fallback: ReactNode; children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/relay-mention-chips.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/relay-mention-chips.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * Self-fetching mention chips for the GraphQL-resolvable entity types — the
+ * `@marker:id` analogue of `[card://]` entity cards. Each suspends on first
+ * fetch (→ skeleton), reads from the Relay store on streaming remounts
+ * (`store-or-network`, no flash), and falls back to a plain id chip on error.
+ *
+ * id semantics: a mention carries the backend `ContextItemType.idHint`, NOT the
+ * Relay node id (confirmed: device idHint = machineId, and `device(machineId:)`
+ * resolves it). So:
+ *   - device       → machineId          → `device(machineId:)`               → /devices/details/{machineId}
+ *   - organization → organizationId      → `organizationByOrganizationId(...)` → /customers/details/{organizationId}
+ *   - kb article   → knowledgeBaseItemId → `knowledgeBaseItem(id:)`            → /knowledge-base/details/{id}
+ *     (KB's idHint equals the node id — there's no separate field — so the
+ *      `id: ID!` lookup is correct; org's organizationId is a DISTINCT field,
+ *      hence the dedicated `organizationByOrganizationId` query.)
+ */
+
+import { type ReactNode, Suspense } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import type { relayMentionChipsDeviceQuery } from '@/__generated__/relayMentionChipsDeviceQuery.graphql';
+import type { relayMentionChipsKbQuery } from '@/__generated__/relayMentionChipsKbQuery.graphql';
+import type { relayMentionChipsOrgQuery } from '@/__generated__/relayMentionChipsOrgQuery.graphql';
+import { MentionErrorBoundary, MentionTag, MentionTagSkeleton } from './mention-tag';
+
+interface MentionChipProps {
+  id: string;
+  icon?: ReactNode;
+}
+
+// ───────────────────────────── Device ───────────────────────────────────────
+
+const DEVICE_QUERY = graphql`
+  query relayMentionChipsDeviceQuery($machineId: String!) {
+    device(machineId: $machineId) {
+      hostname
+      displayName
+    }
+  }
+`;
+
+function DeviceInner({ id, icon }: MentionChipProps) {
+  const data = useLazyLoadQuery<relayMentionChipsDeviceQuery>(
+    DEVICE_QUERY,
+    { machineId: id },
+    { fetchPolicy: 'store-or-network' },
+  );
+  const d = data.device;
+  return <MentionTag icon={icon} label={d?.displayName || d?.hostname || id} href={`/devices/details/${id}`} />;
+}
+
+export function DeviceMentionChip({ id, icon }: MentionChipProps) {
+  return (
+    <MentionErrorBoundary fallback={<MentionTag icon={icon} label={id} href={`/devices/details/${id}`} />}>
+      <Suspense fallback={<MentionTagSkeleton icon={icon} />}>
+        <DeviceInner id={id} icon={icon} />
+      </Suspense>
+    </MentionErrorBoundary>
+  );
+}
+
+// ─────────────────────────── Organization ───────────────────────────────────
+
+const ORG_QUERY = graphql`
+  query relayMentionChipsOrgQuery($organizationId: String!) {
+    organizationByOrganizationId(organizationId: $organizationId) {
+      name
+    }
+  }
+`;
+
+function OrgInner({ id, icon }: MentionChipProps) {
+  // The mention id IS the organizationId (idHint), which the customers route
+  // also keys on — so it's both the query arg and the href segment.
+  const data = useLazyLoadQuery<relayMentionChipsOrgQuery>(
+    ORG_QUERY,
+    { organizationId: id },
+    { fetchPolicy: 'store-or-network' },
+  );
+  const o = data.organizationByOrganizationId;
+  return <MentionTag icon={icon} label={o?.name || id} href={`/customers/details/${id}`} />;
+}
+
+export function OrganizationMentionChip({ id, icon }: MentionChipProps) {
+  return (
+    <MentionErrorBoundary fallback={<MentionTag icon={icon} label={id} href={`/customers/details/${id}`} />}>
+      <Suspense fallback={<MentionTagSkeleton icon={icon} />}>
+        <OrgInner id={id} icon={icon} />
+      </Suspense>
+    </MentionErrorBoundary>
+  );
+}
+
+// ───────────────────────────── KB Article ───────────────────────────────────
+
+const KB_QUERY = graphql`
+  query relayMentionChipsKbQuery($id: ID!) {
+    knowledgeBaseItem(id: $id) {
+      name
+    }
+  }
+`;
+
+function KbInner({ id, icon }: MentionChipProps) {
+  const data = useLazyLoadQuery<relayMentionChipsKbQuery>(KB_QUERY, { id }, { fetchPolicy: 'store-or-network' });
+  const k = data.knowledgeBaseItem;
+  return <MentionTag icon={icon} label={k?.name || id} href={`/knowledge-base/details/${id}`} />;
+}
+
+export function KbMentionChip({ id, icon }: MentionChipProps) {
+  return (
+    <MentionErrorBoundary fallback={<MentionTag icon={icon} label={id} href={`/knowledge-base/details/${id}`} />}>
+      <Suspense fallback={<MentionTagSkeleton icon={icon} />}>
+        <KbInner id={id} icon={icon} />
+      </Suspense>
+    </MentionErrorBoundary>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/render-mention.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/render-mention.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+/**
+ * `renderMention` for `<EmbeddableChat>` — the `@marker:id` analogue of
+ * `renderEntityCard` for `[card://]`. The lib parses an inline mention token and
+ * calls this; we dispatch by marker to a SELF-FETCHING chip (each entity type
+ * owns its own fetcher + detail-page link), mirroring how `card://` markers
+ * route to per-type entity cards.
+ *
+ * Module-level (not a hook): it needs only the static entity-type config, so a
+ * stable identity falls out for free — the lib's per-message memo relies on
+ * `renderMention` keeping reference equality across streaming chunks.
+ *
+ * Coverage = all eight markers the agent can emit. GraphQL types (device,
+ * customer, kb) resolve via Relay; REST/ai-agent types (policy, query, user,
+ * script, ticket) via `RestMentionChip`. Every chip falls back to a plain id
+ * chip (clickable where a route exists) if its fetch can't resolve a name.
+ * Unknown marker → bare token.
+ */
+
+import type { ReactNode } from 'react';
+import { MINGO_CONTEXT_ENTITY_TYPES } from '../context-sources';
+import { CONTEXT_ENTITY_MARKER as M } from '../context-types';
+import { DeviceMentionChip, KbMentionChip, OrganizationMentionChip } from './relay-mention-chips';
+import { RestMentionChip } from './rest-mention-chips';
+
+/** marker → lead icon, taken from the picker's entity-type config. */
+const ICON_BY_MARKER = new Map<string, ReactNode>(
+  MINGO_CONTEXT_ENTITY_TYPES.flatMap(t => (t.marker ? [[t.marker, t.icon] as const] : [])),
+);
+
+export function renderMingoMention({ marker, id }: { marker: string; id: string }): ReactNode {
+  const icon = ICON_BY_MARKER.get(marker);
+  switch (marker) {
+    case M.DEVICE:
+      return <DeviceMentionChip id={id} icon={icon} />;
+    case M.ORGANIZATION:
+      return <OrganizationMentionChip id={id} icon={icon} />;
+    case M.KB_ARTICLE:
+      return <KbMentionChip id={id} icon={icon} />;
+    case M.POLICY:
+    case M.QUERY:
+    case M.USER:
+    case M.SCRIPT:
+    case M.TICKET:
+      return <RestMentionChip marker={marker} id={id} icon={icon} />;
+    default:
+      // Unknown marker → let the lib render the bare `@marker:id` token.
+      return null;
+  }
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/rest-mention-chips.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/mention-chips/rest-mention-chips.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Self-fetching mention chips for the REST / ai-agent-GraphQL entity types. One
+ * generic component (`RestMentionChip`) backed by a per-marker async resolver,
+ * driven by a TanStack `useSuspenseQuery` so the skeleton/Suspense story matches
+ * the Relay chips. Resolvers never throw — they degrade to `{ label: id }` on a
+ * failed response — so the chip always renders (id when the name can't load).
+ *
+ * id semantics + routes (per the picker in `rest-items.tsx` / `batch-items.tsx`):
+ *   - policy → fleet `getPolicy(policyId)`        → /monitoring/policy/{id}
+ *   - query  → fleet `getQuery(queryId)`          → /monitoring/query/{id}
+ *   - user   → REST `/api/users/{userId}`         → (no detail route)
+ *   - script → tactical `getScripts()` + find     → /scripts/details/{id}
+ *   - ticket → ai-agent `ticket(id:)` GraphQL      → /tickets/dialog?id={id}
+ */
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { type ReactNode, Suspense } from 'react';
+import { apiClient } from '@/lib/api-client';
+import { fleetApiClient } from '@/lib/fleet-api-client';
+import { tacticalApiClient } from '@/lib/tactical-api-client';
+import { MentionErrorBoundary, MentionTag, MentionTagSkeleton } from './mention-tag';
+
+interface Resolved {
+  label: string;
+  href?: string;
+}
+
+async function resolvePolicy(id: string): Promise<Resolved> {
+  const res = await fleetApiClient.getPolicy(Number(id));
+  return { label: (res.ok && res.data?.policy?.name) || id, href: `/monitoring/policy/${id}` };
+}
+
+async function resolveQuery(id: string): Promise<Resolved> {
+  const res = await fleetApiClient.getQuery(Number(id));
+  return { label: (res.ok && res.data?.name) || id, href: `/monitoring/query/${id}` };
+}
+
+async function resolveUser(id: string): Promise<Resolved> {
+  const res = await apiClient.get<{ firstName?: string; lastName?: string; email?: string }>(
+    `/api/users/${encodeURIComponent(id)}`,
+  );
+  const u = res.ok ? res.data : undefined;
+  const fullName = u ? [u.firstName, u.lastName].filter(Boolean).join(' ') : '';
+  return { label: fullName || u?.email || id };
+}
+
+async function resolveScript(id: string): Promise<Resolved> {
+  const res = await tacticalApiClient.getScripts();
+  const list = (res.ok && Array.isArray(res.data) ? res.data : []) as Array<{ id: number | string; name?: string }>;
+  const s = list.find(x => String(x.id) === id);
+  return { label: s?.name || id, href: `/scripts/details/${id}` };
+}
+
+interface TicketEnvelope {
+  data?: { ticket?: { title?: string; ticketNumber?: number } };
+}
+async function resolveTicket(id: string): Promise<Resolved> {
+  const res = await apiClient.post<TicketEnvelope>('/chat/graphql', {
+    query: 'query MingoMentionTicket($id: ID!) { ticket(id: $id) { title ticketNumber } }',
+    variables: { id },
+  });
+  const t = res.ok ? res.data?.data?.ticket : undefined;
+  const label = t?.title || (t?.ticketNumber != null ? `#${t.ticketNumber}` : id);
+  return { label, href: `/tickets/dialog?id=${encodeURIComponent(id)}` };
+}
+
+const RESOLVERS: Record<string, (id: string) => Promise<Resolved>> = {
+  policy: resolvePolicy,
+  query: resolveQuery,
+  user: resolveUser,
+  script: resolveScript,
+  ticket: resolveTicket,
+};
+
+interface RestMentionChipProps {
+  marker: string;
+  id: string;
+  icon?: ReactNode;
+}
+
+function RestInner({ marker, id, icon }: RestMentionChipProps) {
+  const { data } = useSuspenseQuery({
+    queryKey: ['mingo-mention', marker, id],
+    queryFn: () => RESOLVERS[marker](id),
+    staleTime: 5 * 60 * 1000,
+  });
+  return <MentionTag icon={icon} label={data.label} href={data.href} />;
+}
+
+export function RestMentionChip({ marker, id, icon }: RestMentionChipProps) {
+  return (
+    <MentionErrorBoundary fallback={<MentionTag icon={icon} label={id} />}>
+      <Suspense fallback={<MentionTagSkeleton icon={icon} />}>
+        <RestInner marker={marker} id={id} icon={icon} />
+      </Suspense>
+    </MentionErrorBoundary>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/context/relay-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/context/relay-items.tsx
@@ -29,7 +29,7 @@ const DEVICES_FRAGMENT = graphql`
   @refetchable(queryName: "relayItemsDevicesPaginationQuery")
   @argumentDefinitions(search: { type: "String" }, first: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
     devices(search: $search, first: $first, after: $after) @connection(key: "relayItemsDevices_devices") {
-      edges { node { id hostname displayName status } }
+      edges { node { id machineId hostname displayName status } }
     }
   }
 `;
@@ -56,8 +56,11 @@ export function DeviceItems({ query, selectedKeys, onToggle, atLimit }: ContextI
           ? [
               {
                 type: CONTEXT_ENTITY_KIND.DEVICE,
-                id: e.node.id,
-                label: e.node.displayName || e.node.hostname || e.node.id,
+                // Use `machineId` (not the GraphQL/relay node id) — it's the id
+                // the backend's DEVICE context resolver + `@device:<id>` mention
+                // marker expect (ContextItemType.DEVICE idHint = "machineId").
+                id: e.node.machineId,
+                label: e.node.displayName || e.node.hostname || e.node.machineId,
                 description: e.node.status ?? undefined,
               },
             ]

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-realtime-subscription.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-realtime-subscription.ts
@@ -345,9 +345,21 @@ function useDialogChunkProcessor(dialogId: string, options: UseDialogChunkProces
 
       onUserMessage: (
         text: string,
-        meta?: { ownerType?: string; displayName?: string; userId?: string; streamSeq?: number },
+        meta?: {
+          ownerType?: string;
+          displayName?: string;
+          userId?: string;
+          streamSeq?: number;
+          contextItems?: Array<{ type: string; id: string }>;
+        },
       ) => {
         if (meta?.userId && meta.userId === currentUserId) return;
+        // The `MESSAGE_REQUEST` chunk carries only `{ type, id }` — no label.
+        // Fall back to the id as the chip text; the lib resolves the icon by
+        // `type` from `contextPicker.entityTypes`.
+        const contextItems = meta?.contextItems?.length
+          ? meta.contextItems.map(i => ({ type: i.type, id: i.id, label: i.id }))
+          : undefined;
         addMessage(dialogId, {
           id: `user-${Date.now()}-${Math.random().toString(16).slice(2)}`,
           role: 'user',
@@ -357,6 +369,7 @@ function useDialogChunkProcessor(dialogId: string, options: UseDialogChunkProces
           avatar: null,
           timestamp: new Date(),
           streamSeq: meta?.streamSeq,
+          contextItems,
         });
       },
 

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-unified-chat-state.ts
@@ -184,9 +184,15 @@ export function useMingoUnifiedChatState(): MingoUnifiedChat {
       // send time AND its memoized message keeps a stable `getTime()` across
       // realtime chunks (a missing/`new Date()` timestamp would re-render the
       // whole list and collapse open menus on every chunk).
+      // Forward attached entity-context items on user messages so the lib
+      // renders the read-only chip strip under the bubble (Figma 1:6437). They
+      // ride the optimistic message (full `ChatContextItem` with labels) and the
+      // realtime `MESSAGE_REQUEST` echo; the lib resolves each chip's icon from
+      // `contextPicker.entityTypes` by `type`.
+      const context = role === 'user' && m.contextItems?.length ? { contextItems: m.contextItems } : {};
       const unified: UnifiedChatMessage = Array.isArray(m.content)
-        ? { id: m.id, role, content: '', segments: m.content, timestamp: m.timestamp, ...identity }
-        : { id: m.id, role, content: m.content, timestamp: m.timestamp, ...identity };
+        ? { id: m.id, role, content: '', segments: m.content, timestamp: m.timestamp, ...identity, ...context }
+        : { id: m.id, role, content: m.content, timestamp: m.timestamp, ...identity, ...context };
       cache.set(m, unified);
       return unified;
     });

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAiModelStatus } from '@/app/hooks/use-ai-model';
 import { EVENT_SUBTYPE, trackDashboardActivity } from '@/lib/analytics';
 import { isSaasTenantMode } from '@/lib/app-mode';
+import { featureFlags } from '@/lib/feature-flags';
 import { useMingoChat } from './hooks/use-mingo-chat';
 import { useMingoDialog } from './hooks/use-mingo-dialog';
 import { useMingoDialogSelection } from './hooks/use-mingo-dialog-selection';
@@ -236,8 +237,13 @@ export default function Mingo() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [activeDialogId, isDraftChat, sidebarOpen, router]);
 
+  // The standalone `/mingo` page is the LEGACY surface. When `mingo-sidebar` is
+  // on, Mingo lives in the in-layout sidebar drawer instead, so this route is
+  // fully hidden — redirect any direct/bookmarked hit to the dashboard. (Flags
+  // are guaranteed loaded here: `FeatureFlagsGate` blocks the app shell until
+  // then, so the imperative read is stable.) Also covers the non-SaaS guard.
   useEffect(() => {
-    if (!isSaasTenantMode()) {
+    if (!isSaasTenantMode() || featureFlags.mingoSidebar.enabled()) {
       router.replace('/dashboard');
       return;
     }
@@ -349,7 +355,7 @@ export default function Mingo() {
     ],
   );
 
-  if (!isSaasTenantMode()) {
+  if (!isSaasTenantMode() || featureFlags.mingoSidebar.enabled()) {
     return null;
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/queries/dialogs-queries.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/queries/dialogs-queries.ts
@@ -93,6 +93,10 @@ export function getMingoDialogMessagesQuery() {
             type
             ... on TextData {
               text
+              contextItems {
+                type
+                id
+              }
             }
 
             ... on ThinkingData {

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/policy-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/policy-details-view.tsx
@@ -13,6 +13,8 @@ import { PenEditIcon, TrashIcon } from '@flamingo-stack/openframe-frontend-core/
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
 import { ScriptEditor } from '../../../scripts/components/script/script-editor';
 import { ConfirmDeleteMonitoringModal } from '../../components/confirm-delete-monitoring-modal';
 import { usePolicies } from '../../hooks/use-policies';
@@ -38,6 +40,12 @@ export function PolicyDetailsView({ policyId }: PolicyDetailsViewProps) {
   const { policyDetails, isLoading, error } = usePolicyDetails(isValidId ? numericId : null);
   const { deletePolicy, isDeleting } = usePolicies();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  // Register this policy as the Mingo "open view" (passive context) so the agent
+  // gets the user's working context on the next message; cleared → recent views.
+  useTrackOpenView(
+    policyDetails ? { type: CONTEXT_ENTITY_KIND.POLICY, id: policyId, label: policyDetails.name } : null,
+  );
 
   const handleBack = useSafeBack('/monitoring?tab=policies');
 

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
@@ -14,6 +14,8 @@ import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
 import { ScriptEditor } from '../../../scripts/components/script/script-editor';
 import { ConfirmDeleteMonitoringModal } from '../../components/confirm-delete-monitoring-modal';
 import { useQueries } from '../../hooks/use-queries';
@@ -42,6 +44,10 @@ export function QueryDetailsView({ queryId }: QueryDetailsViewProps) {
   const { rows, isLoading: isReportLoading } = useQueryReport(isValidId ? numericId : null);
   const { deleteQuery, isDeleting } = useQueries();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  // Register this query as the Mingo "open view" (passive context) so the agent
+  // gets the user's working context on the next message; cleared → recent views.
+  useTrackOpenView(queryDetails ? { type: CONTEXT_ENTITY_KIND.QUERY, id: queryId, label: queryDetails.name } : null);
 
   const handleBack = useSafeBack('/monitoring?tab=queries');
 

--- a/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-columns.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-columns.tsx
@@ -8,6 +8,7 @@ import {
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button, type ColumnDef, type Row, SplitButton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { resolveNotificationAction } from '@/app/components/notifications/notification-navigation';
+import { openMingoDialogInDrawer } from '@/app/components/notifications/open-mingo-dialog';
 import { formatDate, formatTime } from '@/lib/format-date';
 
 export interface NotificationRow {
@@ -67,17 +68,24 @@ export function buildNotificationColumns({
       cell: ({ row }: { row: Row<NotificationRow> }) => {
         const action = resolveNotificationAction(row.original.notification);
         if (!action) return null;
+        // A Mingo dialog has no URL (it lives in the in-layout drawer once the
+        // `/mingo` page is retired), so it opens via click instead of an href +
+        // new tab. Route actions keep the open-in-new-tab anchor behavior.
+        const isRoute = 'route' in action;
+        const openDrawer = isRoute ? undefined : () => openMingoDialogInDrawer(action.mingoDialogId);
         return (
           <div data-no-row-click className="flex w-full justify-end">
             <SplitButton
               variant="outline"
-              href={action.route}
+              href={isRoute ? action.route : undefined}
+              onClick={openDrawer}
               groupAriaLabel={action.label}
               iconAction={{
                 icon: <ArrowRightUpIcon className="text-ods-text-secondary" />,
-                'aria-label': `Open ${action.label} in new tab`,
-                href: action.route,
-                openInNewTab: true,
+                'aria-label': isRoute ? `Open ${action.label} in new tab` : `Open ${action.label}`,
+                href: isRoute ? action.route : undefined,
+                onClick: openDrawer,
+                openInNewTab: isRoute,
               }}
             >
               {action.label}

--- a/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-columns.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-columns.tsx
@@ -7,7 +7,7 @@ import {
   TrashIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button, type ColumnDef, type Row, SplitButton } from '@flamingo-stack/openframe-frontend-core/components/ui';
-import { resolveNotificationAction } from '@/app/components/notifications/notification-navigation';
+import { isPendingApproval, resolveNotificationAction } from '@/app/components/notifications/notification-navigation';
 import { openMingoDialogInDrawer } from '@/app/components/notifications/open-mingo-dialog';
 import { formatDate, formatTime } from '@/lib/format-date';
 
@@ -72,7 +72,16 @@ export function buildNotificationColumns({
         // `/mingo` page is retired), so it opens via click instead of an href +
         // new tab. Route actions keep the open-in-new-tab anchor behavior.
         const isRoute = 'route' in action;
-        const openDrawer = isRoute ? undefined : () => openMingoDialogInDrawer(action.mingoDialogId);
+        // Opening clears unread (the drawer has no URL, so the location-based
+        // auto-reader can't) — except a pending approval, which stays unread
+        // until it's approved/rejected. `onMarkRead` is only wired for the
+        // unread variant; it's a no-op for already-read rows.
+        const openDrawer = isRoute
+          ? undefined
+          : () => {
+              openMingoDialogInDrawer(action.mingoDialogId);
+              if (!isPendingApproval(row.original.notification)) onMarkRead?.(row.original.id);
+            };
         return (
           <div data-no-row-click className="flex w-full justify-end">
             <SplitButton

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
@@ -1,4 +1,8 @@
-import { ADMIN_APPROVAL_REQUEST_CONTEXT_TYPE, type Notification } from '@flamingo-stack/openframe-frontend-core';
+import {
+  ADMIN_APPROVAL_REQUEST_CONTEXT_TYPE,
+  getApprovalMeta,
+  type Notification,
+} from '@flamingo-stack/openframe-frontend-core';
 import { featureFlags } from '@/lib/feature-flags';
 
 // Backend `NotificationContext.type` discriminators (the string `type` field; the same set the
@@ -81,6 +85,19 @@ export function resolveNotificationAction(notification: Notification): Notificat
   }
 
   return null;
+}
+
+/**
+ * A still-open approval request — its entity should NOT be auto-marked read when
+ * merely opened (it clears only when approved/rejected). Shared by every place
+ * that marks a notification read on open (the location auto-reader, the drawer
+ * tile/table, the desktop click) so the rule stays uniform.
+ */
+export function isPendingApproval(notification: Notification): boolean {
+  const approval = getApprovalMeta(notification);
+  if (!approval) return false;
+  const resolution = approval.resolution?.toUpperCase();
+  return !resolution || resolution === 'PENDING';
 }
 
 /** Convenience for callers that only need a router route (drawer actions yield null). */

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
@@ -1,4 +1,5 @@
 import { ADMIN_APPROVAL_REQUEST_CONTEXT_TYPE, type Notification } from '@flamingo-stack/openframe-frontend-core';
+import { featureFlags } from '@/lib/feature-flags';
 
 // Backend `NotificationContext.type` discriminators (the string `type` field; the same set the
 // concrete `__typename` subtypes carry in schema.graphql). NATS payloads carry only this string,
@@ -32,13 +33,27 @@ const TICKET_CONTEXT_TYPES = new Set<string>([
   ADMIN_MESSAGE_PUBLISHED_CONTEXT_TYPE,
 ]);
 
-export interface NotificationAction {
-  label: string;
-  route: string;
-}
+/**
+ * A notification's primary action. Either a plain `route` the host pushes onto
+ * the router, or — for a Mingo dialog once the standalone `/mingo` page is
+ * retired behind `mingo-sidebar` — a `mingoDialogId` the host opens in the
+ * in-layout chat drawer (the drawer has no URL, so it can't be a route).
+ */
+export type NotificationAction = { label: string; route: string } | { label: string; mingoDialogId: string };
 
 const mingoDialogRoute = (dialogId: string) => `/mingo?dialogId=${encodeURIComponent(dialogId)}`;
 const ticketRoute = (ticketId: string) => `/tickets/dialog?id=${encodeURIComponent(ticketId)}`;
+
+/**
+ * Action for a Mingo dialog. With `mingo-sidebar` ON the `/mingo` page is gone
+ * (it redirects to the dashboard), so the dialog opens in the in-layout drawer
+ * via `mingoDialogId`; the consumer drives the shared Mingo store. Legacy (flag
+ * OFF) still routes to the page. Tickets are unaffected — they always route.
+ */
+const mingoDialogAction = (dialogId: string): NotificationAction =>
+  featureFlags.mingoSidebar.enabled()
+    ? { label: 'Open in Mingo', mingoDialogId: dialogId }
+    : { label: 'Open in Mingo', route: mingoDialogRoute(dialogId) };
 
 /**
  * Resolve the navigation action a notification offers (button label + route), or null when it
@@ -53,7 +68,7 @@ export function resolveNotificationAction(notification: Notification): Notificat
   // Approval requests live in their ticket when one exists, otherwise the mingo dialog.
   if (contextType === ADMIN_APPROVAL_REQUEST_CONTEXT_TYPE) {
     if (ticketId) return { label: 'Open Ticket', route: ticketRoute(ticketId) };
-    if (dialogId) return { label: 'Open in Mingo', route: mingoDialogRoute(dialogId) };
+    if (dialogId) return mingoDialogAction(dialogId);
     return null;
   }
 
@@ -62,15 +77,16 @@ export function resolveNotificationAction(notification: Notification): Notificat
   }
 
   if (contextType === ADMIN_AI_MESSAGE_CONTEXT_TYPE && dialogId) {
-    return { label: 'Open in Mingo', route: mingoDialogRoute(dialogId) };
+    return mingoDialogAction(dialogId);
   }
 
   return null;
 }
 
-/** Convenience for callers that only need the route (e.g. tile body navigation). */
+/** Convenience for callers that only need a router route (drawer actions yield null). */
 export function resolveNotificationRoute(notification: Notification): string | null {
-  return resolveNotificationAction(notification)?.route ?? null;
+  const action = resolveNotificationAction(notification);
+  return action && 'route' in action ? action.route : null;
 }
 
 /**

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
@@ -68,8 +68,9 @@ import {
   ADMIN_AI_MESSAGE_CONTEXT_TYPE,
   CONTEXT_TYPENAME_BY_TYPE,
   notificationTargetsLocation,
-  resolveNotificationRoute,
+  resolveNotificationAction,
 } from './notification-navigation';
+import { openMingoDialogInDrawer } from './open-mingo-dialog';
 import { useApproveRequest } from './use-approve-request';
 
 const DRAWER_PAGE_SIZE = 30;
@@ -238,14 +239,14 @@ interface NavigationTileWrapperProps {
 /** Wraps a tile so its body navigates to the notification's target entity; inner buttons keep their own clicks. */
 function NavigationTileWrapper({ notification, helpers, children }: NavigationTileWrapperProps) {
   const router = useRouter();
-  const { close } = useNotifications();
-  const route = resolveNotificationRoute(notification);
+  const { close, markRead } = useNotifications();
+  const action = resolveNotificationAction(notification);
 
   const navigate = useCallback(
     (event: ReactMouseEvent<HTMLDivElement> | ReactKeyboardEvent<HTMLDivElement>) => {
       // Inner controls (Approve/Reject, expand toggle, dismiss) own their own clicks.
       if ((event.target as HTMLElement).closest('button')) return;
-      if (!route) return;
+      if (!action) return;
       if ('key' in event) {
         if (event.key !== 'Enter' && event.key !== ' ') return;
         event.preventDefault();
@@ -253,12 +254,20 @@ function NavigationTileWrapper({ notification, helpers, children }: NavigationTi
       close();
       // Settle (dismiss the live tile) but keep it unread until the user acts on the entity.
       helpers.onSettle(notification.id);
-      router.push(route);
+      if ('mingoDialogId' in action) {
+        openMingoDialogInDrawer(action.mingoDialogId);
+        // The drawer changes no URL, so the location-based `EntityViewAutoReader`
+        // can't clear this one — mark it read here to match the route flow.
+        // Pending approvals stay unread until decided (same rule as the reader).
+        if (!isPendingApproval(notification)) markRead(notification.id);
+      } else {
+        router.push(action.route);
+      }
     },
-    [route, close, helpers, notification.id, router],
+    [action, close, markRead, helpers, notification, router],
   );
 
-  if (!route) return <>{children}</>;
+  if (!action) return <>{children}</>;
 
   return (
     <div
@@ -366,8 +375,8 @@ function NotificationsDataInner({
       if (isApprovalNotification(notification) && getApprovalMeta(notification)) {
         return <ApprovalTileWithNavigation notification={notification} helpers={helpers} onDecide={decideApproval} />;
       }
-      // Non-approval tiles get the default look, made clickable only when they resolve to a route.
-      if (resolveNotificationRoute(notification)) {
+      // Non-approval tiles get the default look, made clickable only when they resolve to an action.
+      if (resolveNotificationAction(notification)) {
         return (
           <NavigationTileWrapper notification={notification} helpers={helpers}>
             <NotificationTile
@@ -528,7 +537,7 @@ function maybeShowDesktopNotification(
     return;
   }
 
-  const route = resolveNotificationRoute({
+  const action = resolveNotificationAction({
     id: relayId,
     title,
     createdAt: Date.now(),
@@ -547,7 +556,11 @@ function maybeShowDesktopNotification(
     });
     notification.onclick = () => {
       window.focus();
-      if (route) navigate(route);
+      // A Mingo dialog opens in the drawer (no URL); everything else is a route.
+      if (action) {
+        if ('mingoDialogId' in action) openMingoDialogInDrawer(action.mingoDialogId);
+        else navigate(action.route);
+      }
       notification.close();
     };
   } catch {

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
@@ -67,6 +67,7 @@ import { notificationGlobalId } from '@/lib/relay-id';
 import {
   ADMIN_AI_MESSAGE_CONTEXT_TYPE,
   CONTEXT_TYPENAME_BY_TYPE,
+  isPendingApproval,
   notificationTargetsLocation,
   resolveNotificationAction,
 } from './notification-navigation';
@@ -424,14 +425,6 @@ function NotificationsDataInner({
   );
 }
 
-/** A still-actionable approval request: stays unread until the user actually approves/rejects it. */
-function isPendingApproval(notification: Notification): boolean {
-  const approval = getApprovalMeta(notification);
-  if (!approval) return false;
-  const resolution = approval.resolution?.toUpperCase();
-  return !resolution || resolution === 'PENDING';
-}
-
 /**
  * Marks an unread notification read once the user opens the entity it points at (the mingo
  * dialog, the ticket, …). Works off the shared route mapping so it stays consistent across
@@ -527,6 +520,7 @@ function maybeShowDesktopNotification(
   title: string,
   description: string | null,
   navigate: (route: string) => void,
+  markRead: (notificationId: string) => void,
 ): void {
   if (
     typeof window === 'undefined' ||
@@ -558,8 +552,15 @@ function maybeShowDesktopNotification(
       window.focus();
       // A Mingo dialog opens in the drawer (no URL); everything else is a route.
       if (action) {
-        if ('mingoDialogId' in action) openMingoDialogInDrawer(action.mingoDialogId);
-        else navigate(action.route);
+        if ('mingoDialogId' in action) {
+          openMingoDialogInDrawer(action.mingoDialogId);
+          // No route change → the location auto-reader can't clear it; mark read
+          // here. Approval requests are the exception (they clear on decision,
+          // not on open) — leave those unread.
+          if (payload.context?.type !== ADMIN_APPROVAL_REQUEST_CONTEXT_TYPE) markRead(relayId);
+        } else {
+          navigate(action.route);
+        }
       }
       notification.close();
     };
@@ -571,13 +572,15 @@ function maybeShowDesktopNotification(
 function NotificationsLiveBridge({ userId }: NotificationsLiveBridgeProps) {
   const environment = useRelayEnvironment();
   const router = useRouter();
-  const { showDesktopPopups } = useNotifications();
+  const { showDesktopPopups, markRead } = useNotifications();
   const subject = `${NOTIFICATION_SUBJECT_PREFIX}.${userId}.${NOTIFICATION_SUBJECT_SUFFIX}`;
   const environmentRef = useRef(environment);
   environmentRef.current = environment;
   // Refs keep the NATS subscription callback dependency-free (no resubscribe on toggle/navigation).
   const showDesktopPopupsRef = useRef(showDesktopPopups);
   showDesktopPopupsRef.current = showDesktopPopups;
+  const markReadRef = useRef(markRead);
+  markReadRef.current = markRead;
   const routerRef = useRef(router);
   routerRef.current = router;
 
@@ -652,7 +655,14 @@ function NotificationsLiveBridge({ userId }: NotificationsLiveBridgeProps) {
       }
 
       if (showDesktopPopupsRef.current) {
-        maybeShowDesktopNotification(payload, relayId, title, description, route => routerRef.current.push(route));
+        maybeShowDesktopNotification(
+          payload,
+          relayId,
+          title,
+          description,
+          route => routerRef.current.push(route),
+          id => markReadRef.current(id),
+        );
       }
 
       // The bucket was already bumped locally (above) so the sidebar is instantly consistent

--- a/openframe/services/openframe-frontend/src/app/components/notifications/open-mingo-dialog.ts
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/open-mingo-dialog.ts
@@ -1,0 +1,17 @@
+import { useMingoLauncherStore } from '@/app/(app)/mingo/stores/mingo-launcher-store';
+import { useMingoMessagesStore } from '@/app/(app)/mingo/stores/mingo-messages-store';
+
+/**
+ * Opens a Mingo dialog in the in-layout chat drawer — the surface that replaced
+ * the standalone `/mingo` page behind `mingo-sidebar`. Both surfaces share the
+ * module-level Mingo store, so setting the active dialog + opening the launcher
+ * is all the drawer needs to render it; `resetUnread` clears the dialog's own
+ * badge. Plain function (reads stores via `getState`), so it's callable from
+ * event handlers and non-React module code (e.g. a desktop-notification click).
+ */
+export function openMingoDialogInDrawer(dialogId: string): void {
+  const messages = useMingoMessagesStore.getState();
+  messages.setActiveDialogId(dialogId);
+  messages.resetUnread(dialogId);
+  useMingoLauncherStore.getState().setOpen(true);
+}

--- a/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
@@ -32,40 +32,24 @@ const CONTENT_HUB_ORIGIN = 'https://www.flamingo.run';
 import { type ChatRuntime, ChatRuntimeContext } from '@flamingo-stack/openframe-frontend-core/contexts';
 import {
   buildListUrl as buildEntityCardListUrl,
-  type ComposeContentUrl,
   clearEmbedProxyAuth,
-  DEV_SECTION_PARAM_KEYS,
   type EmbedAuthAdapter,
   setEmbedAuthAdapter,
 } from '@flamingo-stack/openframe-frontend-core/utils';
 import { type ReactNode, useMemo } from 'react';
+import { composeOpenframeChatContentUrl } from '@/app/(app)/help-center/help-center-content-href';
 import { runtimeEnv } from '@/lib/runtime-config';
 
 /**
- * Unified content-href seam for the openframe embedder (the same `composeContentUrl`
- * the hub's own page-view cards + chat cards use). openframe hosts NONE of the hub's
- * content in-app, so every card opens OUT to its real home. Two cases:
- *
- *   1. roadmap / delivery — path DIFFERS per platform (openframe `/roadmap` vs
- *      flamingo `/roadmap-and-releases?tab=…`), so a verbatim `externalUrl` can't
- *      be trusted. Rebuild against the flamingo unified page from the item's id
- *      (mirrors `SECTION_PATH_BY_PLATFORM.flamingo` in
- *      `multi-platform-hub/lib/utils/dev-section-url.ts`). `internal_task` is NOT
- *      here — its `externalUrl` is a platform-agnostic `app.clickup.com` link.
- *   2. everything else (blog / release / case-study / podcast / …) — the
- *      RAG-authoritative `externalUrl` verbatim (already an absolute
- *      owning-platform URL), identical to the hub's own composer.
+ * Content-href seam for the openframe embedder. The type→route map is shared
+ * with the Help Center pages (single source of truth in
+ * `help-center-content-href.ts`): the FOUR types openframe hosts in-app
+ * (product release / onboarding guide / roadmap / delivery) resolve to
+ * `/help-center/...` ABSOLUTE same-origin URLs — so the lib's embed-mode nav
+ * recognizes them as in-app and soft-navs there instead of bouncing the card
+ * out to the hub. Every other type (blog / podcast / case-study / …) still
+ * opens OUT to its RAG-authoritative `externalUrl` on the content hub.
  */
-const composeOpenframeContentUrl: ComposeContentUrl = ({ type, identifier, externalUrl, targetPlatform }) => {
-  if (type === 'roadmap_item' || type === 'delivery_item') {
-    const tab = type === 'roadmap_item' ? 'roadmap' : 'delivery';
-    return {
-      href: `${CONTENT_HUB_ORIGIN}/roadmap-and-releases?tab=${tab}&${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(identifier)}`,
-      targetPlatform: null,
-    };
-  }
-  return { href: externalUrl ?? '', targetPlatform: targetPlatform ?? null };
-};
 
 import { refreshAccessToken } from '@/lib/token-refresh-manager';
 
@@ -202,11 +186,10 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
         mode: 'embed',
         defaultContentOrigin: CONTENT_HUB_ORIGIN,
       },
-      // Unified content-href seam: openframe hosts no hub content in-app, so
-      // every card opens OUT to its real home — roadmap/delivery rebuilt against
-      // the flamingo unified page, company-hub content re-based onto company-hub,
-      // everything else passed through verbatim. See `composeOpenframeContentUrl`.
-      composeContentUrl: composeOpenframeContentUrl,
+      // Unified content-href seam (shared with Help Center pages): the four
+      // in-app-hosted types soft-nav into `/help-center/...`; every other type
+      // opens OUT to its hub home. See `composeOpenframeChatContentUrl`.
+      composeContentUrl: composeOpenframeChatContentUrl,
       source: CHAT_SOURCE,
     };
   }, []);

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -34,6 +34,7 @@ import { useEffect, useMemo } from 'react';
 import { featureFlags } from '@/lib/feature-flags';
 import { MINGO_CONTEXT_ENTITY_TYPES } from '../(app)/mingo/context/context-sources';
 import { CONTEXT_ITEMS_MAX } from '../(app)/mingo/context/context-types';
+import { renderMingoMention } from '../(app)/mingo/context/mention-chips/render-mention';
 import { renderMingoContextItems } from '../(app)/mingo/context/render-context-items';
 import { DialogSubscription } from '../(app)/mingo/hooks/use-mingo-realtime-subscription';
 import { useMingoUnifiedChatState } from '../(app)/mingo/hooks/use-mingo-unified-chat-state';
@@ -145,6 +146,10 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
         // No hardcoded greeting here — a blank admin value falls back to the
         // lib's own default copy.
         contextPicker={contextEnabled ? contextPicker : undefined}
+        // Renders inline AI mentions (`@device:<machineId>` in Mingo's replies)
+        // as self-fetching chips — the `@marker:id` analogue of `renderEntityCard`
+        // for `[card://]`. Stable module-level fn so the message memo holds.
+        renderMention={contextEnabled ? renderMingoMention : undefined}
       />
     </>
   );

--- a/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
+++ b/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
@@ -82,22 +82,25 @@ export const getNavigationItems = (
   ];
 
   if (isSaasTenantMode()) {
-    baseItems.push(
-      {
-        id: 'tickets',
-        label: 'Tickets',
-        icon: <TagIcon size={24} />,
-        path: '/tickets',
-        isActive: pathname.startsWith('/tickets'),
-      },
-      {
+    baseItems.push({
+      id: 'tickets',
+      label: 'Tickets',
+      icon: <TagIcon size={24} />,
+      path: '/tickets',
+      isActive: pathname.startsWith('/tickets'),
+    });
+    // The legacy standalone `/mingo` page is fully superseded by the in-layout
+    // Mingo sidebar when `mingo-sidebar` is on — hide its nav entry so the old
+    // route is unreachable (the page itself also redirects, see mingo/page.tsx).
+    if (!featureFlags.mingoSidebar.enabled()) {
+      baseItems.push({
         id: 'mingo',
         label: 'Mingo',
         icon: <MingoIcon className="w-6 h-6" />,
         path: '/mingo',
         isActive: pathname.startsWith('/mingo'),
-      },
-    );
+      });
+    }
   }
 
   baseItems.push({


### PR DESCRIPTION
Bundles the pending frontend work on this branch (two commits).

## 1. Mingo inline AI mention chips
When the assistant echoes `@marker:id` (`@device:…`, `@kb:…`, `@policy:…`, …) the token now renders as a **self-fetching entity chip** — the `@`-mention analogue of `[card://]`.
- `mention-chips/`: per-type renderers — device/customer/kb via **Relay**, policy/query/user/script/ticket via **REST** — each with skeleton → name → id-fallback.
- Wires `renderMention` into `<EmbeddableChat>`, threads backend mention markers through the context picker, and fetches `contextItems` in the dialog-history query.
- Bumps `@flamingo-stack/openframe-frontend-core` **0.0.285 → 0.0.294** (carries the `renderMention` API, polymorphic `Tag`, and the mention/url-transform fixes).

## 2. Notification → Mingo drawer routing
With `mingo-sidebar` ON the standalone `/mingo` page is retired (redirects to dashboard), so notifications pointing at `/mingo?dialogId=…` lost the dialog. They now open the in-layout **chat drawer**.
- `NotificationAction` → `route | mingoDialogId` union; `mingoDialogAction` is flag-aware (drawer ON / legacy route OFF). Tickets unaffected.
- Shared `openMingoDialogInDrawer`; live tiles + desktop notifications + the history table all route Mingo dialogs to the drawer and mark read on open (pending approvals stay unread).

## 3. Misc
- Help-center stable content-href helper; monitoring policy/query detail-view + navigation-config tweaks.

## Notes
- **Host-only** — the core lib repo is untouched here (lib changes ship via its own published 0.0.294).
- `.env.local` (local dev toggles) intentionally **excluded**.
- Gates: Biome clean on all touched files. `tsc` shows pre-existing `enableThinking` errors from the local yalc lib build (environmental — the same dependency exists at `main` via the committed tickets code); CI builds against published 0.0.294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)