### PR TITLE
fix(help-center): bump openframe-frontend-core for og-placeholder default

### DIFF
--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.299",
+    "@flamingo-stack/openframe-frontend-core": "0.0.300",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.296",
+    "@flamingo-stack/openframe-frontend-core": "0.0.299",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-runtime-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/help-center-runtime-provider.tsx
@@ -50,6 +50,10 @@ export function HelpCenterRuntimeProvider({ children }: { children: ReactNode })
       // source of truth in `help-center-content-href.ts`) so a card lands in the
       // SAME place whether it's rendered on a Help Center page or in the chat.
       composeContentUrl: composeOpenframeContentUrl,
+      // NOTE: og-placeholder needs NO wiring here. The lib owns the whole
+      // og-placeholder logic and derives the route base from `imageProxyUrlPrefix`
+      // (set on the app-wide provider, inherited via `...parent`). Don't re-add a
+      // per-subtree `resolvePlaceholderUrl` callback.
     }),
     [parent],
   );


### PR DESCRIPTION
## What & why

Onboarding-guide and release cards with **no cover image** rendered a blank slot with **no og-placeholder request** in the `/help-center` embed.

The fix lives **entirely in the lib** (`flamingo-stack/openframe-oss-lib#1217`): the lib now owns og-placeholder construction and derives the route base from the runtime `endpoints` (`imageProxyUrlPrefix`, already set on the app-wide `OpenframeChatRuntimeProvider`). **This app needs zero og-placeholder code** — only the version bump to pick up the default.

## Change

- **`package.json`** — bump `@flamingo-stack/openframe-frontend-core` `0.0.296` → `0.0.299`.
- **`help-center-runtime-provider.tsx`** — a one-line note so nobody re-adds a per-subtree `resolvePlaceholderUrl` callback (the lib does it).

No hand-built URL, no consumer-side concatenation — the app hands the lib its `endpoints` and nothing else.

## ⚠️ Merge order

Merge **after** `openframe-oss-lib#1217` is merged and published. `0.0.299` is the anticipated next release after npm latest `0.0.298` — **confirm the pin matches the actual published version** before merging (bumping ahead of publish fails `next build` / install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains internal updates and dependency maintenance with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->