### PR TITLE
hotfix(frontend): scripts v2 (Relay) + hide Next Payment during active trial

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/page.tsx
@@ -52,7 +52,7 @@ const ITEMS: Item[] = [
   },
   {
     href: `${HELP_CENTER_BASE}/tickets`,
-    title: 'Help Center',
+    title: 'Support Tickets',
     description: 'Open and manage your support tickets.',
     Icon: LifeBuoyIcon,
   },

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/create/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/create/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { EditScriptPage } from '../../scripts/v2/components/edit-script-page';
+
+export default function CreateScriptV2PageWrapper() {
+  return <EditScriptPage scriptId={null} />;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/details/[id]/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/details/[id]/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { ScriptDetailsView } from '../../../scripts/v2/components/script-details-view';
+
+export default function ScriptDetailsV2Page() {
+  const params = useParams<{ id?: string }>();
+  const id = typeof params?.id === 'string' ? params.id : '';
+  return <ScriptDetailsView scriptId={id} />;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/details/[id]/run/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/details/[id]/run/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import RunScriptView from '../../../../scripts/v2/components/run-script-view';
+
+export default function RunScriptV2Page() {
+  const params = useParams<{ id?: string }>();
+  const id = typeof params?.id === 'string' ? params.id : '';
+  return <RunScriptView scriptId={id} />;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/edit/[id]/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/edit/[id]/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { EditScriptPage } from '../../../scripts/v2/components/edit-script-page';
+
+export default function EditScriptV2PageWrapper() {
+  const params = useParams<{ id?: string }>();
+  const id = typeof params?.id === 'string' ? params.id : null;
+  return <EditScriptPage scriptId={id} />;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/layout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { featureFlags } from '@/lib/feature-flags';
+import { useFeatureFlagsStore } from '@/stores/feature-flags-store';
+
+/**
+ * Gates every `/scripts-v2/*` route behind the `scripts-v2` feature flag.
+ * Feature flags are guaranteed loaded before app children render (see
+ * `FeatureFlagsGate`), so this reads the resolved value with no flash. When the
+ * flag is off, direct navigation here redirects to the stable `/scripts` page.
+ */
+export default function ScriptsV2Layout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+
+  // Subscribe to the resolved flag so the gate re-evaluates when the store loads
+  // or the value changes. When the server doesn't return the flag, fall back to
+  // the env-var default (mirrors `featureFlags.scriptsV2.enabled()`).
+  const serverValue = useFeatureFlagsStore(s => (s.isLoaded ? s.flags['scripts-v2'] : undefined));
+  const enabled = serverValue ?? featureFlags.scriptsV2.enabled();
+
+  useEffect(() => {
+    if (!enabled) {
+      router.replace('/scripts');
+    }
+  }, [enabled, router]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts-v2/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+import { ContentPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { ScriptsTable } from '../scripts/v2/components/scripts-table';
+
+export default function ScriptsV2Page() {
+  return (
+    <ContentPageContainer className="p-[var(--spacing-system-l)]" padding="none" showHeader={false}>
+      <ScriptsTable />
+    </ContentPageContainer>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-editor.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-editor.tsx
@@ -90,6 +90,8 @@ interface ScriptEditorProps {
   shell?: string;
   readOnly?: boolean;
   height?: string;
+  /** Render an error border (e.g. when the bound form field is invalid). */
+  invalid?: boolean;
 }
 
 export function ScriptEditor({
@@ -98,6 +100,7 @@ export function ScriptEditor({
   shell = 'bash',
   readOnly = false,
   height = '400px',
+  invalid = false,
 }: ScriptEditorProps) {
   const editorRef = useRef<ReturnType<Monaco['editor']['create']> | null>(null);
 
@@ -119,7 +122,7 @@ export function ScriptEditor({
   );
 
   return (
-    <div className="rounded-md border border-ods-border overflow-hidden">
+    <div className={`rounded-md border overflow-hidden ${invalid ? 'border-ods-error' : 'border-ods-border'}`}>
       <Editor
         height={height}
         language={language}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-form-fields.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-form-fields.tsx
@@ -21,12 +21,20 @@ import { ScriptEditor } from './script-editor';
 
 interface ScriptFormFieldsProps {
   form: UseFormReturn<EditScriptFormData>;
+  /** Restrict the Shell Type options to these ids. Omit to show every SHELL_TYPES entry. */
+  allowedShellIds?: string[];
+  /** Hide the Category field (the native API has no such concept). */
+  hideCategory?: boolean;
+  /** Hide the "Run as User" toggle (not a stored script field on the native API). */
+  hideRunAsUser?: boolean;
 }
 
-export function ScriptFormFields({ form }: ScriptFormFieldsProps) {
+export function ScriptFormFields({ form, allowedShellIds, hideCategory, hideRunAsUser }: ScriptFormFieldsProps) {
   const { control, watch, setValue, getValues } = form;
   const watchedSupportedPlatforms = watch('supported_platforms');
   const isMdUp = useMdUp();
+
+  const shellTypes = allowedShellIds ? SHELL_TYPES.filter(s => allowedShellIds.includes(s.value)) : SHELL_TYPES;
 
   return (
     <>
@@ -59,18 +67,20 @@ export function ScriptFormFields({ form }: ScriptFormFieldsProps) {
               />
             );
           })}
-          <Controller
-            name="run_as_user"
-            control={control}
-            render={({ field }) => (
-              <CheckboxBlock
-                checked={field.value}
-                onCheckedChange={checked => field.onChange(checked)}
-                label="Run as User"
-                description="Windows Only"
-              />
-            )}
-          />
+          {!hideRunAsUser && (
+            <Controller
+              name="run_as_user"
+              control={control}
+              render={({ field }) => (
+                <CheckboxBlock
+                  checked={field.value}
+                  onCheckedChange={checked => field.onChange(checked)}
+                  label="Run as User"
+                  description="Windows Only"
+                />
+              )}
+            />
+          )}
         </div>
       </div>
 
@@ -105,7 +115,7 @@ export function ScriptFormFields({ form }: ScriptFormFieldsProps) {
                   <SelectValue placeholder="Select Shell Type" />
                 </SelectTrigger>
                 <SelectContent>
-                  {SHELL_TYPES.map(s => (
+                  {shellTypes.map(s => (
                     <SelectItem key={s.value} value={s.value}>
                       <div className="flex items-center gap-2">
                         <s.icon className="w-5 h-5" />
@@ -119,27 +129,29 @@ export function ScriptFormFields({ form }: ScriptFormFieldsProps) {
           )}
         />
 
-        <Controller
-          name="category"
-          control={control}
-          render={({ field, fieldState }) => (
-            <div className="space-y-1">
-              <Label className="text-lg font-['DM_Sans'] font-medium text-ods-text-primary">Category</Label>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger error={fieldState.error?.message} invalid={!!fieldState.error}>
-                  <SelectValue placeholder="Select Category" />
-                </SelectTrigger>
-                <SelectContent>
-                  {CATEGORIES.map(category => (
-                    <SelectItem key={category} value={category}>
-                      {category}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-        />
+        {!hideCategory && (
+          <Controller
+            name="category"
+            control={control}
+            render={({ field, fieldState }) => (
+              <div className="space-y-1">
+                <Label className="text-lg font-['DM_Sans'] font-medium text-ods-text-primary">Category</Label>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger error={fieldState.error?.message} invalid={!!fieldState.error}>
+                    <SelectValue placeholder="Select Category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CATEGORIES.map(category => (
+                      <SelectItem key={category} value={category}>
+                        {category}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          />
+        )}
 
         <Controller
           name="default_timeout"
@@ -211,10 +223,21 @@ export function ScriptFormFields({ form }: ScriptFormFieldsProps) {
       <Controller
         name="script_body"
         control={control}
-        render={({ field }) => (
+        render={({ field, fieldState }) => (
           <div>
             <Label className="text-lg font-['DM_Sans'] font-medium text-ods-text-primary">Syntax</Label>
-            <ScriptEditor value={field.value} onChange={field.onChange} shell={getValues('shell')} height="600px" />
+            <ScriptEditor
+              value={field.value}
+              onChange={field.onChange}
+              shell={getValues('shell')}
+              height="600px"
+              invalid={!!fieldState.error}
+            />
+            {fieldState.error && (
+              <p className="text-h6 text-ods-error truncate mt-1" title={fieldState.error.message}>
+                {fieldState.error.message}
+              </p>
+            )}
           </div>
         )}
       />

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/edit-script-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/edit-script-page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { Suspense, useCallback, useMemo, useState } from 'react';
+import { useLazyLoadQuery, useMutation } from 'react-relay';
+import type { runCommandMutation as RunCommandMutationType } from '@/__generated__/runCommandMutation.graphql';
+import type { scriptDetailRelayQuery as ScriptDetailQueryType } from '@/__generated__/scriptDetailRelayQuery.graphql';
+import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { runCommandMutation } from '@/graphql/scripts/run-command-mutation';
+import { scriptDetailRelayQuery } from '@/graphql/scripts/script-detail-relay';
+import { ExecutionStartedModal } from '../../components/script/execution-started-modal';
+import { ScriptFormFields } from '../../components/script/script-form-fields';
+import type { EditScriptFormData } from '../../types/edit-script.types';
+import { useEditScriptForm } from '../hooks/use-edit-script-form';
+import { ALLOWED_SHELL_IDS, relayScriptToForm, shellToEnum } from '../utils/script-mappers';
+import { EditScriptSkeleton } from './edit-script-skeleton';
+import { type SelectedTestDevice, TestScriptModal } from './test-script-modal';
+
+interface EditScriptFormProps {
+  scriptId: string | null;
+  initialValues: EditScriptFormData | null;
+}
+
+function EditScriptForm({ scriptId, initialValues }: EditScriptFormProps) {
+  const isEditMode = Boolean(scriptId);
+  const { toast } = useToast();
+  const handleBackToList = useSafeBack('/scripts-v2');
+  const handleBackToDetails = useSafeBack(`/scripts-v2/details/${scriptId}`);
+  const backButton = useMemo(
+    () => ({ label: 'Back', onClick: isEditMode ? handleBackToDetails : handleBackToList }),
+    [isEditMode, handleBackToDetails, handleBackToList],
+  );
+
+  const { form, isSubmitting, handleSave } = useEditScriptForm({ scriptId, initialValues, isEditMode });
+
+  const [isTestModalOpen, setIsTestModalOpen] = useState(false);
+  const [testDispatched, setTestDispatched] = useState(false);
+  const [commitRunCommand] = useMutation<RunCommandMutationType>(runCommandMutation);
+
+  const watchedSupportedPlatforms = form.watch('supported_platforms');
+
+  // The test (runCommand) only needs a shell, a non-empty body and at least one
+  // platform (so the device picker has candidates). timeout / privilege have
+  // defaults. Validate these BEFORE opening the device picker so the user is
+  // never sent through device selection only to hit a dead-end.
+  //
+  // `shell` and `script_body` are validated via the resolver (`trigger`) so their
+  // errors and clearing are fully owned by RHF — the form runs in `onChange`
+  // mode, so the red state disappears the moment the field becomes valid.
+  const validateTestPrereqs = useCallback(async () => {
+    const values = form.getValues();
+    const [shellOk, bodyOk] = await Promise.all([form.trigger('shell'), form.trigger('script_body')]);
+
+    const missing: string[] = [];
+    if (!shellOk) {
+      missing.push('a shell type');
+    }
+    if (!bodyOk) {
+      missing.push('script content');
+    }
+    if (values.supported_platforms.length === 0) {
+      missing.push('a supported platform');
+    }
+
+    if (missing.length > 0) {
+      toast({
+        title: 'Cannot test yet',
+        description: `Add ${missing.join(', ')} before testing the script.`,
+        variant: 'destructive',
+      });
+      return false;
+    }
+    return true;
+  }, [form, toast]);
+
+  const handleOpenTest = useCallback(async () => {
+    if (await validateTestPrereqs()) {
+      setIsTestModalOpen(true);
+    }
+  }, [validateTestPrereqs]);
+
+  const handleDeviceSelected = useCallback(
+    async (device: SelectedTestDevice) => {
+      // Prereqs were validated before the picker opened; re-check defensively in
+      // case the form changed while it was open.
+      if (!(await validateTestPrereqs())) {
+        setIsTestModalOpen(false);
+        return;
+      }
+      const values = form.getValues();
+
+      commitRunCommand({
+        variables: {
+          input: {
+            machineId: device.machineId,
+            shell: shellToEnum(values.shell),
+            command: values.script_body,
+            privilegeLevel: device.runAsUser ? 'USER' : 'ADMIN',
+            timeoutSeconds: values.default_timeout,
+          },
+        },
+        onCompleted: () => setTestDispatched(true),
+        onError: err => {
+          toast({
+            title: 'Test failed',
+            description: err instanceof Error ? err.message : 'Failed to dispatch test',
+            variant: 'destructive',
+          });
+        },
+      });
+    },
+    [form, commitRunCommand, toast, validateTestPrereqs],
+  );
+
+  const handleViewLogs = useCallback(() => {
+    setTestDispatched(false);
+    // Open logs in a new tab so the user doesn't lose the in-progress script edits.
+    window.open('/logs-page', '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const actions = useMemo(
+    () => [
+      {
+        label: 'Test Script',
+        onClick: handleOpenTest,
+        variant: 'outline' as const,
+      },
+      {
+        label: 'Save Script',
+        onClick: handleSave,
+        variant: 'accent' as const,
+        disabled: isSubmitting,
+        loading: isSubmitting,
+      },
+    ],
+    [handleSave, isSubmitting, handleOpenTest],
+  );
+
+  return (
+    <PageLayout
+      title={isEditMode ? 'Edit Script' : 'New Script'}
+      backButton={backButton}
+      actions={actions}
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
+    >
+      <ScriptFormFields form={form} allowedShellIds={ALLOWED_SHELL_IDS} hideCategory hideRunAsUser />
+
+      <TestScriptModal
+        isOpen={isTestModalOpen}
+        onClose={() => setIsTestModalOpen(false)}
+        onDeviceSelected={handleDeviceSelected}
+        supportedPlatforms={watchedSupportedPlatforms}
+      />
+
+      <ExecutionStartedModal
+        isOpen={testDispatched}
+        onClose={() => setTestDispatched(false)}
+        scriptName={form.getValues('name') || 'Script'}
+        onViewLogs={handleViewLogs}
+      />
+    </PageLayout>
+  );
+}
+
+function EditScriptLoader({ scriptId }: { scriptId: string }) {
+  const data = useLazyLoadQuery<ScriptDetailQueryType>(
+    scriptDetailRelayQuery,
+    { id: scriptId },
+    { fetchPolicy: 'store-and-network' },
+  );
+
+  const initialValues = useMemo(() => (data.script ? relayScriptToForm(data.script) : null), [data.script]);
+
+  return <EditScriptForm scriptId={scriptId} initialValues={initialValues} />;
+}
+
+interface EditScriptPageProps {
+  scriptId: string | null;
+}
+
+export function EditScriptPage({ scriptId }: EditScriptPageProps) {
+  if (!scriptId) {
+    return <EditScriptForm scriptId={null} initialValues={null} />;
+  }
+
+  return (
+    <Suspense fallback={<EditScriptSkeleton />}>
+      <EditScriptLoader scriptId={scriptId} />
+    </Suspense>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/edit-script-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/edit-script-skeleton.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
+import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+
+/** A label + control pair, matching one cell of the form-fields grid. */
+function FieldSkeleton() {
+  return (
+    <div className="space-y-1">
+      <Skeleton className="h-6 w-24" />
+      <Skeleton className="h-12 w-full rounded-md" />
+    </div>
+  );
+}
+
+/**
+ * Loading state for the v2 Edit Script page. Renders inside the real
+ * `PageLayout` (with the title, back button and disabled actions) so only the
+ * form body swaps when the Relay query resolves — no header jump. The body
+ * mirrors the v2 `ScriptFormFields` layout: 2 platform cards (no Run as User),
+ * a 3-field row (Name / Shell Type / Timeout — no Category), description,
+ * arguments + env vars, then the editor.
+ */
+export function EditScriptSkeleton() {
+  const placeholderActions = [
+    { label: 'Test Script', onClick: () => {}, variant: 'outline' as const, disabled: true },
+    { label: 'Save Script', onClick: () => {}, variant: 'accent' as const, disabled: true },
+  ];
+
+  return (
+    <PageLayout
+      title="Edit Script"
+      backButton={{ label: 'Back', onClick: () => {} }}
+      actions={placeholderActions}
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
+    >
+      <div className="flex flex-col gap-6">
+        {/* Supported Platform */}
+        <div>
+          <Skeleton className="h-7 w-44 mb-2" />
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <Skeleton className="h-14 rounded-md" />
+            <Skeleton className="h-14 rounded-md" />
+          </div>
+        </div>
+
+        {/* Name / Shell Type / Timeout */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
+          <FieldSkeleton />
+          <FieldSkeleton />
+          <FieldSkeleton />
+        </div>
+
+        {/* Description */}
+        <div>
+          <Skeleton className="h-7 w-28 mb-2" />
+          <Skeleton className="h-28 w-full rounded-md" />
+        </div>
+
+        {/* Script Arguments + Environment Vars */}
+        <div className="flex flex-col lg:flex-row gap-6">
+          {[0, 1].map(i => (
+            <div key={i} className="flex-1 flex items-center gap-2">
+              <Skeleton className="h-5 w-5 rounded-full" />
+              <Skeleton className="h-5 w-40" />
+            </div>
+          ))}
+        </div>
+
+        {/* Syntax editor */}
+        <div>
+          <Skeleton className="h-7 w-20 mb-2" />
+          <Skeleton className="h-[300px] lg:h-[600px] w-full rounded-md" />
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-skeleton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
+import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { ScriptSummaryCardSkeleton } from './script-details-skeleton';
+
+/** One arguments column (title + a couple of key/value rows). */
+function ArgumentsSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-6 w-36" />
+      {[0, 1].map(i => (
+        <div key={i} className="flex gap-2">
+          <Skeleton className="h-12 flex-1 rounded-md" />
+          <Skeleton className="h-12 flex-1 rounded-md" />
+        </div>
+      ))}
+      <Skeleton className="h-5 w-44" />
+    </div>
+  );
+}
+
+/**
+ * Loading state for the v2 Run Script page. Renders inside the real `PageLayout`
+ * (title, Back button, disabled Run Script action) so only the body swaps when
+ * the Relay query resolves — matching {@link RunScriptView}: summary card (no
+ * Timeout cell), the editable Timeout input, arguments + env vars, then the
+ * device selector.
+ */
+export function RunScriptSkeleton() {
+  const placeholderActions = [{ label: 'Run Script', onClick: () => {}, variant: 'accent' as const, disabled: true }];
+
+  return (
+    <PageLayout
+      title="Run Script"
+      backButton={{ label: 'Back', onClick: () => {} }}
+      actions={placeholderActions}
+      className="md:px-[var(--spacing-system-l)] md:pb-[var(--spacing-system-l)]"
+    >
+      <div className="flex-1 overflow-auto">
+        <ScriptSummaryCardSkeleton stats={2} />
+
+        {/* Timeout */}
+        <div className="pt-6 space-y-1">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-12 w-full md:max-w-[320px] rounded-md" />
+        </div>
+
+        {/* Script Arguments + Environment Vars */}
+        <div className="pt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <ArgumentsSkeleton />
+          <ArgumentsSkeleton />
+        </div>
+
+        {/* Device selector */}
+        <div className="pt-6 space-y-3">
+          <Skeleton className="h-12 w-full rounded-md" />
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }, (_, i) => (
+              <Skeleton key={i} className="h-20 rounded-md" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-view.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { NotFoundError, PageLayout, ScriptArguments } from '@flamingo-stack/openframe-frontend-core';
+import { Input, Label } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useLazyLoadQuery, useMutation } from 'react-relay';
+import { z } from 'zod';
+import type { runScriptMutation as RunScriptMutationType } from '@/__generated__/runScriptMutation.graphql';
+import type { scriptDetailRelayQuery as ScriptDetailQueryType } from '@/__generated__/scriptDetailRelayQuery.graphql';
+import { DeviceSelector } from '@/app/components/shared/device-selector';
+import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { runScriptMutation } from '@/graphql/scripts/run-script-mutation';
+import { scriptDetailRelayQuery } from '@/graphql/scripts/script-detail-relay';
+import type { Device } from '../../../devices/types/device.types';
+import { ExecutionStartedModal } from '../../components/script/execution-started-modal';
+import { scriptArgumentSchema } from '../../types/edit-script.types';
+import { getDevicePrimaryId } from '../../utils/device-helpers';
+import { parseKeyValues, serializeKeyValues } from '../../utils/script-key-values';
+import { useRunDevices } from '../hooks/use-run-devices';
+import { envVarsToInput, envVarsToPairs, platformsToIds, shellToId } from '../utils/script-mappers';
+import { RunScriptSkeleton } from './run-script-skeleton';
+import { ScriptSummaryCard } from './script-summary-card';
+
+interface RunScriptViewProps {
+  scriptId: string;
+}
+
+const runFormSchema = z.object({
+  timeout: z.number().min(1, 'Timeout must be at least 1 second').max(86400, 'Timeout cannot exceed 24 hours'),
+  scriptArgs: z.array(scriptArgumentSchema),
+  envVars: z.array(scriptArgumentSchema),
+});
+
+type RunFormData = z.infer<typeof runFormSchema>;
+
+function getMachineId(device: Device): string | undefined {
+  return device.machineId || undefined;
+}
+
+function RunScriptContent({ scriptId }: RunScriptViewProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const data = useLazyLoadQuery<ScriptDetailQueryType>(
+    scriptDetailRelayQuery,
+    { id: scriptId },
+    { fetchPolicy: 'store-and-network' },
+  );
+  const script = data.script;
+
+  const supportedPlatforms = useMemo(() => platformsToIds(script?.supportedPlatforms), [script?.supportedPlatforms]);
+
+  const { devices: allDevices, isLoadingDevices } = useRunDevices({
+    scriptId,
+    supportedPlatforms,
+    enabled: Boolean(script),
+  });
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showExecutionModal, setShowExecutionModal] = useState(false);
+  const [commitRun] = useMutation<RunScriptMutationType>(runScriptMutation);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<RunFormData>({
+    resolver: zodResolver(runFormSchema),
+    defaultValues: { timeout: 90, scriptArgs: [], envVars: [] },
+  });
+
+  useEffect(() => {
+    if (script) {
+      const parsedArgs = parseKeyValues(script.defaultArgs ? [...script.defaultArgs] : [], ' ');
+      const parsedEnv = envVarsToPairs(script.envVars);
+      reset({
+        timeout: script.defaultTimeoutSeconds ?? 90,
+        // Show one empty row when the script has none, so the inputs are visible.
+        // Empty rows are dropped on submit, so the run still starts without them.
+        scriptArgs: parsedArgs.length > 0 ? parsedArgs : [{ id: 'arg-0', key: '', value: '' }],
+        envVars: parsedEnv.length > 0 ? parsedEnv : [{ id: 'env-0', key: '', value: '' }],
+      });
+    }
+  }, [script, reset]);
+
+  const handleBack = useSafeBack(`/scripts-v2/details/${scriptId}`);
+
+  const dispatchToDevice = useCallback(
+    (machineId: string, args: string[], timeoutSeconds: number, envVars: ReturnType<typeof envVarsToInput>) =>
+      new Promise<void>((resolve, reject) => {
+        commitRun({
+          variables: {
+            input: {
+              machineId,
+              scriptId,
+              privilegeLevel: 'ADMIN',
+              args,
+              timeoutSeconds,
+              envVars,
+            },
+          },
+          onCompleted: () => resolve(),
+          onError: err => reject(err),
+        });
+      }),
+    [commitRun, scriptId],
+  );
+
+  const onSubmit = useCallback(
+    async (formData: RunFormData) => {
+      if (selectedIds.size === 0) {
+        toast({
+          title: 'No devices selected',
+          description: 'Please select at least one device.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      const selectedDevices = allDevices.filter(d => selectedIds.has(getDevicePrimaryId(d)));
+      const machineIds = selectedDevices.map(getMachineId).filter((id): id is string => !!id);
+
+      if (machineIds.length === 0) {
+        toast({
+          title: 'No compatible devices',
+          description: 'Selected devices have no machine ID.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      const args = serializeKeyValues(formData.scriptArgs, ' ');
+      const envVars = envVarsToInput(formData.envVars);
+
+      try {
+        await Promise.all(machineIds.map(machineId => dispatchToDevice(machineId, args, formData.timeout, envVars)));
+        setShowExecutionModal(true);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Failed to dispatch script';
+        toast({ title: 'Submission failed', description: msg, variant: 'destructive' });
+      }
+    },
+    [allDevices, selectedIds, toast, dispatchToDevice],
+  );
+
+  const onFormError = useCallback(
+    (formErrors: Record<string, { message?: string }>) => {
+      const firstError = Object.values(formErrors)[0];
+      if (firstError?.message) {
+        toast({ title: 'Validation error', description: firstError.message, variant: 'destructive' });
+      }
+    },
+    [toast],
+  );
+
+  const handleViewLogs = useCallback(() => {
+    setShowExecutionModal(false);
+    router.push('/logs-page');
+  }, [router]);
+
+  const actions = useMemo(
+    () => [
+      {
+        label: 'Run Script',
+        onClick: handleSubmit(onSubmit, onFormError),
+        variant: 'accent' as const,
+        disabled: selectedIds.size === 0,
+        loading: isSubmitting,
+      },
+    ],
+    [handleSubmit, onSubmit, onFormError, selectedIds.size, isSubmitting],
+  );
+
+  if (!script) {
+    return <NotFoundError message="Script not found" />;
+  }
+
+  return (
+    <PageLayout
+      title="Run Script"
+      backButton={{ label: 'Back', onClick: handleBack }}
+      actions={actions}
+      className="md:px-[var(--spacing-system-l)] md:pb-[var(--spacing-system-l)]"
+    >
+      <div className="flex-1 overflow-auto">
+        <ScriptSummaryCard
+          name={script.name}
+          description={script.description}
+          shellId={shellToId(script.shell)}
+          platforms={supportedPlatforms}
+          showTimeout={false}
+        />
+
+        <div className="pt-6">
+          <Label className="text-ods-text-primary font-semibold text-lg">Timeout</Label>
+          <Controller
+            name="timeout"
+            control={control}
+            render={({ field }) => (
+              <Input
+                type="number"
+                className="md:max-w-[320px] w-full"
+                value={field.value}
+                onChange={e => field.onChange(Number(e.target.value) || 0)}
+                endAdornment={<span className="text-ods-text-secondary text-sm">Seconds</span>}
+              />
+            )}
+          />
+        </div>
+
+        <div className="pt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Controller
+            name="scriptArgs"
+            control={control}
+            render={({ field }) => (
+              <ScriptArguments
+                arguments={field.value}
+                onArgumentsChange={field.onChange}
+                keyPlaceholder="Key"
+                valuePlaceholder="Enter Value (empty=flag)"
+                addButtonLabel="Add Script Argument"
+                titleLabel="Script Arguments"
+              />
+            )}
+          />
+          <Controller
+            name="envVars"
+            control={control}
+            render={({ field }) => (
+              <ScriptArguments
+                arguments={field.value}
+                onArgumentsChange={field.onChange}
+                keyPlaceholder="Key"
+                valuePlaceholder="Enter Value"
+                addButtonLabel="Add Environment Var"
+                titleLabel="Environment Vars"
+              />
+            )}
+          />
+        </div>
+
+        <div className="pt-6 space-y-1">
+          <DeviceSelector
+            devices={allDevices}
+            loading={isLoadingDevices}
+            selectedIds={selectedIds}
+            getDeviceKey={getDevicePrimaryId}
+            onSelectionChange={setSelectedIds}
+            showSelectionModeRadio={false}
+            addAllBehavior="replace"
+            isDeviceDisabled={d => (!getMachineId(d) ? 'Agent is not\nconnected' : undefined)}
+          />
+        </div>
+      </div>
+
+      <ExecutionStartedModal
+        isOpen={showExecutionModal}
+        onClose={() => setShowExecutionModal(false)}
+        scriptName={script.name || 'Script'}
+        onViewLogs={handleViewLogs}
+      />
+    </PageLayout>
+  );
+}
+
+export function RunScriptView({ scriptId }: RunScriptViewProps) {
+  return (
+    <Suspense fallback={<RunScriptSkeleton />}>
+      <RunScriptContent scriptId={scriptId} />
+    </Suspense>
+  );
+}
+
+export default RunScriptView;

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-details-skeleton.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
+import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+
+/**
+ * Skeleton for {@link ScriptSummaryCard}: the name + description header followed
+ * by a metadata strip. `stats` controls how many meta cells are drawn — 3 on the
+ * details page (Shell / Platforms / Timeout), 2 on the run page (no Timeout).
+ */
+export function ScriptSummaryCardSkeleton({ stats = 3 }: { stats?: number }) {
+  return (
+    <div className="bg-ods-card border border-ods-border rounded-[8px] overflow-hidden">
+      <div className="flex flex-col gap-2 border-b border-ods-border p-[var(--spacing-system-m)]">
+        <Skeleton className="h-6 w-56" />
+        <Skeleton className="h-5 w-80 max-w-full" />
+      </div>
+      <div className="flex flex-wrap items-center gap-[var(--spacing-system-m)] p-[var(--spacing-system-m)]">
+        {Array.from({ length: stats }, (_, i) => (
+          <div key={i} className="flex flex-[1_0_0] min-w-[140px] flex-col justify-center gap-1">
+            <Skeleton className="h-6 w-28" />
+            <Skeleton className="h-4 w-36" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Code editor block skeleton (Syntax label + editor surface). */
+function EditorSkeleton() {
+  return (
+    <div className="flex flex-col gap-1">
+      <Skeleton className="h-5 w-16" />
+      <div className="bg-ods-card border border-ods-border rounded-lg p-4 h-[400px] flex flex-col gap-2">
+        {Array.from({ length: 12 }, (_, i) => (
+          <Skeleton key={i} className="h-4" style={{ width: `${Math.max(20, 80 - i * 5 + ((i * 17) % 30))}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Loading state for the v2 Script Details page. Renders inside the real
+ * `PageLayout` (title, Back button, disabled Run Script action) so only the body
+ * swaps when the Relay query resolves — matching {@link ScriptDetailsView}:
+ * summary card, then the Syntax editor.
+ */
+export function ScriptDetailsSkeleton() {
+  const placeholderActions = [{ label: 'Run Script', onClick: () => {}, variant: 'accent' as const, disabled: true }];
+
+  return (
+    <PageLayout
+      title="Script Details"
+      backButton={{ label: 'Back', onClick: () => {} }}
+      actions={placeholderActions}
+      className="md:px-[var(--spacing-system-l)] md:pb-[var(--spacing-system-l)]"
+    >
+      <div className="flex flex-col gap-6">
+        <ScriptSummaryCardSkeleton stats={3} />
+        <EditorSkeleton />
+      </div>
+    </PageLayout>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-details-view.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { NotFoundError, PageLayout } from '@flamingo-stack/openframe-frontend-core';
+import { ArrowRightUpIcon, PenEditIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import type { ActionsMenuGroup } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Suspense, useMemo } from 'react';
+import { useLazyLoadQuery } from 'react-relay';
+import type { scriptDetailRelayQuery as ScriptDetailQueryType } from '@/__generated__/scriptDetailRelayQuery.graphql';
+import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { scriptDetailRelayQuery } from '@/graphql/scripts/script-detail-relay';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
+import { ScriptArgumentsCard } from '../../components/script/script-arguments-card';
+import { ScriptEditor } from '../../components/script/script-editor';
+import { envVarsToStrings, platformsToIds, shellToId } from '../utils/script-mappers';
+import { ScriptDetailsSkeleton } from './script-details-skeleton';
+import { ScriptSummaryCard } from './script-summary-card';
+
+interface ScriptDetailsViewProps {
+  scriptId: string;
+}
+
+function ScriptDetailsContent({ scriptId }: ScriptDetailsViewProps) {
+  const data = useLazyLoadQuery<ScriptDetailQueryType>(
+    scriptDetailRelayQuery,
+    { id: scriptId },
+    { fetchPolicy: 'store-and-network' },
+  );
+  const script = data.script;
+  const handleBack = useSafeBack('/scripts-v2');
+
+  useTrackOpenView(script ? { type: CONTEXT_ENTITY_KIND.SCRIPT, id: scriptId, label: script.name || scriptId } : null);
+
+  const editHref = `/scripts-v2/edit/${scriptId}`;
+  const runHref = `/scripts-v2/details/${scriptId}/run`;
+
+  const actions = useMemo(
+    () => [
+      {
+        label: 'Run Script',
+        href: runHref,
+        variant: 'accent' as const,
+        // Split button: the divider + arrow half opens the run page in a new tab.
+        iconAction: {
+          icon: <ArrowRightUpIcon className="w-5 h-5" />,
+          'aria-label': 'Open Run Script in new tab',
+          href: runHref,
+          openInNewTab: true,
+        },
+      },
+    ],
+    [runHref],
+  );
+
+  const menuActions = useMemo<ActionsMenuGroup[]>(
+    () => [
+      {
+        items: [
+          {
+            id: 'edit-script',
+            label: 'Edit Script',
+            icon: <PenEditIcon className="w-6 h-6 text-ods-text-secondary" />,
+            href: editHref,
+          },
+        ],
+      },
+    ],
+    [editHref],
+  );
+
+  if (!script) {
+    return <NotFoundError message="Script not found" />;
+  }
+
+  const shellId = shellToId(script.shell);
+  const platforms = platformsToIds(script.supportedPlatforms);
+  const args = script.defaultArgs ? [...script.defaultArgs] : [];
+  const envVarStrings = envVarsToStrings(script.envVars);
+
+  return (
+    <PageLayout
+      title="Script Details"
+      backButton={{ label: 'Back', onClick: handleBack }}
+      actions={actions}
+      menuActions={menuActions}
+      actionsVariant="menu-primary"
+      className="md:px-[var(--spacing-system-l)] md:pb-[var(--spacing-system-l)]"
+    >
+      <div className="flex flex-col gap-6">
+        <ScriptSummaryCard
+          name={script.name}
+          description={script.description}
+          shellId={shellId}
+          platforms={platforms}
+          timeoutSeconds={script.defaultTimeoutSeconds}
+        />
+
+        {(args.length > 0 || envVarStrings.length > 0) && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {args.length > 0 ? (
+              <ScriptArgumentsCard title="Default Script Arguments" args={args} separator=" " />
+            ) : (
+              <div />
+            )}
+            {envVarStrings.length > 0 && <ScriptArgumentsCard title="Default Environment Vars" args={envVarStrings} />}
+          </div>
+        )}
+
+        {script.scriptBody && (
+          <div className="flex flex-col gap-1">
+            <div className="text-h5 text-ods-text-secondary w-full">Syntax</div>
+            <ScriptEditor value={script.scriptBody} shell={shellId} readOnly height="400px" />
+          </div>
+        )}
+      </div>
+    </PageLayout>
+  );
+}
+
+export function ScriptDetailsView({ scriptId }: ScriptDetailsViewProps) {
+  return (
+    <Suspense fallback={<ScriptDetailsSkeleton />}>
+      <ScriptDetailsContent scriptId={scriptId} />
+    </Suspense>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-summary-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-summary-card.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { TruncateText } from '@flamingo-stack/openframe-frontend-core';
+import { SHELL_TYPES } from '@flamingo-stack/openframe-frontend-core/types';
+import { getOSLabel } from '@flamingo-stack/openframe-frontend-core/utils';
+
+interface ScriptSummaryCardProps {
+  name: string;
+  description?: string | null;
+  /** Lowercase shell id (e.g. 'bash'). */
+  shellId: string;
+  /** Platform ids (e.g. ['windows', 'darwin']). */
+  platforms: string[];
+  timeoutSeconds?: number | null;
+  /** Show the Timeout cell. Off on the run page, where the timeout is editable below. */
+  showTimeout?: boolean;
+}
+
+/** Number of equal-width columns the metadata strip is laid out on. */
+const META_COLUMNS = 4;
+
+/** A value-over-label cell in the metadata strip. */
+function MetaStat({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex flex-[1_0_0] min-w-[140px] flex-col justify-center gap-1">
+      <TruncateText variant="h4">{value}</TruncateText>
+      <TruncateText variant="h6" tone="secondary">
+        {label}
+      </TruncateText>
+    </div>
+  );
+}
+
+function shellLabel(shellId: string): string {
+  return SHELL_TYPES.find(s => s.value === shellId)?.label ?? shellId;
+}
+
+/**
+ * Summary card shown on the script details and run pages: the name + description
+ * header, then a metadata strip (shell type, platforms, and — on details —
+ * timeout). The strip is laid out on a 4-column grid; a trailing spacer keeps
+ * the cells aligned when there are fewer than 4.
+ */
+export function ScriptSummaryCard({
+  name,
+  description,
+  shellId,
+  platforms,
+  timeoutSeconds,
+  showTimeout = true,
+}: ScriptSummaryCardProps) {
+  const platformsText = platforms.map(getOSLabel).join(', ') || '—';
+
+  const stats = [
+    { label: 'Shell Type', value: shellLabel(shellId) },
+    { label: 'Supported Platforms', value: platformsText },
+    ...(showTimeout ? [{ label: 'Timeout (seconds)', value: String(timeoutSeconds ?? '—') }] : []),
+  ];
+
+  return (
+    <div className="bg-ods-card border border-ods-border rounded-[8px] overflow-hidden">
+      <div className="flex flex-col gap-1 border-b border-ods-border p-[var(--spacing-system-m)]">
+        <TruncateText variant="h4">{name}</TruncateText>
+        {description && (
+          <TruncateText variant="h6" tone="secondary">
+            {description}
+          </TruncateText>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-[var(--spacing-system-m)] p-[var(--spacing-system-m)]">
+        {stats.map(stat => (
+          <MetaStat key={stat.label} value={stat.value} label={stat.label} />
+        ))}
+        {stats.length < META_COLUMNS && (
+          <div aria-hidden className="min-w-px" style={{ flex: `${META_COLUMNS - stats.length} 1 0%` }} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/scripts-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/scripts-table.tsx
@@ -1,0 +1,514 @@
+'use client';
+
+import { OSTypeBadgeGroup, type ShellType, ShellTypeBadge } from '@flamingo-stack/openframe-frontend-core/components';
+import { MingoIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
+import {
+  ArrowRightUpIcon,
+  BracketCurlyIcon,
+  Filter02Icon,
+  PenEditIcon,
+  PlayIcon,
+  PlusCircleIcon,
+  SearchIcon,
+  TerminalIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  ActionsMenuDropdown,
+  type ActionsMenuGroup,
+  Button,
+  type ColumnDef,
+  DataTable,
+  FilterModal,
+  Input,
+  multiSelectFilterFn,
+  PageLayout,
+  type Row,
+  TruncateText,
+  useDataTable,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useApiParams, useDebounce } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { SHELL_TYPES } from '@flamingo-stack/openframe-frontend-core/types';
+import { getOSLabel } from '@flamingo-stack/openframe-frontend-core/utils';
+import { useRouter } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useLazyLoadQuery, usePaginationFragment } from 'react-relay';
+import type { scriptsTableRelay_query$key as ScriptsFragmentKey } from '@/__generated__/scriptsTableRelay_query.graphql';
+import type { scriptsTableRelayPaginationQuery as ScriptsPaginationQueryType } from '@/__generated__/scriptsTableRelayPaginationQuery.graphql';
+import type {
+  ScriptFilterInput,
+  scriptsTableRelayQuery as ScriptsTableQueryType,
+} from '@/__generated__/scriptsTableRelayQuery.graphql';
+import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
+import { EmptyState } from '@/app/components/shared';
+import { scriptsTableRelayFragment, scriptsTableRelayQuery } from '@/graphql/scripts/scripts-table-relay';
+import { openInNewTab } from '@/lib/open-in-new-tab';
+import { AVAILABLE_PLATFORMS } from '@/lib/platforms';
+import { ALLOWED_SHELL_IDS, platformsToEnums, platformsToIds, shellToEnum, shellToId } from '../utils/script-mappers';
+
+const PAGE_SIZE = 20;
+
+interface UiScriptEntry {
+  id: string;
+  name: string;
+  description: string;
+  shellType: string;
+  supportedPlatforms: string[];
+  timeout: number;
+}
+
+// Static filter options derived from the backend enums (the connection is
+// server-paginated, so we can't enumerate distinct values from loaded rows).
+// Limited to the shells the product supports (see ALLOWED_SHELL_IDS).
+const SHELL_FILTER_OPTIONS = SHELL_TYPES.filter(s => ALLOWED_SHELL_IDS.includes(s.value)).map(s => ({
+  id: s.value,
+  label: s.label,
+  value: s.value,
+}));
+
+const PLATFORM_FILTER_OPTIONS = AVAILABLE_PLATFORMS.map(p => ({
+  id: p.id,
+  label: getOSLabel(p.id),
+  value: p.id,
+}));
+
+// ----------------------------------------------------------------
+// Inner content — Relay hooks, must live inside Suspense
+// ----------------------------------------------------------------
+
+interface ScriptsTableContentProps {
+  backendFilters: ScriptFilterInput;
+  debouncedSearch: string;
+  tableFilters: Record<string, string[]>;
+  onFilterChange: (filters: Record<string, any[]>) => void;
+  onEmptyChange: (isEmpty: boolean) => void;
+  mobileFilterOpen: boolean;
+  onMobileFilterClose: () => void;
+}
+
+function ScriptsTableContent({
+  backendFilters,
+  debouncedSearch,
+  tableFilters,
+  onFilterChange,
+  onEmptyChange,
+  mobileFilterOpen,
+  onMobileFilterClose,
+}: ScriptsTableContentProps) {
+  const askMingo = useAskMingo();
+  const [isPending] = useTransition();
+
+  const queryData = useLazyLoadQuery<ScriptsTableQueryType>(
+    scriptsTableRelayQuery,
+    {
+      filter: backendFilters,
+      search: debouncedSearch || null,
+      first: PAGE_SIZE,
+      after: null,
+    },
+    { fetchPolicy: 'store-and-network' },
+  );
+
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment<
+    ScriptsPaginationQueryType,
+    ScriptsFragmentKey
+  >(scriptsTableRelayFragment, queryData);
+
+  const transformedScripts: UiScriptEntry[] = useMemo(() => {
+    const edges = data.scripts?.edges ?? [];
+    return edges.map(edge => {
+      const node = edge.node;
+      return {
+        id: node.id,
+        name: node.name,
+        description: node.description ?? '',
+        shellType: shellToId(node.shell),
+        supportedPlatforms: platformsToIds(node.supportedPlatforms),
+        timeout: node.defaultTimeoutSeconds ?? 300,
+      };
+    });
+  }, [data.scripts?.edges]);
+
+  const fetchNextPage = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(PAGE_SIZE);
+    }
+  }, [hasNext, isLoadingNext, loadNext]);
+
+  const renderRowActions = useCallback((script: UiScriptEntry) => {
+    const runHref = `/scripts-v2/details/${script.id}/run`;
+    const editHref = `/scripts-v2/edit/${script.id}`;
+    const newTabIcon = <ArrowRightUpIcon className="w-5 h-5 text-ods-text-secondary" />;
+
+    const groups: ActionsMenuGroup[] = [
+      {
+        items: [
+          {
+            id: 'run-script',
+            label: 'Run Script',
+            icon: <TerminalIcon className="w-6 h-6 text-ods-text-secondary" />,
+            href: runHref,
+            iconAction: {
+              icon: newTabIcon,
+              'aria-label': 'Open Run Script in new tab',
+              href: runHref,
+              openInNewTab: true,
+            },
+          },
+          {
+            id: 'edit-script',
+            label: 'Edit Script',
+            icon: <PenEditIcon className="w-6 h-6 text-ods-text-secondary" />,
+            href: editHref,
+            iconAction: {
+              icon: newTabIcon,
+              'aria-label': 'Open Edit Script in new tab',
+              href: editHref,
+              openInNewTab: true,
+            },
+          },
+        ],
+      },
+    ];
+
+    return <ActionsMenuDropdown groups={groups} />;
+  }, []);
+
+  const columns = useMemo<ColumnDef<UiScriptEntry>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }: { row: Row<UiScriptEntry> }) => (
+          <div className="flex flex-col justify-center gap-1 min-w-0">
+            <TruncateText>{row.original.name}</TruncateText>
+            {row.original.description && (
+              <TruncateText variant="h6" tone="secondary">
+                {row.original.description}
+              </TruncateText>
+            )}
+          </div>
+        ),
+        enableSorting: false,
+        meta: { width: 'flex-1 min-w-0' },
+      },
+      {
+        accessorKey: 'shellType',
+        header: 'Shell Type',
+        cell: ({ row }: { row: Row<UiScriptEntry> }) => (
+          <ShellTypeBadge shellType={row.original.shellType as ShellType} iconClassName="w-4 h-4 md:w-6 md:h-6" />
+        ),
+        enableSorting: false,
+        filterFn: multiSelectFilterFn,
+        meta: {
+          width: 'w-[100px] md:w-[160px]',
+          filter: { options: SHELL_FILTER_OPTIONS },
+        },
+      },
+      {
+        accessorKey: 'supportedPlatforms',
+        header: 'OS',
+        cell: ({ row }: { row: Row<UiScriptEntry> }) => (
+          <OSTypeBadgeGroup osTypes={row.original.supportedPlatforms} iconSize="w-4 h-4 md:w-6 md:h-6" />
+        ),
+        enableSorting: false,
+        filterFn: multiSelectFilterFn,
+        meta: {
+          width: 'w-[90px]',
+          hideAt: 'lg',
+          filter: { options: PLATFORM_FILTER_OPTIONS },
+        },
+      },
+      {
+        id: 'actions',
+        cell: ({ row }: { row: Row<UiScriptEntry> }) => (
+          <div data-no-row-click className="flex gap-2 items-center justify-end pointer-events-auto">
+            {renderRowActions(row.original)}
+          </div>
+        ),
+        enableSorting: false,
+        meta: { width: 'w-12 shrink-0 flex-none', align: 'right' },
+      },
+      {
+        id: 'open',
+        cell: ({ row }: { row: Row<UiScriptEntry> }) => (
+          <div data-no-row-click className="flex items-center justify-end pointer-events-auto">
+            <Button
+              onClick={openInNewTab(`/scripts-v2/details/${row.original.id}`)}
+              variant="outline"
+              size="icon"
+              leftIcon={<ArrowRightUpIcon className="w-5 h-5" />}
+              aria-label="Open in new tab"
+              className="bg-ods-card"
+            />
+          </div>
+        ),
+        enableSorting: false,
+        meta: { width: 'w-12 shrink-0 flex-none', align: 'right' },
+      },
+    ],
+    [renderRowActions],
+  );
+
+  const filterGroups = useMemo(
+    () => [
+      { id: 'shellType', title: 'Shell Type', options: SHELL_FILTER_OPTIONS },
+      { id: 'supportedPlatforms', title: 'OS', options: PLATFORM_FILTER_OPTIONS },
+    ],
+    [],
+  );
+
+  const columnFilters = useMemo(
+    () =>
+      Object.entries(tableFilters)
+        .filter(([, value]) => value && value.length > 0)
+        .map(([id, value]) => ({ id, value })),
+    [tableFilters],
+  );
+
+  const handleColumnFiltersChange = useCallback(
+    (updater: any) => {
+      const next = typeof updater === 'function' ? updater(columnFilters) : updater;
+      const nextFilters: Record<string, any[]> = {};
+      for (const f of next) {
+        nextFilters[f.id] = Array.isArray(f.value) ? f.value : [f.value];
+      }
+      onFilterChange(nextFilters);
+    },
+    [columnFilters, onFilterChange],
+  );
+
+  const table = useDataTable<UiScriptEntry>({
+    data: transformedScripts,
+    columns,
+    getRowId: (row: UiScriptEntry) => row.id,
+    enableSorting: false,
+    state: { columnFilters },
+    onColumnFiltersChange: handleColumnFiltersChange,
+  });
+
+  const scriptRowHref = useCallback((script: UiScriptEntry) => `/scripts-v2/details/${script.id}`, []);
+
+  const hasActiveFilters = Object.values(tableFilters).some(values => values.length > 0);
+  const showEmptyState = !debouncedSearch && !hasActiveFilters && !isPending && transformedScripts.length === 0;
+
+  useEffect(() => {
+    onEmptyChange(showEmptyState);
+  }, [showEmptyState, onEmptyChange]);
+
+  if (showEmptyState) {
+    return (
+      <EmptyState
+        icon={<BracketCurlyIcon />}
+        title="No scripts yet"
+        description="Reusable code snippets you run on devices to automate tasks, fix issues, or collect data will be displayed here."
+        actions={[
+          { icon: <PlayIcon />, label: 'Run on one device or push to many at once' },
+          { icon: <TerminalIcon />, label: 'Write in PowerShell, Bash, Python, or Batch' },
+          {
+            icon: (
+              <MingoIcon
+                className="size-5"
+                eyesColor="var(--ods-flamingo-cyan-base)"
+                cornerColor="var(--ods-flamingo-cyan-base)"
+              />
+            ),
+            label: 'Let Mingo suggest or generate scripts for you',
+          },
+        ]}
+        buttonLabel="Ask Mingo about Scripts"
+        buttonIcon={
+          <MingoIcon
+            className="size-5"
+            eyesColor="var(--ods-flamingo-cyan-base)"
+            cornerColor="var(--ods-flamingo-cyan-base)"
+          />
+        }
+        onButtonClick={() => askMingo('scripts')}
+      />
+    );
+  }
+
+  return (
+    <>
+      <DataTable table={table}>
+        <DataTable.Header stickyHeader stickyHeaderOffset="top-0" rightSlot={<DataTable.RowCount />} />
+        <DataTable.Body
+          loading={isPending}
+          skeletonRows={PAGE_SIZE}
+          emptyMessage={
+            debouncedSearch
+              ? `No scripts found matching "${debouncedSearch}". Try adjusting your search.`
+              : 'No scripts found. Try adjusting your filters or add a new script.'
+          }
+          rowClassName="mb-1"
+          rowHref={scriptRowHref}
+        />
+        <DataTable.InfiniteFooter
+          hasNextPage={hasNext}
+          isFetchingNextPage={isLoadingNext}
+          onLoadMore={fetchNextPage}
+          skeletonRows={2}
+        />
+      </DataTable>
+
+      <FilterModal
+        isOpen={mobileFilterOpen}
+        onClose={onMobileFilterClose}
+        filterGroups={filterGroups}
+        onFilterChange={onFilterChange}
+        currentFilters={tableFilters}
+      />
+    </>
+  );
+}
+
+// ----------------------------------------------------------------
+// Loading skeleton
+// ----------------------------------------------------------------
+
+const EMPTY_ROWS: UiScriptEntry[] = [];
+
+function ScriptsTableSkeleton() {
+  const columns = useMemo<ColumnDef<UiScriptEntry>[]>(
+    () => [
+      { accessorKey: 'name', header: 'Name', enableSorting: false, meta: { width: 'flex-1 min-w-0' } },
+      {
+        accessorKey: 'shellType',
+        header: 'Shell Type',
+        enableSorting: false,
+        meta: { width: 'w-[100px] md:w-[160px]' },
+      },
+      {
+        accessorKey: 'supportedPlatforms',
+        header: 'OS',
+        enableSorting: false,
+        meta: { width: 'w-[90px]', hideAt: 'lg' },
+      },
+    ],
+    [],
+  );
+
+  const table = useDataTable<UiScriptEntry>({
+    data: EMPTY_ROWS,
+    columns,
+    getRowId: (row: UiScriptEntry) => row.id,
+    enableSorting: false,
+  });
+
+  return (
+    <DataTable table={table}>
+      <DataTable.Header stickyHeader stickyHeaderOffset="top-0" />
+      <DataTable.Body loading={true} skeletonRows={PAGE_SIZE} emptyMessage="" rowClassName="mb-1" />
+    </DataTable>
+  );
+}
+
+// ----------------------------------------------------------------
+// Outer shell — layout + URL state + Suspense boundary
+// ----------------------------------------------------------------
+
+export function ScriptsTable() {
+  const router = useRouter();
+
+  const { params, setParam, setParams } = useApiParams({
+    search: { type: 'string', default: '' },
+    shellType: { type: 'array', default: [] },
+    supportedPlatforms: { type: 'array', default: [] },
+  });
+
+  const [searchInput, setSearchInput] = useState(params.search);
+  const debouncedSearch = useDebounce(searchInput, 300);
+
+  const setParamRef = useRef(setParam);
+  setParamRef.current = setParam;
+  useEffect(() => {
+    setParamRef.current('search', debouncedSearch);
+  }, [debouncedSearch]);
+
+  useEffect(() => {
+    setSearchInput(params.search);
+  }, [params.search]);
+
+  const [isEmpty, setIsEmpty] = useState(false);
+  const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
+
+  const backendFilters: ScriptFilterInput = useMemo(() => {
+    const shells = params.shellType.map(shellToEnum);
+    const supportedPlatforms = platformsToEnums(params.supportedPlatforms);
+    return {
+      ...(shells.length > 0 && { shells }),
+      ...(supportedPlatforms.length > 0 && { supportedPlatforms }),
+    };
+  }, [params.shellType, params.supportedPlatforms]);
+
+  const tableFilters = useMemo(
+    () => ({
+      shellType: params.shellType,
+      supportedPlatforms: params.supportedPlatforms,
+    }),
+    [params.shellType, params.supportedPlatforms],
+  );
+
+  const handleFilterChange = useCallback(
+    (columnFilters: Record<string, any[]>) => {
+      setParams({
+        shellType: columnFilters.shellType || [],
+        supportedPlatforms: columnFilters.supportedPlatforms || [],
+      });
+      document.querySelector('main')?.scrollTo({ top: 0, behavior: 'instant' });
+    },
+    [setParams],
+  );
+
+  const handleNewScript = useCallback(() => {
+    router.push('/scripts-v2/create');
+  }, [router]);
+
+  const actions = useMemo(
+    () => [
+      {
+        label: 'Add Script',
+        variant: (isEmpty ? 'accent' : 'outline') as 'accent' | 'outline',
+        icon: <PlusCircleIcon size={24} className={isEmpty ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'} />,
+        onClick: handleNewScript,
+      },
+    ],
+    [handleNewScript, isEmpty],
+  );
+
+  return (
+    <PageLayout title="Scripts" actions={actions}>
+      {!isEmpty && (
+        <div className="sticky top-0 z-20 flex items-center gap-[var(--spacing-system-m)] bg-ods-bg py-[var(--spacing-system-l)] -my-[var(--spacing-system-l)]">
+          <Input
+            placeholder="Search for Scripts"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            className="flex-1"
+            startAdornment={<SearchIcon className="w-4 h-4 md:w-6 md:h-6" />}
+          />
+          <Button
+            variant="outline"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setMobileFilterOpen(true)}
+            aria-label="Open filters"
+            leftIcon={<Filter02Icon />}
+          />
+        </div>
+      )}
+
+      <Suspense fallback={<ScriptsTableSkeleton />}>
+        <ScriptsTableContent
+          backendFilters={backendFilters}
+          debouncedSearch={debouncedSearch}
+          tableFilters={tableFilters}
+          onFilterChange={handleFilterChange}
+          onEmptyChange={setIsEmpty}
+          mobileFilterOpen={mobileFilterOpen}
+          onMobileFilterClose={() => setMobileFilterOpen(false)}
+        />
+      </Suspense>
+    </PageLayout>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/test-script-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/test-script-modal.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import {
+  Button,
+  Checkbox,
+  ModalV2,
+  ModalV2Content,
+  ModalV2Footer,
+  ModalV2Header,
+  ModalV2Title,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { DeviceSelector } from '@/app/components/shared/device-selector';
+import { apiClient } from '@/lib/api-client';
+import { DEVICE_STATUS } from '../../../devices/constants/device-statuses';
+import { GET_DEVICES_QUERY } from '../../../devices/queries/devices-queries';
+import type { Device, DevicesGraphQlNode, GraphQlResponse } from '../../../devices/types/device.types';
+import { createDeviceListItem } from '../../../devices/utils/device-transform';
+import { getDevicePrimaryId } from '../../utils/device-helpers';
+import { mapPlatformsToOsTypes } from '../../utils/script-utils';
+
+export interface SelectedTestDevice {
+  machineId: string;
+  deviceName: string;
+  /** Run the test as the logged-in user (Windows) — maps to privilegeLevel USER. */
+  runAsUser: boolean;
+}
+
+interface TestScriptModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDeviceSelected: (device: SelectedTestDevice) => void;
+  supportedPlatforms: string[];
+}
+
+async function fetchOnlineDevices(supportedPlatforms: string[]): Promise<Device[]> {
+  const osTypes = mapPlatformsToOsTypes(supportedPlatforms || []);
+
+  const filter = {
+    statuses: [DEVICE_STATUS.ONLINE],
+    ...(osTypes.length > 0 && { osTypes }),
+  };
+
+  const response = await apiClient.post<
+    GraphQlResponse<{
+      devices: {
+        edges: Array<{ node: DevicesGraphQlNode; cursor: string }>;
+        pageInfo: { hasNextPage: boolean; endCursor?: string };
+        filteredCount: number;
+      };
+    }>
+  >('/api/graphql', {
+    query: GET_DEVICES_QUERY,
+    variables: { filter, first: 100, search: '', sort: { field: 'status', direction: 'DESC' } },
+  });
+
+  if (!response.ok) {
+    throw new Error(response.error || 'Failed to fetch devices');
+  }
+
+  const graphqlResponse = response.data;
+  if (!graphqlResponse?.data) {
+    throw new Error('No data received from server');
+  }
+  if (graphqlResponse.errors && graphqlResponse.errors.length > 0) {
+    throw new Error(graphqlResponse.errors[0].message);
+  }
+
+  const nodes = graphqlResponse.data.devices.edges.map(e => e.node);
+  return nodes.map(createDeviceListItem);
+}
+
+export function TestScriptModal({ isOpen, onClose, onDeviceSelected, supportedPlatforms }: TestScriptModalProps) {
+  const { toast } = useToast();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [runAsUser, setRunAsUser] = useState(false);
+
+  const platformsKey = JSON.stringify(supportedPlatforms);
+  const hasPlatforms = supportedPlatforms.length > 0;
+
+  const devicesQuery = useQuery({
+    queryKey: ['test-script-v2-devices', platformsKey],
+    queryFn: () => fetchOnlineDevices(supportedPlatforms),
+    enabled: isOpen && hasPlatforms,
+  });
+
+  const devices = devicesQuery.data ?? [];
+
+  const handleConfirm = useCallback(() => {
+    if (selectedIds.size === 0) {
+      toast({ title: 'No device selected', description: 'Please select a device.', variant: 'destructive' });
+      return;
+    }
+
+    const selectedDevice = devices.find(d => selectedIds.has(getDevicePrimaryId(d)));
+    if (!selectedDevice) return;
+
+    const machineId = selectedDevice.machineId;
+    if (!machineId) {
+      toast({
+        title: 'No machine ID',
+        description: 'This device has no machine ID and cannot run a test.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    onDeviceSelected({
+      machineId,
+      deviceName: selectedDevice.displayName || selectedDevice.hostname,
+      runAsUser,
+    });
+    setSelectedIds(new Set());
+    setRunAsUser(false);
+    onClose();
+  }, [selectedIds, devices, runAsUser, toast, onDeviceSelected, onClose]);
+
+  const handleClose = useCallback(() => {
+    setSelectedIds(new Set());
+    setRunAsUser(false);
+    onClose();
+  }, [onClose]);
+
+  return (
+    <ModalV2 isOpen={isOpen} onClose={handleClose} className="max-w-6xl h-[90vh] max-h-[900px]">
+      <ModalV2Header>
+        <ModalV2Title>Select Device</ModalV2Title>
+      </ModalV2Header>
+      <ModalV2Content>
+        {!hasPlatforms ? (
+          <div className="flex items-center justify-center h-64 bg-ods-card border border-ods-border rounded-[6px]">
+            <p className="text-ods-text-secondary">Select at least one supported platform to see available devices.</p>
+          </div>
+        ) : (
+          <DeviceSelector
+            devices={devices}
+            loading={devicesQuery.isLoading}
+            selectedIds={selectedIds}
+            getDeviceKey={getDevicePrimaryId}
+            onSelectionChange={setSelectedIds}
+            showSelectionModeRadio={false}
+            addAllBehavior="replace"
+            singleSelect
+            isDeviceDisabled={d => (!d.machineId ? 'Agent is not\nconnected' : undefined)}
+          />
+        )}
+      </ModalV2Content>
+      <ModalV2Footer className="justify-between">
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <Checkbox checked={runAsUser} onCheckedChange={checked => setRunAsUser(checked === true)} />
+          <span className="text-h6 text-ods-text-primary">
+            Run as User <span className="text-ods-text-secondary">(Windows only)</span>
+          </span>
+        </label>
+        <div className="flex gap-4">
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="accent" onClick={handleConfirm} disabled={selectedIds.size === 0}>
+            Select Device
+          </Button>
+        </div>
+      </ModalV2Footer>
+    </ModalV2>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/hooks/use-edit-script-form.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/hooks/use-edit-script-form.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation } from 'react-relay';
+import { z } from 'zod';
+import type { createScriptMutation as CreateScriptMutationType } from '@/__generated__/createScriptMutation.graphql';
+import type { updateScriptMutation as UpdateScriptMutationType } from '@/__generated__/updateScriptMutation.graphql';
+import { safeBackOrReplace } from '@/app/hooks/use-safe-back';
+import { createScriptMutation } from '@/graphql/scripts/create-script-mutation';
+import { updateScriptMutation } from '@/graphql/scripts/update-script-mutation';
+import { EDIT_SCRIPT_DEFAULT_VALUES, type EditScriptFormData, editScriptSchema } from '../../types/edit-script.types';
+import { formToWriteInput } from '../utils/script-mappers';
+
+// v2 tweaks to the shared schema:
+// - script_body is required (drives the Syntax error state).
+// - category is dropped — the native API has no such concept, so the field is
+//   hidden and must not be a required validation gate.
+const editScriptFormSchema = editScriptSchema.extend({
+  script_body: z.string().min(1, 'Please add script content'),
+  category: z.string(),
+});
+
+interface UseEditScriptFormOptions {
+  scriptId: string | null;
+  initialValues: EditScriptFormData | null;
+  isEditMode: boolean;
+}
+
+// On the create page, start with one empty argument and one empty env-var row so
+// the inputs are visible up front. Empty rows are filtered out on submit.
+const CREATE_SCRIPT_DEFAULT_VALUES: EditScriptFormData = {
+  ...EDIT_SCRIPT_DEFAULT_VALUES,
+  args: [{ id: 'arg-0', key: '', value: '' }],
+  env_vars: [{ id: 'env-0', key: '', value: '' }],
+};
+
+export function useEditScriptForm({ scriptId, initialValues, isEditMode }: UseEditScriptFormOptions) {
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const form = useForm<EditScriptFormData>({
+    resolver: zodResolver(editScriptFormSchema),
+    defaultValues: isEditMode ? EDIT_SCRIPT_DEFAULT_VALUES : CREATE_SCRIPT_DEFAULT_VALUES,
+    // `onChange` lets RHF own the validation lifecycle: errors set via `trigger`
+    // (e.g. the Test pre-check) clear themselves as soon as the field becomes
+    // valid, instead of needing a manual `clearErrors`.
+    mode: 'onChange',
+  });
+
+  const { reset, handleSubmit } = form;
+
+  useEffect(() => {
+    if (initialValues && isEditMode) {
+      reset(initialValues);
+    }
+  }, [initialValues, isEditMode, reset]);
+
+  const [commitCreate, isCreating] = useMutation<CreateScriptMutationType>(createScriptMutation);
+  const [commitUpdate, isUpdating] = useMutation<UpdateScriptMutationType>(updateScriptMutation);
+
+  const onSubmit = useCallback(
+    (data: EditScriptFormData) => {
+      const input = formToWriteInput(data);
+
+      if (isEditMode && scriptId) {
+        commitUpdate({
+          variables: { input: { id: scriptId, ...input } },
+          onCompleted: () => {
+            toast({ title: 'Success', description: 'Script updated successfully', variant: 'success' });
+            safeBackOrReplace(router, `/scripts-v2/details/${scriptId}`);
+          },
+          onError: err => {
+            toast({
+              title: 'Error',
+              description: err instanceof Error ? err.message : 'Failed to update script',
+              variant: 'destructive',
+            });
+          },
+        });
+        return;
+      }
+
+      commitCreate({
+        variables: { input },
+        onCompleted: response => {
+          toast({ title: 'Success', description: 'Script created successfully', variant: 'success' });
+          const newId = response.createScript?.id;
+          router.replace(newId ? `/scripts-v2/details/${newId}` : '/scripts-v2');
+        },
+        onError: err => {
+          toast({
+            title: 'Error',
+            description: err instanceof Error ? err.message : 'Failed to create script',
+            variant: 'destructive',
+          });
+        },
+      });
+    },
+    [isEditMode, scriptId, commitCreate, commitUpdate, router, toast],
+  );
+
+  const handleSave = useCallback(() => {
+    handleSubmit(onSubmit, errors => {
+      const messages = Object.values(errors)
+        .map(error => (error as { message?: string } | undefined)?.message)
+        .filter((message): message is string => Boolean(message));
+      toast({
+        title: 'Cannot save yet',
+        description: messages.length > 0 ? messages.join(', ') : 'Please fill in all required fields.',
+        variant: 'destructive',
+      });
+    })();
+  }, [handleSubmit, onSubmit, toast]);
+
+  return { form, isSubmitting: isCreating || isUpdating, handleSave };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/hooks/use-run-devices.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/hooks/use-run-devices.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { DEVICE_STATUS } from '../../../devices/constants/device-statuses';
+import { GET_DEVICES_QUERY } from '../../../devices/queries/devices-queries';
+import type { Device, DevicesGraphQlNode, GraphQlResponse } from '../../../devices/types/device.types';
+import { createDeviceListItem } from '../../../devices/utils/device-transform';
+import { mapPlatformsToOsTypes } from '../../utils/script-utils';
+
+export const runDevicesQueryKeys = {
+  devices: (scriptId: string) => ['run-script-v2-devices', scriptId] as const,
+};
+
+async function fetchDevicesForScript(supportedPlatforms: string[]): Promise<Device[]> {
+  const osTypes = mapPlatformsToOsTypes(supportedPlatforms);
+
+  const filter = {
+    statuses: [DEVICE_STATUS.ONLINE, DEVICE_STATUS.OFFLINE],
+    ...(osTypes.length > 0 && { osTypes }),
+  };
+
+  const response = await apiClient.post<
+    GraphQlResponse<{
+      devices: {
+        edges: Array<{ node: DevicesGraphQlNode; cursor: string }>;
+        pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string; endCursor?: string };
+        filteredCount: number;
+      };
+    }>
+  >('/api/graphql', {
+    query: GET_DEVICES_QUERY,
+    variables: {
+      filter,
+      first: 100,
+      search: '',
+      sort: { field: 'status', direction: 'DESC' },
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(response.error || `Request failed with status ${response.status}`);
+  }
+
+  const graphqlResponse = response.data;
+  if (!graphqlResponse?.data) {
+    throw new Error('No data received from server');
+  }
+  if (graphqlResponse.errors && graphqlResponse.errors.length > 0) {
+    throw new Error(graphqlResponse.errors[0].message || 'GraphQL error occurred');
+  }
+
+  const nodes = graphqlResponse.data.devices.edges.map(e => e.node);
+  return nodes.map(createDeviceListItem);
+}
+
+interface UseRunDevicesOptions {
+  scriptId: string;
+  supportedPlatforms: string[];
+  enabled: boolean;
+}
+
+export function useRunDevices({ scriptId, supportedPlatforms, enabled }: UseRunDevicesOptions) {
+  const query = useQuery({
+    queryKey: runDevicesQueryKeys.devices(scriptId),
+    queryFn: () => fetchDevicesForScript(supportedPlatforms),
+    enabled,
+  });
+
+  return {
+    devices: query.data ?? [],
+    isLoadingDevices: query.isLoading,
+    devicesError: query.error?.message ?? null,
+  };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/utils/script-mappers.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/utils/script-mappers.ts
@@ -1,0 +1,160 @@
+import type { ScriptArgument } from '@flamingo-stack/openframe-frontend-core';
+import type { ScriptPlatform, ScriptShell } from '@/__generated__/scriptDetailRelayQuery.graphql';
+import { EDIT_SCRIPT_DEFAULT_VALUES, type EditScriptFormData } from '../../types/edit-script.types';
+import { parseKeyValues, serializeKeyValues } from '../../utils/script-key-values';
+
+/**
+ * Translation layer between the UI's (tactical-shaped) form model and the
+ * native OpenFrame GraphQL Script model. The v2 views intentionally reuse the
+ * existing presentational components, so every model difference is contained
+ * here.
+ */
+
+// ---------------------------------------------------------------------------
+// Shell <-> ScriptShell enum
+// ---------------------------------------------------------------------------
+
+const SHELL_TO_ENUM: Record<string, ScriptShell> = {
+  powershell: 'POWERSHELL',
+  cmd: 'CMD',
+  bash: 'BASH',
+  python: 'PYTHON',
+  nushell: 'NUSHELL',
+  shell: 'SHELL',
+};
+
+/**
+ * Shells the frontend is allowed to create / run with. The backend `ScriptShell`
+ * enum exposes more (PYTHON, NUSHELL, SHELL), but per product the UI only offers
+ * these three. Used to limit both the editor's shell select and the list filter.
+ */
+export const ALLOWED_SHELL_IDS: string[] = ['cmd', 'bash', 'powershell'];
+
+export function shellToEnum(shell: string): ScriptShell {
+  return SHELL_TO_ENUM[shell?.toLowerCase()] ?? 'SHELL';
+}
+
+/** Lowercase id consumed by ShellTypeBadge / ScriptInfoSection / the editor. */
+export function shellToId(shell: ScriptShell | string | null | undefined): string {
+  return (shell ?? 'shell').toString().toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Platform <-> ScriptPlatform enum (UI ids: windows / darwin / linux)
+// ---------------------------------------------------------------------------
+
+const PLATFORM_ID_TO_ENUM: Record<string, ScriptPlatform> = {
+  windows: 'WINDOWS',
+  darwin: 'MACOS',
+  linux: 'LINUX',
+};
+
+const PLATFORM_ENUM_TO_ID: Record<string, string> = {
+  WINDOWS: 'windows',
+  MACOS: 'darwin',
+  LINUX: 'linux',
+};
+
+export function platformsToEnums(ids: string[]): ScriptPlatform[] {
+  return ids.map(id => PLATFORM_ID_TO_ENUM[id?.toLowerCase()]).filter((v): v is ScriptPlatform => !!v);
+}
+
+export function platformsToIds(enums: ReadonlyArray<ScriptPlatform | string> | null | undefined): string[] {
+  if (!enums) return [];
+  return enums.map(e => PLATFORM_ENUM_TO_ID[e as string]).filter((v): v is string => !!v);
+}
+
+// ---------------------------------------------------------------------------
+// Env vars <-> ScriptEnvVar { name, value, secret }
+// ---------------------------------------------------------------------------
+
+export interface ScriptEnvVarInput {
+  name: string;
+  value: string;
+  secret: boolean;
+}
+
+/** Form key/value pairs -> GraphQL ScriptEnvVarInput[] (secret defaults to false). */
+export function envVarsToInput(pairs: ScriptArgument[]): ScriptEnvVarInput[] {
+  return pairs.filter(p => p.key.trim() !== '').map(p => ({ name: p.key, value: p.value ?? '', secret: false }));
+}
+
+/** GraphQL env vars -> "name=value" strings (consumed by ScriptArgumentsCard). */
+export function envVarsToStrings(
+  envVars: ReadonlyArray<{ name: string; value?: string | null }> | null | undefined,
+): string[] {
+  if (!envVars) return [];
+  return envVars.map(e => (e.value ? `${e.name}=${e.value}` : e.name));
+}
+
+/** GraphQL env vars -> form key/value pairs. */
+export function envVarsToPairs(
+  envVars: ReadonlyArray<{ name: string; value?: string | null }> | null | undefined,
+): ScriptArgument[] {
+  if (!envVars) return [];
+  return envVars.map((e, i) => ({ id: `env-${i}`, key: e.name, value: e.value ?? '' }));
+}
+
+// ---------------------------------------------------------------------------
+// Form payload -> Create / Update input
+// ---------------------------------------------------------------------------
+
+export interface ScriptWriteInput {
+  name: string;
+  description: string;
+  shell: ScriptShell;
+  scriptBody: string;
+  tag: string | null;
+  supportedPlatforms: ScriptPlatform[];
+  defaultTimeoutSeconds: number;
+  defaultArgs: string[];
+  envVars: ScriptEnvVarInput[];
+}
+
+export function formToWriteInput(data: EditScriptFormData): ScriptWriteInput {
+  return {
+    name: data.name,
+    description: data.description,
+    shell: shellToEnum(data.shell),
+    scriptBody: data.script_body,
+    // Category is not exposed in v2; preserve an existing tag on edit, else null.
+    tag: data.category?.trim() ? data.category : null,
+    supportedPlatforms: platformsToEnums(data.supported_platforms),
+    defaultTimeoutSeconds: data.default_timeout,
+    // Args are stored as "key value" strings, matching the legacy tactical shape.
+    defaultArgs: serializeKeyValues(data.args, ' '),
+    envVars: envVarsToInput(data.env_vars),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Relay script node -> form values
+// ---------------------------------------------------------------------------
+
+export interface ScriptDetailNode {
+  id: string;
+  name: string;
+  description?: string | null;
+  shell: ScriptShell | string;
+  scriptBody: string;
+  tag?: string | null;
+  supportedPlatforms?: ReadonlyArray<ScriptPlatform | string> | null;
+  defaultTimeoutSeconds?: number | null;
+  defaultArgs?: ReadonlyArray<string> | null;
+  envVars?: ReadonlyArray<{ name: string; value?: string | null; secret?: boolean }> | null;
+}
+
+export function relayScriptToForm(node: ScriptDetailNode): EditScriptFormData {
+  return {
+    name: node.name ?? '',
+    shell: shellToId(node.shell),
+    default_timeout: node.defaultTimeoutSeconds ?? EDIT_SCRIPT_DEFAULT_VALUES.default_timeout,
+    args: parseKeyValues(node.defaultArgs ? [...node.defaultArgs] : [], ' '),
+    script_body: node.scriptBody ?? '',
+    run_as_user: false,
+    env_vars: envVarsToPairs(node.envVars),
+    description: node.description ?? '',
+    supported_platforms: platformsToIds(node.supportedPlatforms),
+    category: node.tag ?? '',
+  };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
@@ -50,8 +50,8 @@ function BillingUsageContent() {
 
   // `Next Payment` comes straight from the backend's server-computed
   // `subscription.nextPayment` (projected next-invoice total). The row is
-  // omitted when there's nothing to bill (null / 0) — e.g. a trial with no
-  // upcoming charge — instead of rendering a "Free" placeholder.
+  // omitted when there's nothing to bill (null / 0) or while the user is on
+  // an active trial — instead of rendering a "Free" placeholder.
   const nextPaymentAmount = billing.nextPayment ?? 0;
 
   const menuActions: ActionsMenuGroup[] =
@@ -187,7 +187,9 @@ function BillingUsageContent() {
             value={ai.isPayg ? 'Pay as you go' : flags.hasAi ? formatCount(ai.allocation) : 'None'}
             muted={!flags.hasAi && !ai.isPayg}
           />
-          {nextPaymentAmount > 0 && <BillingRow label="Next Payment" value={formatCurrency(nextPaymentAmount)} />}
+          {!flags.isTrial && nextPaymentAmount > 0 && (
+            <BillingRow label="Next Payment" value={formatCurrency(nextPaymentAmount)} />
+          )}
           {flags.isPendingCancellation ? (
             <BillingRow
               label="Plan ends on"

--- a/openframe/services/openframe-frontend/src/graphql/scripts/create-script-mutation.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/create-script-mutation.ts
@@ -1,0 +1,10 @@
+import { graphql } from 'react-relay';
+
+export const createScriptMutation = graphql`
+  mutation createScriptMutation($input: CreateScriptInput!) {
+    createScript(input: $input) {
+      id
+      name
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/graphql/scripts/run-command-mutation.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/run-command-mutation.ts
@@ -1,0 +1,15 @@
+import { graphql } from 'react-relay';
+
+/**
+ * Ad-hoc command dispatch (v2). Used by "Test Script" to run the current,
+ * possibly-unsaved script body on a device without persisting a script.
+ * Returns only an executionId — the result is delivered asynchronously
+ * (Logs / Notifications), the schema has no synchronous output channel.
+ */
+export const runCommandMutation = graphql`
+  mutation runCommandMutation($input: RunCommandInput!) {
+    runCommand(input: $input) {
+      executionId
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/graphql/scripts/run-script-mutation.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/run-script-mutation.ts
@@ -1,0 +1,9 @@
+import { graphql } from 'react-relay';
+
+export const runScriptMutation = graphql`
+  mutation runScriptMutation($input: RunScriptInput!) {
+    runScript(input: $input) {
+      executionId
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/graphql/scripts/script-detail-relay.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/script-detail-relay.ts
@@ -1,0 +1,27 @@
+import { graphql } from 'react-relay';
+
+/**
+ * Single script query (v2). Resolves every field the detail / edit / run
+ * views need from the native OpenFrame GraphQL API.
+ */
+export const scriptDetailRelayQuery = graphql`
+  query scriptDetailRelayQuery($id: ID!) {
+    script(id: $id) {
+      id
+      name
+      description
+      shell
+      scriptBody
+      tag
+      supportedPlatforms
+      defaultTimeoutSeconds
+      defaultArgs
+      envVars {
+        name
+        value
+        secret
+      }
+      status
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/graphql/scripts/scripts-table-relay.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/scripts-table-relay.ts
@@ -1,0 +1,50 @@
+import { graphql } from 'react-relay';
+
+/**
+ * Scripts list query (v2 — native OpenFrame GraphQL API via Relay).
+ *
+ * Mirrors the cursor-paginated `scripts(...)` connection from the backend
+ * schema. Search and the shell/platform filters are pushed to the server;
+ * the pagination fragment drives infinite scroll.
+ */
+export const scriptsTableRelayQuery = graphql`
+  query scriptsTableRelayQuery(
+    $filter: ScriptFilterInput
+    $search: String
+    $first: Int!
+    $after: String
+  ) {
+    ...scriptsTableRelay_query
+      @arguments(filter: $filter, search: $search, first: $first, after: $after)
+  }
+`;
+
+export const scriptsTableRelayFragment = graphql`
+  fragment scriptsTableRelay_query on Query
+    @refetchable(queryName: "scriptsTableRelayPaginationQuery")
+    @argumentDefinitions(
+      filter: { type: "ScriptFilterInput" }
+      search: { type: "String" }
+      first: { type: "Int", defaultValue: 20 }
+      after: { type: "String" }
+    ) {
+    scripts(filter: $filter, search: $search, first: $first, after: $after)
+      @connection(key: "scriptsTableRelay_scripts") {
+      filteredCount
+      edges {
+        node {
+          id
+          name
+          description
+          shell
+          supportedPlatforms
+          defaultTimeoutSeconds
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/graphql/scripts/update-script-mutation.ts
+++ b/openframe/services/openframe-frontend/src/graphql/scripts/update-script-mutation.ts
@@ -1,0 +1,10 @@
+import { graphql } from 'react-relay';
+
+export const updateScriptMutation = graphql`
+  mutation updateScriptMutation($input: UpdateScriptInput!) {
+    updateScript(input: $input) {
+      id
+      name
+    }
+  }
+`;

--- a/openframe/services/openframe-frontend/src/lib/feature-flags.ts
+++ b/openframe/services/openframe-frontend/src/lib/feature-flags.ts
@@ -15,6 +15,7 @@ export const FEATURE_FLAG_NAMES = [
   'mingo-ai-chat-settings',
   'customer-ai-assistant-settings',
   'time-tracker',
+  'scripts-v2',
 ] as const;
 
 /**
@@ -83,6 +84,11 @@ export const featureFlags = {
   timeTracker: {
     enabled(): boolean {
       return getFlagValue('time-tracker', () => false);
+    },
+  },
+  scriptsV2: {
+    enabled(): boolean {
+      return getFlagValue('scripts-v2', () => false);
     },
   },
 } as const;

--- a/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
+++ b/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
@@ -22,6 +22,7 @@ const CATEGORY_BY_NAV_ID: Record<string, NotificationCategory> = {
   organizations: NotificationCategory.CUSTOMERS,
   devices: NotificationCategory.DEVICES,
   scripts: NotificationCategory.SCRIPTS,
+  'scripts-v2': NotificationCategory.SCRIPTS,
   monitoring: NotificationCategory.MONITORING,
   logs: NotificationCategory.LOGS,
   tickets: NotificationCategory.TICKETS,
@@ -63,8 +64,19 @@ export const getNavigationItems = (
       label: 'Scripts',
       icon: <BracketCurlyIcon size={24} />,
       path: '/scripts',
-      isActive: pathname.startsWith('/scripts'),
+      isActive: pathname.startsWith('/scripts') && !pathname.startsWith('/scripts-v2'),
     },
+    ...(featureFlags.scriptsV2.enabled()
+      ? [
+          {
+            id: 'scripts-v2',
+            label: 'Scripts v2',
+            icon: <BracketCurlyIcon size={24} />,
+            path: '/scripts-v2',
+            isActive: pathname.startsWith('/scripts-v2'),
+          },
+        ]
+      : []),
     {
       id: 'monitoring',
       label: 'Monitoring',


### PR DESCRIPTION
## Summary
- **Billing:** "Next Payment" row in the Current Plan card is now hidden while the user is on an active trial. Previously it showed a projected charge (e.g. \$13.00) even during the trial period, which is misleading next to the "Trial ends on" row.
- **Scripts v2:** Adds the in-progress Relay-based scripts experience — new `scripts-v2/` route group (list/create/details/edit/run pages), `scripts/v2/` components & hooks, and `graphql/scripts/` Relay queries/fragments/mutations. Wired into feature flags and navigation.

## Changes
- Billing: gate the Next Payment row on `!flags.isTrial` in `billing-usage-view.tsx`
- New scripts v2 pages, components, hooks, and GraphQL operations (react-relay)
- `feature-flags.ts` + `navigation-config.tsx` wiring for scripts v2
- Minor tweaks to existing scripts editor/form fields and help-center page

## Notes
- `.env.local` (local dev config) intentionally excluded from this PR.

## Test plan
- [ ] `npm run lint:biome`
- [ ] `npm run type-check`
- [ ] `npm run build`
- [ ] On an active-trial tenant, verify the Billing & Usage page shows no "Next Payment" row while "Trial ends on" remains
- [ ] Verify scripts v2 routes render and run/edit flows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Scripts v2 section with redesigned interface for creating, editing, and managing scripts (behind feature flag).
  * Added device selection and testing capabilities for script validation.
  * Added searchable scripts table with filtering by shell type and supported platforms.
  * Updated Help Center navigation label from "Help Center" to "Support Tickets."

* **Improvements**
  * Enhanced form validation and error messaging for script creation and editing.
  * Improved billing view logic for next payment display during trial periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->