### PR TITLE
fix(frontend): route Mingo ticket/FAQ cards to internal pages, not the hub

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
@@ -40,11 +40,12 @@ const HC = HELP_CENTER_BASE.replace(/^\//, '');
  *  are NOT here — they have no detail route and use `overrides` instead. */
 const HOSTED_TYPES = new Set(['onboarding_guide', 'product_release']);
 
-/** In-app ticket-dialog href for a HubSpot-ticket card. The ticket `identifier`
- *  is the same id `/tickets/dialog` keys on (the id the notifications + mention
- *  chips already route with). Shared by every `hubspot_ticket*` override. */
-const ticketDialogHref = (id: string): { href: string; targetPlatform: string | null } => ({
-  href: `/tickets/dialog?id=${encodeURIComponent(id)}`,
+/** In-app href for a HubSpot-ticket card → the Help Center tickets list with the
+ *  ticket pre-opened. `?ticket=<external_id>` is the deep-link param `HelpCenterList`
+ *  reads to auto-open that ticket's drawer (the same id the hub URL used). Shared
+ *  by every `hubspot_ticket*` override. */
+const helpCenterTicketHref = (id: string): { href: string; targetPlatform: string | null } => ({
+  href: `${HELP_CENTER_BASE}/tickets?ticket=${encodeURIComponent(id)}`,
   targetPlatform: null,
 });
 
@@ -52,7 +53,7 @@ const ticketDialogHref = (id: string): { href: string; targetPlatform: string | 
  * The unified `composeContentUrl` for OpenFrame. Returns RELATIVE in-app hrefs
  * for the four hosted types and the hub URL for everything else — exactly what
  * the `host`-mode help-center subtree needs. The embed-mode chat wraps this via
- * {@link toSameOriginInAppHref} to absolutize the in-app branch.
+ * {@link toSameOriginHelpCenterHref} to absolutize the in-app branch.
  */
 export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentUrl({
   hostedTypes: HOSTED_TYPES,
@@ -78,41 +79,36 @@ export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentU
     }),
     // Mingo entity cards with a real in-app destination → soft-nav in the chat
     // (and same-origin nav on the pages) instead of bouncing to the content hub.
-    // A HubSpot-ticket card opens the internal ticket dialog (every variant the
-    // RAG can emit); FAQ has no per-item detail route, so it deep-links to the
-    // in-app FAQ list. These hrefs leave `/help-center`, so `isInAppHref` (below)
-    // must recognize `/tickets` too for the embed-mode same-origin soft-nav.
-    hubspot_ticket: ticketDialogHref,
-    hubspot_ticket_anon: ticketDialogHref,
-    hubspot_ticket_self: ticketDialogHref,
+    // A HubSpot-ticket card opens the Help Center tickets list with that ticket
+    // pre-opened (every variant the RAG can emit); FAQ has no per-item detail
+    // route, so it deep-links to the in-app FAQ list. Both live under
+    // `/help-center`, so `isInAppHelpCenterHref` already covers them.
+    hubspot_ticket: helpCenterTicketHref,
+    hubspot_ticket_anon: helpCenterTicketHref,
+    hubspot_ticket_self: helpCenterTicketHref,
     faq: () => ({ href: `${HELP_CENTER_BASE}/faqs`, targetPlatform: null }),
   },
 });
 
-/** Relative-route prefixes the embedder serves IN-APP (soft-nav, same origin)
- *  rather than bouncing out to the content hub: the `/help-center` content
- *  subtree plus the internal `/tickets` dialog a HubSpot-ticket card opens. */
-const IN_APP_ROUTE_PREFIXES = [HELP_CENTER_BASE, '/tickets'] as const;
-
-/** True when a composed href points at an in-app route (the relative-same-origin
- *  branch of {@link composeOpenframeContentUrl}) — `/help-center…` or `/tickets…`. */
-export function isInAppHref(href: string): boolean {
-  return IN_APP_ROUTE_PREFIXES.some(
-    prefix => href === prefix || href.startsWith(`${prefix}/`) || href.startsWith(`${prefix}?`),
-  );
+/** True when a composed href points at an in-app `/help-center` route (i.e. the
+ *  relative-same-origin branch of {@link composeOpenframeContentUrl}). Every
+ *  in-app target — content detail routes, the roadmap/delivery list filters, the
+ *  ticket list, the FAQ list — lives under `/help-center`. */
+export function isInAppHelpCenterHref(href: string): boolean {
+  return href === HELP_CENTER_BASE || href.startsWith(`${HELP_CENTER_BASE}/`);
 }
 
 /**
- * Embed-mode adapter: absolutize an in-app href (`/help-center/…` or `/tickets/…`)
- * against the CURRENT origin so the lib's `computeIsNewTab` recognizes it as
- * same-origin in-app (same-tab soft-nav) instead of absolutizing it against the
- * hub origin and opening a new tab. Non-in-app (already-absolute hub) hrefs pass
- * through. SSR-safe: with no `window` it returns the href unchanged (cards only
- * ever render client-side, so the relative form never reaches the user).
+ * Embed-mode adapter: absolutize an in-app `/help-center/...` href against the
+ * CURRENT origin so the lib's `computeIsNewTab` recognizes it as same-origin
+ * in-app (same-tab soft-nav) instead of absolutizing it against the hub origin
+ * and opening a new tab. Non-hosted (already-absolute hub) hrefs pass through.
+ * SSR-safe: with no `window` it returns the href unchanged (cards only ever
+ * render client-side, so the relative form never reaches the user).
  */
-export function toSameOriginInAppHref(href: string): string {
+export function toSameOriginHelpCenterHref(href: string): string {
   if (typeof window === 'undefined') return href;
-  if (!isInAppHref(href)) return href;
+  if (!isInAppHelpCenterHref(href)) return href;
   return window.location.origin + href;
 }
 
@@ -120,5 +116,5 @@ export function toSameOriginInAppHref(href: string): string {
  *  but in-app hrefs are absolutized to the current origin for the embedded chat. */
 export const composeOpenframeChatContentUrl: ComposeContentUrl = input => {
   const resolved = composeOpenframeContentUrl(input);
-  return { href: toSameOriginInAppHref(resolved.href), targetPlatform: resolved.targetPlatform };
+  return { href: toSameOriginHelpCenterHref(resolved.href), targetPlatform: resolved.targetPlatform };
 };

--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
@@ -24,6 +24,7 @@ import {
   type ComposeContentUrl,
   DEFAULT_CONTENT_SUFFIXES,
   DEV_SECTION_PARAM_KEYS,
+  faqItemAnchor,
   makeComposeContentUrl,
 } from '@flamingo-stack/openframe-frontend-core/utils';
 import { HELP_CENTER_BASE } from './endpoints';
@@ -80,13 +81,14 @@ export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentU
     // Mingo entity cards with a real in-app destination → soft-nav in the chat
     // (and same-origin nav on the pages) instead of bouncing to the content hub.
     // A HubSpot-ticket card opens the Help Center tickets list with that ticket
-    // pre-opened (every variant the RAG can emit); FAQ has no per-item detail
-    // route, so it deep-links to the in-app FAQ list. Both live under
-    // `/help-center`, so `isInAppHelpCenterHref` already covers them.
+    // pre-opened (every variant the RAG can emit); a FAQ card deep-links to its
+    // specific question via the `#faq-item-<id>` hash the FAQ page dispatches on
+    // (same anchor the hub uses) — `faqItemAnchor` is the lib's SSOT for it. Both
+    // live under `/help-center`, so `isInAppHelpCenterHref` already covers them.
     hubspot_ticket: helpCenterTicketHref,
     hubspot_ticket_anon: helpCenterTicketHref,
     hubspot_ticket_self: helpCenterTicketHref,
-    faq: () => ({ href: `${HELP_CENTER_BASE}/faqs`, targetPlatform: null }),
+    faq: id => ({ href: `${HELP_CENTER_BASE}/faqs#${faqItemAnchor(id)}`, targetPlatform: null }),
   },
 });
 

--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-content-href.ts
@@ -40,11 +40,19 @@ const HC = HELP_CENTER_BASE.replace(/^\//, '');
  *  are NOT here — they have no detail route and use `overrides` instead. */
 const HOSTED_TYPES = new Set(['onboarding_guide', 'product_release']);
 
+/** In-app ticket-dialog href for a HubSpot-ticket card. The ticket `identifier`
+ *  is the same id `/tickets/dialog` keys on (the id the notifications + mention
+ *  chips already route with). Shared by every `hubspot_ticket*` override. */
+const ticketDialogHref = (id: string): { href: string; targetPlatform: string | null } => ({
+  href: `/tickets/dialog?id=${encodeURIComponent(id)}`,
+  targetPlatform: null,
+});
+
 /**
  * The unified `composeContentUrl` for OpenFrame. Returns RELATIVE in-app hrefs
  * for the four hosted types and the hub URL for everything else — exactly what
  * the `host`-mode help-center subtree needs. The embed-mode chat wraps this via
- * {@link toSameOriginHelpCenterHref} to absolutize the in-app branch.
+ * {@link toSameOriginInAppHref} to absolutize the in-app branch.
  */
 export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentUrl({
   hostedTypes: HOSTED_TYPES,
@@ -68,26 +76,43 @@ export const composeOpenframeContentUrl: ComposeContentUrl = makeComposeContentU
       href: `${HELP_CENTER_BASE}/bug-fixes-and-enhancements?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`,
       targetPlatform: null,
     }),
+    // Mingo entity cards with a real in-app destination → soft-nav in the chat
+    // (and same-origin nav on the pages) instead of bouncing to the content hub.
+    // A HubSpot-ticket card opens the internal ticket dialog (every variant the
+    // RAG can emit); FAQ has no per-item detail route, so it deep-links to the
+    // in-app FAQ list. These hrefs leave `/help-center`, so `isInAppHref` (below)
+    // must recognize `/tickets` too for the embed-mode same-origin soft-nav.
+    hubspot_ticket: ticketDialogHref,
+    hubspot_ticket_anon: ticketDialogHref,
+    hubspot_ticket_self: ticketDialogHref,
+    faq: () => ({ href: `${HELP_CENTER_BASE}/faqs`, targetPlatform: null }),
   },
 });
 
-/** True when a composed href points at an in-app `/help-center` route (i.e. the
- *  relative-same-origin branch of {@link composeOpenframeContentUrl}). */
-export function isInAppHelpCenterHref(href: string): boolean {
-  return href === HELP_CENTER_BASE || href.startsWith(`${HELP_CENTER_BASE}/`);
+/** Relative-route prefixes the embedder serves IN-APP (soft-nav, same origin)
+ *  rather than bouncing out to the content hub: the `/help-center` content
+ *  subtree plus the internal `/tickets` dialog a HubSpot-ticket card opens. */
+const IN_APP_ROUTE_PREFIXES = [HELP_CENTER_BASE, '/tickets'] as const;
+
+/** True when a composed href points at an in-app route (the relative-same-origin
+ *  branch of {@link composeOpenframeContentUrl}) — `/help-center…` or `/tickets…`. */
+export function isInAppHref(href: string): boolean {
+  return IN_APP_ROUTE_PREFIXES.some(
+    prefix => href === prefix || href.startsWith(`${prefix}/`) || href.startsWith(`${prefix}?`),
+  );
 }
 
 /**
- * Embed-mode adapter: absolutize an in-app `/help-center/...` href against the
- * CURRENT origin so the lib's `computeIsNewTab` recognizes it as same-origin
- * in-app (same-tab soft-nav) instead of absolutizing it against the hub origin
- * and opening a new tab. Non-hosted (already-absolute hub) hrefs pass through.
- * SSR-safe: with no `window` it returns the href unchanged (cards only ever
- * render client-side, so the relative form never reaches the user).
+ * Embed-mode adapter: absolutize an in-app href (`/help-center/…` or `/tickets/…`)
+ * against the CURRENT origin so the lib's `computeIsNewTab` recognizes it as
+ * same-origin in-app (same-tab soft-nav) instead of absolutizing it against the
+ * hub origin and opening a new tab. Non-in-app (already-absolute hub) hrefs pass
+ * through. SSR-safe: with no `window` it returns the href unchanged (cards only
+ * ever render client-side, so the relative form never reaches the user).
  */
-export function toSameOriginHelpCenterHref(href: string): string {
+export function toSameOriginInAppHref(href: string): string {
   if (typeof window === 'undefined') return href;
-  if (!isInAppHelpCenterHref(href)) return href;
+  if (!isInAppHref(href)) return href;
   return window.location.origin + href;
 }
 
@@ -95,5 +120,5 @@ export function toSameOriginHelpCenterHref(href: string): string {
  *  but in-app hrefs are absolutized to the current origin for the embedded chat. */
 export const composeOpenframeChatContentUrl: ComposeContentUrl = input => {
   const resolved = composeOpenframeContentUrl(input);
-  return { href: toSameOriginHelpCenterHref(resolved.href), targetPlatform: resolved.targetPlatform };
+  return { href: toSameOriginInAppHref(resolved.href), targetPlatform: resolved.targetPlatform };
 };

--- a/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
@@ -20,8 +20,10 @@
  * resolve on the hub origin — those routes don't exist in openframe. Embed
  * mode makes the lib (a) absolutize every relative card/chip href against
  * `defaultContentOrigin` and (b) always open it in a new tab, so a click
- * lands on the real page on the hub instead of 404-ing in-app. Mingo emits
- * no openframe-internal links, so there's no same-tab `navigate` to wire.
+ * lands on the real page on the hub instead of 404-ing in-app. The in-app
+ * entity cards openframe DOES host (tickets / FAQ, via `composeContentUrl`)
+ * are emitted as same-origin absolute URLs and soft-nav in-app; the `navigate`
+ * hook below handles the one case the router can't — a same-page hash deep-link.
  */
 
 /** Public origin of the Flamingo content hub where the chat's content
@@ -182,9 +184,37 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
         // Embedder, not host — see the file header. Relative content-card
         // hrefs get absolutized against `defaultContentOrigin` and opened in
         // a new tab (the lib's `computeIsNewTab` short-circuits to new-tab in
-        // embed mode), so there's no in-app `navigate` to wire.
+        // embed mode). The one same-tab case we DO handle is a same-page hash
+        // deep-link (see `navigate` below).
         mode: 'embed',
         defaultContentOrigin: CONTENT_HUB_ORIGIN,
+        // Same-page hash deep-links — e.g. a FAQ card → `/help-center/faqs#faq-item-<id>`
+        // clicked while ALREADY on `/faqs`. The lib's same-tab fallback router-pushes
+        // the same pathname, which doesn't emit a `hashchange`; but the FAQ page
+        // dispatches its "expand + scroll to the cited question" on `hashchange`, so
+        // the item wouldn't open. Set the hash directly here to fire that event.
+        // Everything else (cross-page in-app, hub links, query-only deep-links like
+        // `?ticket=`) returns false so the lib's default nav handles it unchanged.
+        navigate: ({ href }) => {
+          if (typeof window === 'undefined') return false;
+          let url: URL;
+          try {
+            url = new URL(href, window.location.origin);
+          } catch {
+            return false;
+          }
+          const samePageHash =
+            url.origin === window.location.origin && url.pathname === window.location.pathname && !!url.hash;
+          if (!samePageHash) return false;
+          if (window.location.hash === url.hash) {
+            // Re-clicking the same anchor fires no native hashchange — re-dispatch
+            // so the page re-runs its scroll/open for the already-selected row.
+            window.dispatchEvent(new HashChangeEvent('hashchange'));
+          } else {
+            window.location.hash = url.hash;
+          }
+          return true;
+        },
       },
       // Unified content-href seam (shared with Help Center pages): the four
       // in-app-hosted types soft-nav into `/help-center/...`; every other type

--- a/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-chat-runtime-provider.tsx
@@ -23,7 +23,8 @@
  * lands on the real page on the hub instead of 404-ing in-app. The in-app
  * entity cards openframe DOES host (tickets / FAQ, via `composeContentUrl`)
  * are emitted as same-origin absolute URLs and soft-nav in-app; the `navigate`
- * hook below handles the one case the router can't — a same-page hash deep-link.
+ * hook below handles the same-PAGE deep-link cases a plain router push can't
+ * (a hash for FAQ, a `?ticket=` query for tickets).
  */
 
 /** Public origin of the Flamingo content hub where the chat's content
@@ -38,6 +39,7 @@ import {
   type EmbedAuthAdapter,
   setEmbedAuthAdapter,
 } from '@flamingo-stack/openframe-frontend-core/utils';
+import { useRouter } from 'next/navigation';
 import { type ReactNode, useMemo } from 'react';
 import { composeOpenframeChatContentUrl } from '@/app/(app)/help-center/help-center-content-href';
 import { runtimeEnv } from '@/lib/runtime-config';
@@ -128,6 +130,7 @@ if (typeof window !== 'undefined') {
 }
 
 export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const runtime = useMemo<ChatRuntime>(() => {
     // Guide-mode endpoints are SAME-ORIGIN relative `/content/*` paths. The
     // lib's `embedAuthedFetch` rejects cross-origin URLs in production builds
@@ -184,17 +187,20 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
         // Embedder, not host — see the file header. Relative content-card
         // hrefs get absolutized against `defaultContentOrigin` and opened in
         // a new tab (the lib's `computeIsNewTab` short-circuits to new-tab in
-        // embed mode). The one same-tab case we DO handle is a same-page hash
-        // deep-link (see `navigate` below).
+        // embed mode). The same-tab cases we DO own are same-PAGE deep-links —
+        // see `navigate` below.
         mode: 'embed',
         defaultContentOrigin: CONTENT_HUB_ORIGIN,
-        // Same-page hash deep-links — e.g. a FAQ card → `/help-center/faqs#faq-item-<id>`
-        // clicked while ALREADY on `/faqs`. The lib's same-tab fallback router-pushes
-        // the same pathname, which doesn't emit a `hashchange`; but the FAQ page
-        // dispatches its "expand + scroll to the cited question" on `hashchange`, so
-        // the item wouldn't open. Set the hash directly here to fire that event.
-        // Everything else (cross-page in-app, hub links, query-only deep-links like
-        // `?ticket=`) returns false so the lib's default nav handles it unchanged.
+        // Same-PAGE deep-links — a card clicked while ALREADY on its target page:
+        //   - FAQ  → `/help-center/faqs#faq-item-<id>`   (hash deep-link)
+        //   - ticket → `/help-center/tickets?ticket=<id>` (query deep-link)
+        // The lib's same-tab fallback router-pushes the same pathname, which
+        // neither emits a `hashchange` (the FAQ page expands+scrolls on it) nor
+        // re-opens the ticket drawer the tickets page derives from `?ticket=`. So
+        // drive each page's own re-sync here: the query via the real router (the
+        // same `replace` the ticket list's row-click uses) so `useSearchParams`
+        // re-derives, and the hash via `location.hash` so `hashchange` fires.
+        // Cross-page / hub links return false → the lib's default nav is unchanged.
         navigate: ({ href }) => {
           if (typeof window === 'undefined') return false;
           let url: URL;
@@ -203,14 +209,24 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
           } catch {
             return false;
           }
-          const samePageHash =
-            url.origin === window.location.origin && url.pathname === window.location.pathname && !!url.hash;
-          if (!samePageHash) return false;
-          if (window.location.hash === url.hash) {
-            // Re-clicking the same anchor fires no native hashchange — re-dispatch
-            // so the page re-runs its scroll/open for the already-selected row.
-            window.dispatchEvent(new HashChangeEvent('hashchange'));
-          } else {
+          const samePage = url.origin === window.location.origin && url.pathname === window.location.pathname;
+          if (!samePage) return false;
+          const hashChanged = url.hash !== window.location.hash;
+          const searchChanged = url.search !== window.location.search;
+          if (!hashChanged && !searchChanged) {
+            // Re-clicking the same target — re-fire the hash event so a hash page
+            // re-runs its scroll/open (a query page is already in the right state).
+            if (url.hash) window.dispatchEvent(new HashChangeEvent('hashchange'));
+            return true;
+          }
+          // Query deep-link (e.g. `?ticket=<id>`) → real router so the page's
+          // `useSearchParams` re-derives the open drawer (matches its row-click).
+          if (searchChanged) {
+            router.replace(`${url.pathname}${url.search}`, { scroll: false });
+          }
+          // Hash deep-link (e.g. `#faq-item-<id>`) → a router nav to the same
+          // pathname emits no `hashchange`, which the page listens for; set it.
+          if (hashChanged) {
             window.location.hash = url.hash;
           }
           return true;
@@ -222,7 +238,9 @@ export function OpenframeChatRuntimeProvider({ children }: { children: ReactNode
       composeContentUrl: composeOpenframeChatContentUrl,
       source: CHAT_SOURCE,
     };
-  }, []);
+    // `router` is the only reactive dep; Next returns a stable instance, so the
+    // runtime object is effectively built once.
+  }, [router]);
 
   return <ChatRuntimeContext.Provider value={runtime}>{children}</ChatRuntimeContext.Provider>;
 }


### PR DESCRIPTION
## Problem
Ticket and FAQ entity cards that Mingo renders inline in the embeddable chat opened the **external** content hub (`https://www.flamingo.run/tickets?ticket=...`) instead of internal app pages.

## Root cause
Both are `no-fetch` entity cards that render `buildAnchorProps(chatRef.url)`. But the lib resolves every inline card's href through `runtime.composeContentUrl` first (in `ChatCardLoader` → `resolveSourceRowCTA`, `url: finalHref ?? chatRef.url`). The host's `composeOpenframeContentUrl` only mapped the 4 hosted content types internally, so tickets/FAQ fell through to their external `externalUrl`.

## Fix (host-only — same seam the other cards already use)
- Add `overrides` to `composeOpenframeContentUrl`:
  - every `hubspot_ticket*` → `/tickets/dialog?id=<id>` (the internal ticket dialog — same id the notifications + mention chips route with)
  - `faq` → the in-app FAQ list `/help-center/faqs` (FAQ has no per-item detail route)
- Generalize the embed-mode same-origin adapter (`isInAppHref` / `toSameOriginInAppHref`) to recognize `/tickets…` alongside `/help-center…`, so the ticket href soft-navs in-app instead of being absolutized to the hub origin and opened in a new tab.

No lib change.

## Notes / assumptions
- Assumes the ticket card's `chatRef.id` is the same id `/tickets/dialog?id=` keys on (consistent with notifications + mention chips). If a HubSpot ticket id ≠ internal dialog id, that mapping needs adjusting.
- KB/`markdown` docs were left out of scope (they already have internal detail pages but weren't part of the ask); trivial to add the same way if wanted.
- Gates: Biome clean, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link routing for help center content in chat and embed modes, ensuring proper handling of in-app links and external references.
  * Enhanced support for HubSpot ticket card variants to route correctly to the tickets dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->