### PR TITLE
fix(frontend): show sign-in page when /me returns 403

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/faqs/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/faqs/page.tsx
@@ -1,22 +1,47 @@
 'use client';
 
-import { FaqDocumentPage } from '@flamingo-stack/openframe-frontend-core/components/faq';
+import { FaqSection } from '@flamingo-stack/openframe-frontend-core/components/faq';
+import { PageHeading, PageLayout, PageShell } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { HelpCircle } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { CONTENT_API_BASE, HELP_CENTER_BASE } from '../endpoints';
 
 export const dynamic = 'force-dynamic';
 
+/** Hero icon sizing — same token the lib's `DevSectionPage` hero uses. */
+const SECTION_HERO_ICON_CLASS = 'h-10 w-10 text-ods-accent';
+
 /**
- * FAQs — the page chrome (PageShell + PageLayout + back button) now lives in the
- * lib's `<FaqDocumentPage>` (same as `LegalDocumentPage` / `DevSectionPage`); this
- * route is config-only.
+ * FAQs — composed in the host (NOT via the lib's `FaqDocumentPage`) so the header
+ * matches the multi-platform hub's `/faqs`: `PageShell` → `PageLayout` (back button
+ * only) → a `PageHeading` hero with a leading icon + accent dot → the bare
+ * `<FaqSection heading={null}>`. This is the SAME composition the hub's
+ * `PageWithHeader` produces; `FaqDocumentPage` routes its title through the frozen
+ * `PageLayout`/`TitleBlock` (text-h2, no icon, no accent dot), which is the look we
+ * are intentionally moving away from here to align with the hub + the sibling
+ * `DevSectionPage` / `LegalDocumentPage` heroes.
  */
 export default function FaqsPage() {
+  const router = useRouter();
+
   return (
-    <FaqDocumentPage
-      title="FAQs"
-      subtitle="Quick answers about OpenFrame, the open-source stack, and how we work."
-      backButton={{ label: 'Back to Help Center', href: HELP_CENTER_BASE }}
-      apiBaseUrl={CONTENT_API_BASE}
-    />
+    <PageShell>
+      <PageLayout backButton={{ label: 'Back to Help Center', onClick: () => router.push(HELP_CENTER_BASE) }}>
+        <div className="flex flex-col gap-4">
+          <PageHeading className="flex items-center gap-3">
+            <HelpCircle className={SECTION_HERO_ICON_CLASS} />
+            <span>
+              Frequently Asked Questions
+              <span className="text-ods-accent">.</span>
+            </span>
+          </PageHeading>
+          <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl">
+            Answers to the most common questions about OpenFrame.
+          </p>
+        </div>
+
+        <FaqSection heading={null} apiBaseUrl={CONTENT_API_BASE} />
+      </PageLayout>
+    </PageShell>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-auth-session.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-auth-session.ts
@@ -44,7 +44,10 @@ export function useAuthSession() {
       if (response.ok && response.data?.authenticated) {
         return response.data;
       }
-      if (response.status === 401) {
+      // 401 (unauthenticated) and 403 (forbidden) both mean "not signed in" —
+      // resolve to null so the user is shown the sign-in page instead of a
+      // blank screen / error state.
+      if (response.status === 401 || response.status === 403) {
         return null;
       }
       // For transient errors (500, network), throw so React Query retries
@@ -92,7 +95,7 @@ export function useAuthSession() {
       // and we're not still loading
       const currentState = useAuthStore.getState();
       if (currentState.isAuthenticated && query.fetchStatus === 'idle' && !query.isError) {
-        // Session expired (401) - clear state
+        // Session expired / forbidden (401/403) - clear state
         // Skip logout if query is in error state (transient 5xx/network errors)
         storeLogout();
       }


### PR DESCRIPTION
## Summary

When `/api/me` returns a **403**, the app now renders the sign-in page (same view shown to unauthorized users) instead of a blank screen / indefinite skeleton.

### Root cause
In `use-auth-session.ts`, the auth-check query only treated `401` as "not signed in" (resolve to `null`). A `403` fell through to the `throw new Error(...)` path intended for transient 5xx/network errors. That left React Query in an error state with `query.data === undefined`, so `isReady` stayed `false` and `AppLayoutInner` rendered `<AppShellSkeleton />` indefinitely.

### Fix
`403` now resolves to `null` alongside `401`, routing through the existing unauthenticated path: the auth store logs out, `isAuthenticated` becomes `false`, and the route guard shows the sign-in view (sign-in button / `UnauthorizedOverlay` in SaaS mode, `/auth` redirect in OSS mode). Unlike 401, no token refresh is attempted — a 403 is forbidden, not an expired token. Transient 5xx/network errors still throw and retry, preserving prior session data.

### Also included
- Help-center FAQs page header aligned with the multi-platform hub composition (`PageShell` + `PageLayout` + `PageHeading` hero).

## Testing
- `npm run lint:biome` (pre-commit hook) passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)