### PR TITLE
feat(frontend): real-token billing usage + invoices history

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
@@ -21,6 +21,7 @@ import { BillingRow, SectionBlock } from './billing-section';
 import { BillingUsageSkeleton } from './billing-usage-skeleton';
 import { CancelOfferModal } from './cancel-offer-modal';
 import { type CancelReason, CancelSubscriptionModal } from './cancel-subscription-modal';
+import { InvoicesHistory } from './invoices-history';
 import { SubscriptionCancelledModal } from './subscription-cancelled-modal';
 
 export function BillingUsageView() {
@@ -44,10 +45,7 @@ function BillingUsageContent() {
   const [cancelReason, setCancelReason] = useState<CancelReason | null>(null);
   const [cancelComment, setCancelComment] = useState<string>('');
 
-  const { status, flags, device, ai, ui, billing, updatedPlan } = useBillingSummary(
-    data.subscription,
-    data.billingPlan,
-  );
+  const { status, flags, device, ai, ui, billing, updatedPlan } = useBillingSummary(data.subscription);
   const { impact, isLoading: isImpactLoading } = useCancellationImpact({ enabled: cancelStep === 'reason' });
 
   const menuActions: ActionsMenuGroup[] =
@@ -115,7 +113,8 @@ function BillingUsageContent() {
         <DashboardInfoCard
           title="Device Usage"
           value={device.used}
-          percentage={device.pct}
+          // PAYG has no package limit, so no percentage — just the usage count.
+          percentage={device.isPayg ? undefined : device.pct}
           progressVariant={device.progressVariant}
           showProgress={device.showProgress}
           progressOverflow="wrap"
@@ -124,7 +123,7 @@ function BillingUsageContent() {
           <DashboardInfoCard
             title="AI Usage"
             value={ai.used}
-            percentage={ai.pct}
+            percentage={ai.isPayg ? undefined : ai.pct}
             progressVariant={ai.progressVariant}
             showProgress={ai.showProgress}
             progressOverflow="wrap"
@@ -158,9 +157,6 @@ function BillingUsageContent() {
             >
               {device.state === 'over' && <BillingRow label="Device Overage" value={formatCount(device.overage)} />}
               {flags.hasAi && ai.state === 'over' && <BillingRow label="AI Overage" value={formatCount(ai.overage)} />}
-              {billing.estimatedOverageCost > 0 && (
-                <BillingRow label="Estimated Overage" value={formatCurrency(billing.estimatedOverageCost)} />
-              )}
               <BillingRow label="Next Billing" value={formatDateOrDash(billing.nextBilling)} />
             </div>
           )}
@@ -179,7 +175,7 @@ function BillingUsageContent() {
             muted={!flags.hasAi && !ai.isPayg}
           />
           <BillingRow
-            label="Monthly Cost"
+            label="Next Payment"
             value={flags.isTrial ? 'Free' : formatCurrency(billing.monthlyCost || billing.estimatedOverageCost)}
           />
           {flags.isPendingCancellation ? (
@@ -211,7 +207,6 @@ function BillingUsageContent() {
         <SectionBlock title="Usage Overview">
           <BillingRow label="Active devices" value={formatCount(device.active)} />
           <BillingRow label="Inactive devices" value={formatCount(device.inactive)} />
-          {flags.hasAi && <BillingRow label="AI conversations" value={formatCount(0)} />}
         </SectionBlock>
       </div>
 
@@ -235,6 +230,8 @@ function BillingUsageContent() {
           </SectionBlock>
         </div>
       )}
+
+      <InvoicesHistory invoices={data.subscription?.pendingInvoices ?? []} />
 
       <CancelSubscriptionModal
         isOpen={cancelStep === 'reason'}
@@ -284,12 +281,6 @@ function BillingUsageContent() {
 
 const billingUsageViewQuery = graphql`
   query billingUsageViewQuery {
-    billingPlan {
-      products {
-        name
-        unitSize
-      }
-    }
     subscription {
       id
       status
@@ -318,6 +309,7 @@ const billingUsageViewQuery = graphql`
         amountDue
         currency
         createdAt
+        dueDate
       }
       usage {
         devicesUsed

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/invoices-history.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/invoices-history.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { ExternalLinkIcon, SearchIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  type ColumnDef,
+  DataTable,
+  Input,
+  type Row,
+  Tag,
+  TruncateText,
+  useDataTable,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useCallback, useMemo, useState } from 'react';
+import { formatCurrency, formatDateOrDash } from '../lib/format';
+
+interface InvoiceItem {
+  id: string;
+  amountDue: number; // smallest currency unit (cents)
+  currency: string;
+  createdAt: string;
+  dueDate: string | null;
+  hostedInvoiceUrl: string;
+}
+
+export function InvoicesHistory({ invoices }: { invoices: readonly InvoiceItem[] }) {
+  const [search, setSearch] = useState('');
+
+  const data = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const list = query ? invoices.filter(invoice => invoice.id.toLowerCase().includes(query)) : invoices;
+    return list as InvoiceItem[];
+  }, [invoices, search]);
+
+  const columns = useMemo<ColumnDef<InvoiceItem>[]>(
+    () => [
+      {
+        // The Stripe invoice id is an opaque base64 string with no user value, so the
+        // issue date stands in as the invoice identifier here.
+        accessorKey: 'createdAt',
+        header: 'INVOICE',
+        cell: ({ row }: { row: Row<InvoiceItem> }) => (
+          <TruncateText>{formatDateOrDash(row.original.createdAt)}</TruncateText>
+        ),
+        meta: { width: 'flex-1 min-w-0' },
+      },
+      {
+        accessorKey: 'dueDate',
+        header: 'DUE DATE',
+        cell: ({ row }: { row: Row<InvoiceItem> }) => (
+          <TruncateText>{formatDateOrDash(row.original.dueDate)}</TruncateText>
+        ),
+        meta: { width: 'flex-1 min-w-0' },
+      },
+      {
+        accessorKey: 'amountDue',
+        header: 'AMOUNT',
+        cell: ({ row }: { row: Row<InvoiceItem> }) => (
+          <TruncateText>{formatCurrency(row.original.amountDue / 100)}</TruncateText>
+        ),
+        meta: { width: 'flex-1 min-w-0' },
+      },
+      {
+        accessorKey: 'status',
+        header: 'STATUS',
+        // Status is mocked: pendingInvoices are unpaid, and the schema exposes no status field yet.
+        cell: () => <Tag variant="warning" label="Unpaid" />,
+        enableSorting: false,
+        // The body cell is a `flex-col` (default `align-items: stretch`), which stretches the
+        // tag full-width. `items-start` keeps it at its natural width, left-aligned.
+        meta: { width: 'flex-1 min-w-0', cellClassName: 'items-start' },
+      },
+      {
+        id: 'actions',
+        cell: ({ row }: { row: Row<InvoiceItem> }) => (
+          <div data-no-row-click className="flex justify-end pointer-events-auto">
+            <a
+              href={row.original.hostedInvoiceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open invoice"
+              className="flex items-center justify-center p-3 bg-ods-card border border-ods-border rounded-md text-ods-text-secondary hover:text-ods-text-primary transition-colors"
+            >
+              <ExternalLinkIcon className="size-6" />
+            </a>
+          </div>
+        ),
+        enableSorting: false,
+        // Fixed width reserved in BOTH header and body so the flex-1 columns line up
+        // (an empty `w-auto` header cell would collapse to 0 and shift every column).
+        meta: { width: 'w-14 shrink-0 flex-none', align: 'right' },
+      },
+    ],
+    [],
+  );
+
+  const getRowId = useCallback((row: InvoiceItem) => row.id, []);
+
+  const table = useDataTable<InvoiceItem>({ data, columns, getRowId });
+
+  if (invoices.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-[var(--spacing-system-l)]">
+      <h2 className="text-h2 text-ods-text-primary">Invoices History</h2>
+
+      <Input
+        startAdornment={<SearchIcon />}
+        placeholder="Search for Invoice"
+        value={search}
+        onChange={event => setSearch(event.target.value)}
+        className="w-full"
+      />
+
+      <DataTable table={table}>
+        <DataTable.Header rightSlot={<DataTable.RowCount />} />
+        <DataTable.Body emptyState={{ title: 'No invoices found', description: 'Try adjusting your search.' }} />
+      </DataTable>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-billing-summary.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-billing-summary.ts
@@ -2,32 +2,25 @@ import { useMemo } from 'react';
 import type { billingUsageViewQuery$data } from '@/__generated__/billingUsageViewQuery.graphql';
 import { SubscriptionStatus } from '@/app/components/subscription-lock/subscription-status';
 import { OpenframeProduct, SubscriptionProductStatus } from '@/generated/schema-enums';
-import { toDisplayQuantity } from '../subscription/utils/subscription.utils';
 
 const WARNING_THRESHOLD = 90;
-const OVER_THRESHOLD = 100;
 
 export type UsageState = 'success' | 'warning' | 'over';
 
-function getUsageState(percentage: number): UsageState {
-  if (percentage >= OVER_THRESHOLD) return 'over';
+/**
+ * `over` is driven by real overage (used > allocation), not the rounded
+ * percentage: at exactly 100% (used === allocation) you're at the limit, not
+ * over it, so it stays a warning. `warning` covers the 90–100% approach.
+ */
+function getUsageState(percentage: number, isOver: boolean): UsageState {
+  if (isOver) return 'over';
   if (percentage >= WARNING_THRESHOLD) return 'warning';
   return 'success';
 }
 
 type SubscriptionData = billingUsageViewQuery$data['subscription'];
-type BillingPlanData = billingUsageViewQuery$data['billingPlan'];
 
-export function useBillingSummary(subscription: SubscriptionData, billingPlan: BillingPlanData) {
-  const unitSizeByProduct = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const p of billingPlan?.products ?? []) {
-      map.set(p.name, Number(p.unitSize ?? 1) || 1);
-    }
-    return map;
-  }, [billingPlan]);
-  const managedDevicesUnitSize = unitSizeByProduct.get(OpenframeProduct.MANAGED_DEVICES) ?? 1;
-  const aiUnitSize = unitSizeByProduct.get(OpenframeProduct.AI_ASSISTANCE) ?? 1;
+export function useBillingSummary(subscription: SubscriptionData) {
   const subscriptionProducts = subscription?.products ?? [];
   const status = subscription?.status ?? SubscriptionStatus.ACTIVE;
   const pendingInvoices = subscription?.pendingInvoices ?? [];
@@ -66,17 +59,23 @@ export function useBillingSummary(subscription: SubscriptionData, billingPlan: B
   const aiIsPayg = aiProduct?.payAsYouGoOption != null && aiActive == null;
   const hasAi = aiActive != null || aiIsPayg;
 
-  const deviceAllocation = toDisplayQuantity(managedDevicesActive?.quantity, managedDevicesUnitSize);
-  const aiAllocation = toDisplayQuantity(aiActive?.quantity, aiUnitSize);
+  const deviceAllocation = managedDevicesActive?.quantity ?? 0;
+  const aiAllocation = aiActive?.quantity ?? 0;
 
   const devicePct = deviceAllocation > 0 ? Math.round((devicesUsed / deviceAllocation) * 100) : 0;
   const aiPct = aiAllocation > 0 ? Math.round((aiTokensUsed / aiAllocation) * 100) : 0;
 
-  const deviceState: UsageState = deviceIsPayg ? 'success' : getUsageState(devicePct);
-  const aiState: UsageState = aiIsPayg ? 'success' : hasAi ? getUsageState(aiPct) : 'success';
-
   const deviceOverage = Math.max(0, devicesUsed - deviceAllocation);
   const aiOverage = Math.max(0, aiTokensUsed - aiAllocation);
+
+  const deviceState: UsageState = deviceIsPayg
+    ? 'success'
+    : getUsageState(devicePct, deviceAllocation > 0 && deviceOverage > 0);
+  const aiState: UsageState = aiIsPayg
+    ? 'success'
+    : hasAi
+      ? getUsageState(aiPct, aiAllocation > 0 && aiOverage > 0)
+      : 'success';
 
   const warnings: Array<{ title: string; description: string }> = [];
   if (deviceState === 'warning') {
@@ -133,9 +132,9 @@ export function useBillingSummary(subscription: SubscriptionData, billingPlan: B
   const hasPendingPlan = managedDevicesPending != null || aiPending != null;
   const updatedPlan = {
     showDevice: managedDevicesPending != null,
-    deviceQuantity: toDisplayQuantity(managedDevicesPending?.quantity, managedDevicesUnitSize),
+    deviceQuantity: managedDevicesPending?.quantity ?? 0,
     showAi: aiPending != null,
-    aiQuantity: toDisplayQuantity(aiPending?.quantity, aiUnitSize),
+    aiQuantity: aiPending?.quantity ?? 0,
     startDate: (managedDevicesPending?.startDate ?? aiPending?.startDate ?? null) as string | null,
   };
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/model-token-rates.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/model-token-rates.tsx
@@ -22,6 +22,7 @@ const modelTokenRatesQuery = graphql`
   query modelTokenRatesQuery {
     aiModelRates {
       modelName
+      displayName
       providerType
       inputTokenRate
       outputTokenRate
@@ -59,27 +60,32 @@ function ModelTokenRatesContent() {
   if (rates.length === 0) return null;
 
   return (
-    <div className="flex flex-col bg-ods-card border border-ods-border rounded-[6px] overflow-hidden min-w-[260px]">
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-ods-border text-h5 text-ods-text-secondary uppercase tracking-[-0.02em]">
+    <div className="flex flex-col bg-ods-card border border-ods-border rounded-[6px] overflow-hidden min-w-[260px] max-h-[min(60vh,420px)]">
+      <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-ods-border text-h5 text-ods-text-secondary uppercase tracking-[-0.02em]">
         <span className="flex-1">Model</span>
         <span>OpenFrame Token</span>
       </div>
-      {rates.map(rate => {
-        const Icon = PROVIDER_ICON[rate.providerType];
-        return (
-          <div key={`${rate.providerType}-${rate.modelName}`} className="flex items-center gap-2 px-3 py-2">
-            {Icon && <Icon className="size-6 shrink-0" />}
-            <span className="text-h6 text-ods-text-primary whitespace-nowrap">{rate.modelName}</span>
-            <div className="flex-1 h-px bg-ods-border min-w-8" />
-            <span className="text-h6 text-ods-text-primary whitespace-nowrap">
-              {formatRate(rate.inputTokenRate)}
-              {rate.outputTokenRate !== rate.inputTokenRate && (
-                <span className="text-ods-text-secondary"> / {formatRate(rate.outputTokenRate)}</span>
-              )}
-            </span>
-          </div>
-        );
-      })}
+      {/* Scroll the rows when the model list is taller than the capped height; the header stays pinned. */}
+      <div className="flex flex-col overflow-y-auto">
+        {rates.map(rate => {
+          const Icon = PROVIDER_ICON[rate.providerType];
+          return (
+            <div key={`${rate.providerType}-${rate.modelName}`} className="flex items-center gap-2 px-3 py-2">
+              {Icon && <Icon className="size-6 shrink-0" />}
+              <span className="text-h6 text-ods-text-primary whitespace-nowrap">
+                {rate.displayName || rate.modelName}
+              </span>
+              <div className="flex-1 h-px bg-ods-border min-w-8" />
+              <span className="text-h6 text-ods-text-primary whitespace-nowrap">
+                {formatRate(rate.inputTokenRate)}
+                {rate.outputTokenRate !== rate.inputTokenRate && (
+                  <span className="text-ods-text-secondary"> / {formatRate(rate.outputTokenRate)}</span>
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/plan-change-summary.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/plan-change-summary.tsx
@@ -4,7 +4,7 @@ import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import type { ReactNode } from 'react';
 import { BillingRow, SectionBlock } from '../../components/billing-section';
 import type { BillingPeriod, PlanComparison, PlanLine } from '../types/subscription.types';
-import { formatCompact, formatMoney } from '../utils/subscription.utils';
+import { formatCompact, formatMoney, isPlanChanged } from '../utils/subscription.utils';
 
 export interface PlanChangeSummaryItem {
   /** Short row label, e.g. "Devices" / "AI Tokens". */
@@ -112,9 +112,19 @@ export function PlanChangeSummary({ items }: PlanChangeSummaryProps) {
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       <SectionBlock title="Current Plan">
         {items.map(item => (
-          <BillingRow key={item.label} label={item.label} value={currentValueText(item.comparison.current)} muted />
+          <BillingRow
+            key={item.label}
+            label={item.label}
+            value={currentValueText(item.comparison.current)}
+            // Mute only changed rows; unchanged rows stay white to match the New side.
+            muted={isPlanChanged(item.comparison)}
+          />
         ))}
-        <BillingRow label="Total" value={totalText(currentTotal)} muted />
+        <BillingRow
+          label="Total"
+          value={totalText(currentTotal)}
+          muted={totalDirection(currentTotal, nextTotal) !== 'same'}
+        />
       </SectionBlock>
 
       <SectionBlock title="New Plan">

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
@@ -3,13 +3,12 @@
 import { QuestionCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import {
   Card,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
   Input,
   RadioGroupBlock,
   TabSelector,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import type { ReactNode } from 'react';
@@ -19,7 +18,12 @@ import type { productSubscriptionCardSubscriptionFragment$key } from '@/__genera
 import { useProductSelection } from '../hooks/use-product-selection';
 import type { ProductUpdates } from '../types/subscription.types';
 import { buildPackageRadioOptions } from '../utils/build-package-radio-options';
-import { CUSTOM_OPTION_ID, calculateCustomQuantityPrice, formatMoney } from '../utils/subscription.utils';
+import {
+  CUSTOM_OPTION_ID,
+  calculateCustomQuantityPrice,
+  formatCompact,
+  formatMoney,
+} from '../utils/subscription.utils';
 
 export const productSubscriptionCardProductFragment = graphql`
   fragment productSubscriptionCardProductFragment on Product {
@@ -59,7 +63,11 @@ interface ProductSubscriptionCardProps {
   productRef: productSubscriptionCardProductFragment$key;
   subscriptionProductRef: productSubscriptionCardSubscriptionFragment$key | null;
   title: string;
-  description: string;
+  /**
+   * Static text, or a builder receiving the selected billing-period label
+   * ("monthly" / "yearly") so copy reflects the chosen package type.
+   */
+  description: string | ((periodLabel: string) => string);
   packageUnitLabel: string;
   customLabel: string;
   customSubtitle: string;
@@ -73,25 +81,33 @@ interface ProductSubscriptionCardProps {
   onUpdatesChange: (updates: ProductUpdates) => void;
 }
 
+/**
+ * Click-triggered help popover. A hover Tooltip is wrong for this content: it
+ * opens after a delay, dismisses on click, and can't scroll — but the rates
+ * panel is interactive and can be long. DropdownMenu opens instantly on click,
+ * stays open while interacting, and closes only on outside-click / Escape.
+ */
 function HelpTooltip({ content }: { content: ReactNode }) {
   const isText = typeof content === 'string';
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label="More information"
-            className="shrink-0 text-ods-text-secondary hover:text-ods-text-primary transition-colors"
-          >
-            <QuestionCircleIcon className="size-6" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent align="end" sideOffset={8} className={isText ? 'max-w-xs' : 'p-0 bg-transparent border-0'}>
-          {content}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="More information"
+          className="shrink-0 text-ods-text-secondary hover:text-ods-text-primary transition-colors"
+        >
+          <QuestionCircleIcon className="size-6" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className={isText ? 'max-w-xs' : 'p-0 bg-transparent border-0 shadow-none'}
+      >
+        {content}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -125,16 +141,17 @@ export function ProductSubscriptionCard({
     setCustomQuantity,
   } = useProductSelection({ product, subscriptionProduct, onUpdatesChange });
 
-  // customQuantity is the real product count the user typed; it must be a whole
-  // multiple of unitSize. Tier pricing works in units, so divide before pricing.
+  // customQuantity is the real product count the user typed (same unit the
+  // backend stores and prices in); unitSize only constrains its granularity —
+  // it must be a positive whole multiple of unitSize.
   const isCustom = selection.selectedPackageId === CUSTOM_OPTION_ID;
   const customQty = selection.customQuantity;
-  const customNotDivisible = isCustom && customQty != null && customQty > 0 && customQty % unitSize !== 0;
-  const customUnits = customQty != null && customQty > 0 && customQty % unitSize === 0 ? customQty / unitSize : null;
+  const customDivisible = customQty != null && customQty > 0 && customQty % unitSize === 0;
+  const customNotDivisible = isCustom && customQty != null && customQty > 0 && !customDivisible;
 
   const customPrice =
-    isCustom && customUnits != null
-      ? calculateCustomQuantityPrice(customUnits, allTiers, baselineUnitPrice, months)
+    isCustom && customDivisible && customQty != null
+      ? calculateCustomQuantityPrice(customQty, allTiers, baselineUnitPrice, months)
       : null;
 
   const radioOptions = buildPackageRadioOptions({
@@ -146,9 +163,12 @@ export function ProductSubscriptionCard({
     customLabel,
     customSubtitle,
     payAsYouGoOption: product.payAsYouGoOption ?? null,
-    unitSize,
-    showPayg: selection.billingPeriod === 'MONTHLY',
   });
+
+  // "MONTHLY" → "monthly" / "YEARLY" → "yearly", so period-aware copy matches
+  // the selected package type.
+  const periodLabel = selection.billingPeriod.toLowerCase();
+  const resolvedDescription = typeof description === 'function' ? description(periodLabel) : description;
 
   return (
     <Card
@@ -163,7 +183,7 @@ export function ProductSubscriptionCard({
         {helpText && <HelpTooltip content={helpText} />}
       </div>
 
-      <p className="text-h4 text-ods-text-primary">{description}</p>
+      <p className="text-h4 text-ods-text-primary">{resolvedDescription}</p>
 
       {billingPeriodItems.length > 1 ? (
         <TabSelector
@@ -212,7 +232,7 @@ export function ProductSubscriptionCard({
                 />
                 {customNotDivisible ? (
                   <p className="text-h6 text-ods-error">
-                    {`Must be a multiple of ${formatMoney(unitSize)} ${packageUnitLabel}`}
+                    {`Must be a multiple of ${formatCompact(unitSize)} ${packageUnitLabel}`}
                   </p>
                 ) : (
                   customPrice && (

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
@@ -9,7 +9,7 @@ import { SubscriptionStatus } from '@/app/components/subscription-lock/subscript
 import { TrialEndedBanner } from '@/app/components/subscription-lock/trial-ended-banner';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import type { OpenframeProduct, PlanLine, ProductUpdates } from '../types/subscription.types';
-import { buildProductCancelUpdates } from '../utils/subscription.utils';
+import { buildProductCancelUpdates, isPlanChanged } from '../utils/subscription.utils';
 import { ModelTokenRates } from './model-token-rates';
 import { PlanChangeSummary, type PlanChangeSummaryItem } from './plan-change-summary';
 import { ProductSubscriptionCard } from './product-subscription-card';
@@ -18,7 +18,8 @@ import { SubscriptionSubmitButton } from './subscription-submit-button';
 
 interface ProductDisplay {
   title: string;
-  description: string;
+  /** Static text, or a builder receiving the selected period label ("monthly"/"yearly"). */
+  description: string | ((periodLabel: string) => string);
   /** Short label used in the Current/New plan comparison block. */
   rowLabel: string;
   packageUnitLabel: string;
@@ -31,12 +32,13 @@ interface ProductDisplay {
 const PAYG_PLAN_LINE: PlanLine = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
 
 const ADDITIONAL_DEVICES_HELPER_TEXT =
-  'You can add more devices anytime. Additional devices beyond your package are charged at $5/device and added to your next invoice.';
+  'You can add more devices anytime. Additional devices beyond your package are charged at pay-as-you-go rates and added to your next invoice.';
 
 const PRODUCT_DISPLAY: Partial<Record<OpenframeProduct, ProductDisplay>> = {
   MANAGED_DEVICES: {
     title: 'Device Management Plan',
-    description: "Select the number of devices you'd like to include in your monthly subscription plan:",
+    description: periodLabel =>
+      `Select the number of devices you'd like to include in your ${periodLabel} subscription plan:`,
     rowLabel: 'Devices',
     packageUnitLabel: 'devices',
     customLabel: 'Custom Amount',
@@ -143,8 +145,11 @@ function SubscriptionSettingsContent() {
     return [{ label: display.rowLabel, comparison: effective }];
   });
 
-  // Only meaningful for the update flow (active subscription) once something changed.
-  const showPlanChange = !needsCheckout && packageUpdates.length > 0 && summaryItems.length > 0;
+  // Only meaningful for the update flow (active subscription). Driven by the
+  // comparison, not `packageUpdates`, so a valid selection that differs from the
+  // current plan always previews — even when the change can't yet be expressed
+  // as a mutation (see isPlanChanged).
+  const showPlanChange = !needsCheckout && summaryItems.some(item => isPlanChanged(item.comparison));
 
   return (
     <PageLayout

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-product-selection.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-product-selection.ts
@@ -34,8 +34,9 @@ export function useProductSelection({ product, subscriptionProduct, onUpdatesCha
   onUpdatesChangeRef.current = onUpdatesChange;
 
   useEffect(() => {
-    // customQuantity is the real product count; it must be a positive multiple
-    // of unitSize (devices: 1, AI tokens: 100_000).
+    // customQuantity is the real product count the user typed; unitSize only
+    // constrains granularity — it must be a positive multiple of unitSize
+    // (devices: 1, AI tokens: 100_000).
     const unitSize = Number(product.unitSize ?? 1) || 1;
     const valid =
       selection.selectedPackageId !== CUSTOM_OPTION_ID ||
@@ -65,9 +66,8 @@ export function useProductSelection({ product, subscriptionProduct, onUpdatesCha
   const baselineUnitPrice = allTiers[0]?.unitPrice ?? product.payAsYouGoOption?.price ?? null;
   const tiers = allTiers.slice(1);
   const isYearly = selection.billingPeriod === 'YEARLY';
-  // Products per billable unit (devices: 1, AI tokens: 100_000). tier.from and
-  // mutation quantity are in units; the Custom input holds the real product
-  // count and must be a whole multiple of unitSize.
+  // Granularity for the Custom input (devices: 1, AI tokens: 100_000): the
+  // entered real product count must be a whole multiple of unitSize.
   const unitSize = Number(product.unitSize ?? 1) || 1;
 
   return {

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/build-package-radio-options.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/build-package-radio-options.tsx
@@ -21,10 +21,6 @@ interface BuildPackageRadioOptionsArgs {
   customLabel: string;
   customSubtitle: string;
   payAsYouGoOption: PayAsYouGoOption | null;
-  /** Products per billable unit (devices: 1, AI tokens: 100_000) — display only. */
-  unitSize: number;
-  /** PAYG is monthly-only; hidden on the yearly tab. */
-  showPayg: boolean;
 }
 
 export function buildPackageRadioOptions({
@@ -36,20 +32,17 @@ export function buildPackageRadioOptions({
   customLabel,
   customSubtitle,
   payAsYouGoOption,
-  unitSize,
-  showPayg,
 }: BuildPackageRadioOptionsArgs) {
-  const paygOption =
-    showPayg && payAsYouGoOption
-      ? [{ value: PAYG_OPTION_ID, label: 'Pay as you go', description: formatPaygSubtitle(payAsYouGoOption) }]
-      : [];
+  const paygOption = payAsYouGoOption
+    ? [{ value: PAYG_OPTION_ID, label: 'Pay as you go', description: formatPaygSubtitle(payAsYouGoOption) }]
+    : [];
 
   const tierOptions = tiers.map(tier => {
     const total = tier.from * tier.unitPrice * months;
     const discountPercent = baselineUnitPrice ? Math.round((1 - tier.unitPrice / baselineUnitPrice) * 100) : 0;
     return {
       value: String(tier.from),
-      label: `${formatCompact(tier.from * unitSize)} ${packageUnitLabel}`,
+      label: `${formatCompact(tier.from)} ${packageUnitLabel}`,
       description: `$${formatMoney(total)}${periodSuffix}`,
       trailing:
         discountPercent > 0 ? (

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
@@ -20,11 +20,11 @@ export function formatCompact(value: number): string {
 }
 
 /**
- * Topmost selectable radio for a billing period: PAYG is monthly-only and sits
- * first when present; otherwise the first tier; otherwise Custom.
+ * Topmost selectable radio for a billing period: PAYG sits first when present
+ * (any period); otherwise the first tier; otherwise Custom.
  */
 export function topmostSelectionId(product: ProductData, period: BillingPeriod): string {
-  if (period === 'MONTHLY' && product.payAsYouGoOption) return PAYG_OPTION_ID;
+  if (product.payAsYouGoOption) return PAYG_OPTION_ID;
   const periodOption = product.packageOptions.find(o => o.billingPeriod === period) ?? product.packageOptions[0];
   const tiers = periodOption?.priceTiers?.slice(1) ?? [];
   return tiers.length > 0 ? String(tiers[0].from) : CUSTOM_OPTION_ID;
@@ -85,7 +85,7 @@ export function buildInitialSelection(
     selectedPackageId = String(matchedTier.from);
   } else if (activeQuantity != null) {
     selectedPackageId = CUSTOM_OPTION_ID;
-    customQuantity = toDisplayQuantity(activeQuantity, product.unitSize);
+    customQuantity = activeQuantity;
   } else {
     // No active tier/custom package: default to PAYG (current PAYG state, or soft-default for trial/no-plan users).
     selectedPackageId = PAYG_OPTION_ID;
@@ -116,27 +116,18 @@ function toCatalogOptionId(globalId: string): string {
 }
 
 /**
- * Backend `quantity` (and catalog `priceTier.from`) is stored in billable units
- * (devices: 1, AI tokens: 100_000). Multiply by `unitSize` to get the value the
- * user actually sees in the UI (real device count, real token count).
+ * Backend `quantity`, catalog `priceTier.from`/`upTo`, and the Custom Amount
+ * input all speak the same real product count (devices, tokens) — no unit
+ * conversion. `unitSize` (devices: 1, AI tokens: 100_000) is only a granularity
+ * constraint: the custom quantity must be a positive whole multiple of it.
+ * Returns the entered quantity when valid, else null (the UI surfaces a
+ * "must be a multiple of N" error in that case).
  */
-export function toDisplayQuantity(rawUnits: number | null | undefined, unitSize: number | null | undefined): number {
-  if (rawUnits == null) return 0;
-  const size = Number(unitSize ?? 1) || 1;
-  return rawUnits * size;
-}
-
-/**
- * The Custom Amount input holds the real product count the user typed (tokens,
- * devices, …). Tier `from` / mutation `quantity` are in units, so convert by
- * dividing by `unitSize`. Returns null when empty or not a whole multiple of
- * `unitSize` (the UI surfaces a "must be a multiple of N" error in that case).
- */
-function customUnits(product: ProductData, customQuantity: number | null): number | null {
+function validCustomQuantity(product: ProductData, customQuantity: number | null): number | null {
   if (customQuantity == null || customQuantity <= 0) return null;
   const unitSize = Number(product.unitSize ?? 1) || 1;
   if (customQuantity % unitSize !== 0) return null;
-  return customQuantity / unitSize;
+  return customQuantity;
 }
 
 /**
@@ -173,7 +164,7 @@ export function diffPackageUpdates(
 
   let nextQuantity: number | null = null;
   if (currentSelection.selectedPackageId === CUSTOM_OPTION_ID) {
-    nextQuantity = customUnits(product, currentSelection.customQuantity);
+    nextQuantity = validCustomQuantity(product, currentSelection.customQuantity);
   } else if (currentSelection.selectedPackageId) {
     const parsed = Number.parseInt(currentSelection.selectedPackageId, 10);
     nextQuantity = Number.isFinite(parsed) ? parsed : null;
@@ -188,6 +179,24 @@ export function diffPackageUpdates(
   }
 
   return [];
+}
+
+/**
+ * Whether a product's selection differs from its current commitment — drives the
+ * visibility of the Current/New plan-change summary. Deliberately independent of
+ * `diffPackageUpdates`: the summary is a visual preview, so any valid selection
+ * that differs from today should show it, even in catalog edge-cases where the
+ * change can't yet be expressed as a `PackageUpdateInput`. An invalid/empty
+ * custom amount (`next.quantity == null`) is not a change.
+ */
+export function isPlanChanged({ current, next }: PlanComparison): boolean {
+  const nextValid = next.payg || next.quantity != null;
+  if (!nextValid) return false;
+  if (!current) return !next.payg;
+  if (current.payg !== next.payg) return true;
+  if (next.payg) return false;
+  if (current.billingPeriod !== next.billingPeriod) return true;
+  return (current.quantity ?? null) !== (next.quantity ?? null);
 }
 
 interface CancelablePackageOption {
@@ -234,7 +243,7 @@ export function buildCheckoutProduct(
 
   let quantity: number | null = null;
   if (currentSelection.selectedPackageId === CUSTOM_OPTION_ID) {
-    quantity = customUnits(product, currentSelection.customQuantity);
+    quantity = validCustomQuantity(product, currentSelection.customQuantity);
   } else if (currentSelection.selectedPackageId) {
     const parsed = Number.parseInt(currentSelection.selectedPackageId, 10);
     quantity = Number.isFinite(parsed) ? parsed : null;
@@ -248,10 +257,10 @@ export function buildCheckoutProduct(
   };
 }
 
-/** Selected committed quantity in billable units (null for PAYG / empty Custom). */
-function selectionUnits(product: ProductData, selection: ProductSelectionState): number | null {
+/** Selected committed quantity in real product counts (null for PAYG / empty Custom). */
+function selectionQuantity(product: ProductData, selection: ProductSelectionState): number | null {
   if (selection.selectedPackageId === PAYG_OPTION_ID) return null;
-  if (selection.selectedPackageId === CUSTOM_OPTION_ID) return customUnits(product, selection.customQuantity);
+  if (selection.selectedPackageId === CUSTOM_OPTION_ID) return validCustomQuantity(product, selection.customQuantity);
   if (selection.selectedPackageId) {
     const parsed = Number.parseInt(selection.selectedPackageId, 10);
     return Number.isFinite(parsed) ? parsed : null;
@@ -260,18 +269,19 @@ function selectionUnits(product: ProductData, selection: ProductSelectionState):
 }
 
 /**
- * Annualized committed cost for `units` billable units against `tiers`.
- * `priceTier.unitPrice` is per unit per month, so a year is always × 12 — the
+ * Annualized committed cost for `quantity` real product counts against `tiers`.
+ * `priceTier.unitPrice` is per product per month, so a year is always × 12 — the
  * yearly discount is already baked into the yearly period's tiers.
  */
 function annualizedPackagePrice(
-  units: number | null,
+  quantity: number | null,
   tiers: readonly PriceTierInput[] | null | undefined,
 ): number | null {
-  if (units == null || units <= 0 || !tiers || tiers.length === 0) return null;
-  const applicable = tiers.find(t => units >= t.from && (t.upTo == null || units <= t.upTo)) ?? tiers[tiers.length - 1];
+  if (quantity == null || quantity <= 0 || !tiers || tiers.length === 0) return null;
+  const applicable =
+    tiers.find(t => quantity >= t.from && (t.upTo == null || quantity <= t.upTo)) ?? tiers[tiers.length - 1];
   if (!applicable) return null;
-  return units * applicable.unitPrice * 12;
+  return quantity * applicable.unitPrice * 12;
 }
 
 function tiersForPeriod(product: ProductData, period: BillingPeriod | null): readonly PriceTierInput[] {
@@ -297,7 +307,7 @@ export function buildPlanComparison(
       const period = (activePackage.billingPeriod ?? null) as BillingPeriod | null;
       current = {
         payg: false,
-        quantity: toDisplayQuantity(activePackage.quantity, product.unitSize),
+        quantity: activePackage.quantity,
         billingPeriod: period,
         annualTotal: annualizedPackagePrice(activePackage.quantity, tiersForPeriod(product, period)),
       };
@@ -311,12 +321,12 @@ export function buildPlanComparison(
   if (selection.selectedPackageId === PAYG_OPTION_ID) {
     next = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
   } else {
-    const units = selectionUnits(product, selection);
+    const quantity = selectionQuantity(product, selection);
     next = {
       payg: false,
-      quantity: units != null ? toDisplayQuantity(units, product.unitSize) : null,
+      quantity,
       billingPeriod: selection.billingPeriod,
-      annualTotal: annualizedPackagePrice(units, tiersForPeriod(product, selection.billingPeriod)),
+      annualTotal: annualizedPackagePrice(quantity, tiersForPeriod(product, selection.billingPeriod)),
     };
   }
 


### PR DESCRIPTION
## Summary

Refactors the billing/subscription module to treat AI/device **quantities and price tiers as real product counts** end-to-end (the backend no longer uses billable units). `unitSize` is now used **only** to validate that a custom token amount is a whole multiple — every multiply/divide conversion (`toDisplayQuantity`, `customUnits`, `tier.from * unitSize`) is removed. Also adds the **Invoices History** list and fixes several display issues.

> ⚠️ This assumes the backend now returns/accepts `quantity` and price tiers in real tokens. If that change isn't deployed yet, the `quantity` sent to Stripe would be 100,000× off — please validate on staging before merge.

## Usage & summary
- Allocations and pending-plan quantities read backend `quantity` directly (no `unitSize` scaling).
- **"Over limit"** fires only on real overage (`used > allocation`), not at exactly 100%; `warning` covers the 90–100% approach.
- PAYG cards show **no percentage** (no package limit) — just the usage count.
- Rename **"Monthly Cost" → "Next Payment"**; drop the **Estimated Overage** row and the hardcoded **AI conversations** row (no backend field).

## Subscription form
- **PAYG** is now offered on the **yearly** tab too (was monthly-only).
- Device-plan copy reflects the selected billing period (monthly/yearly).
- Removed the hardcoded **"$5/device"** price from the helper text.
- Model token rates use **`displayName`**; the rates panel **scrolls** when long and opens via a click **DropdownMenu** (was a hover Tooltip that dismissed on click and overflowed).
- Plan-change summary: mute only **changed** rows in the Current column so unchanged rows stay white, matching the New column.

## Invoices history
- New **DataTable**-based list from `subscription.pendingInvoices` (issue date / due date / amount / status + open-in-Stripe action, client-side search).
- **Status is mocked as "Unpaid"** until the schema exposes an invoice status.

## Known follow-ups (need backend)
- Invoice **status** is mocked; schema exposes no status field on `PendingInvoice`.
- No human invoice **number** (`number`) — the INVOICE column shows the issue date instead of the opaque Stripe id.
- Source is `pendingInvoices` (unpaid only), not full invoice history.
- The "Search for Invoice" box filters by the (hidden) Stripe id — effectively a no-op until a searchable field exists.

## Testing
- `npm run lint:biome` — clean (4 pre-existing warnings, unrelated).
- `npm run type-check` — 0 errors in changed files (the ~700 TS7016 are a known yalc-environment issue, not from this change).
- `npm run relay` — artifacts regenerate (gitignored; rebuilt in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable invoices history section displaying pending invoices with due dates and direct payment links
  * Enhanced model token rates display with pinned headers and scrollable rows

* **Improvements**
  * Relabeled "Monthly Cost" to "Next Payment" for clearer billing information
  * Removed "Estimated Overage" from billing summary
  * Improved plan change highlighting—only changed items are emphasized
  * Converted billing period help from hover tooltips to click-triggered menu for better accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->