### PR TITLE
Hotfix: Ai settings provider block position

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-config-fields.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-config-fields.tsx
@@ -20,92 +20,105 @@ import {
   LLM_PROVIDER_OPTIONS,
 } from '../utils/ai-settings-display';
 
-interface AiConfigFieldsProps<T extends AiLogicFormValues & FieldValues> {
+interface AiProviderModelFieldsProps<T extends AiLogicFormValues & FieldValues> {
   control: Control<T>;
   /** Watched provider; drives the model option list. */
   llmProvider: AIProvider;
-  /** Watched answer style; CUSTOM reveals the custom prompt field. */
-  answerStyle: AnswerStyle;
   modelsByProvider: SupportedModelsByProvider | undefined;
   /** Clears the selected model when the provider changes. */
   onProviderChange: () => void;
 }
 
 /**
- * Shared AI-logic fields (provider, model, answer style, custom prompt) used by
- * both the CLIENT (customer) and ADMIN (Mingo) tabs. The host form owns the
- * `quickActions` field separately via AiSettingsQuickActionsEditor.
+ * LLM Provider + Provider Model selects, rendered side by side. Split out from
+ * the answer-style fields so hosts can place it independently (e.g. the customer
+ * tab keeps it in the top block, above the previews, per design).
  */
-export function AiConfigFields<T extends AiLogicFormValues & FieldValues>({
+export function AiProviderModelFields<T extends AiLogicFormValues & FieldValues>({
   control,
   llmProvider,
-  answerStyle,
   modelsByProvider,
   onProviderChange,
-}: AiConfigFieldsProps<T>) {
+}: AiProviderModelFieldsProps<T>) {
   // The generic constraint guarantees the form has the AI-logic fields; cast
   // narrows Control to that shape for type-safe field names.
   const aiControl = control as unknown as Control<AiLogicFormValues>;
   const modelOptions = modelsByProvider?.[llmProvider] ?? [];
 
   return (
-    <>
-      <div className="flex flex-row gap-[var(--spacing-system-l)]">
-        <div className="flex-1 min-w-0">
-          <Controller
-            name="llmProvider"
-            control={aiControl}
-            render={({ field, fieldState }) => (
-              <Select
-                value={field.value}
-                onValueChange={value => {
-                  field.onChange(value);
-                  onProviderChange();
-                }}
-              >
-                <SelectTrigger label="LLM Provider" error={fieldState.error?.message}>
-                  <SelectValue placeholder="Select a provider" />
-                </SelectTrigger>
-                <SelectContent>
-                  {LLM_PROVIDER_OPTIONS.map(provider => {
-                    const Icon = LLM_PROVIDER_ICON[provider];
-                    return (
-                      <SelectItem key={provider} value={provider}>
-                        <span className="flex items-center gap-2">
-                          <Icon className="w-5 h-5" />
-                          {LLM_PROVIDER_LABEL[provider]}
-                        </span>
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <Controller
-            name="providerModel"
-            control={aiControl}
-            render={({ field, fieldState }) => (
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger label="Provider Model" error={fieldState.error?.message}>
-                  <SelectValue placeholder="Select a model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {modelOptions.map(model => (
-                    <SelectItem key={model.value} value={model.value}>
-                      {model.label}
+    <div className="flex flex-row gap-[var(--spacing-system-l)]">
+      <div className="flex-1 min-w-0">
+        <Controller
+          name="llmProvider"
+          control={aiControl}
+          render={({ field, fieldState }) => (
+            <Select
+              value={field.value}
+              onValueChange={value => {
+                field.onChange(value);
+                onProviderChange();
+              }}
+            >
+              <SelectTrigger label="LLM Provider" error={fieldState.error?.message}>
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {LLM_PROVIDER_OPTIONS.map(provider => {
+                  const Icon = LLM_PROVIDER_ICON[provider];
+                  return (
+                    <SelectItem key={provider} value={provider}>
+                      <span className="flex items-center gap-2">
+                        <Icon className="w-5 h-5" />
+                        {LLM_PROVIDER_LABEL[provider]}
+                      </span>
                     </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          )}
+        />
       </div>
 
+      <div className="flex-1 min-w-0">
+        <Controller
+          name="providerModel"
+          control={aiControl}
+          render={({ field, fieldState }) => (
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger label="Provider Model" error={fieldState.error?.message}>
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {modelOptions.map(model => (
+                  <SelectItem key={model.value} value={model.value}>
+                    {model.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface AiAnswerStyleFieldsProps<T extends AiLogicFormValues & FieldValues> {
+  control: Control<T>;
+  /** Watched answer style; CUSTOM reveals the custom prompt field. */
+  answerStyle: AnswerStyle;
+}
+
+/** Answer Style radio group + the conditional custom-prompt textarea. */
+export function AiAnswerStyleFields<T extends AiLogicFormValues & FieldValues>({
+  control,
+  answerStyle,
+}: AiAnswerStyleFieldsProps<T>) {
+  const aiControl = control as unknown as Control<AiLogicFormValues>;
+
+  return (
+    <>
       <Controller
         name="answerStyle"
         control={aiControl}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
@@ -12,7 +12,7 @@ import { useCustomerAiAssistantForm } from '../hooks/use-customer-ai-assistant-f
 import { getProviderModelLabel, useSupportedModels } from '../hooks/use-supported-models';
 import type { AgentAiConfig, ClientView } from '../types/ai-settings';
 import { CUSTOMER_AI_ASSISTANT_FORM_ID, type CustomerAiAssistantSubmit } from '../types/customer-ai-assistant.types';
-import { AiConfigFields } from './ai-config-fields';
+import { AiAnswerStyleFields, AiProviderModelFields } from './ai-config-fields';
 import { AiSettingsOverview } from './ai-settings-overview';
 import { AiSettingsQuickActionsEditor } from './ai-settings-quick-actions-editor';
 import { AiSettingsPreviews } from './previews/ai-settings-previews';
@@ -68,6 +68,13 @@ export function CustomerAiAssistantTab({ aiConfig, view, isEditMode, onSubmit }:
             render={({ field, fieldState }) => (
               <Input {...field} label="Assistant Name" error={fieldState.error?.message} />
             )}
+          />
+
+          <AiProviderModelFields
+            control={form.control}
+            llmProvider={llmProvider}
+            modelsByProvider={modelsByProvider}
+            onProviderChange={() => form.setValue('providerModel', '')}
           />
         </div>
 
@@ -129,13 +136,7 @@ export function CustomerAiAssistantTab({ aiConfig, view, isEditMode, onSubmit }:
         />
       </div>
 
-      <AiConfigFields
-        control={form.control}
-        llmProvider={llmProvider}
-        answerStyle={answerStyle}
-        modelsByProvider={modelsByProvider}
-        onProviderChange={() => form.setValue('providerModel', '')}
-      />
+      <AiAnswerStyleFields control={form.control} answerStyle={answerStyle} />
 
       <AiSettingsQuickActionsEditor control={form.control} className="mt-8" />
     </form>

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/page.tsx
@@ -1,26 +1,9 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 import { AiSettings } from '@/app/(app)/settings/ai-settings/components/ai-settings-view';
-import { isSaasTenantMode } from '@/lib/app-mode';
 
 export const dynamic = 'force-dynamic';
 
 export default function AiSettingsPage() {
-  const router = useRouter();
-
-  // AI Settings relies on the openframe-saas-ai-agent service (/chat/graphql),
-  // which doesn't exist in self-hosted — keep it saas-tenant only.
-  useEffect(() => {
-    if (!isSaasTenantMode()) {
-      router.replace('/dashboard');
-    }
-  }, [router]);
-
-  if (!isSaasTenantMode()) {
-    return null;
-  }
-
   return <AiSettings />;
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAuthStore } from '@/app/(auth)/auth/stores';
 import { useLogoutConfirmStore } from '@/app/(auth)/auth/stores/logout-confirm-store';
 import { apiClient } from '@/lib/api-client';
-import { isOssTenantMode, isSaasTenantMode } from '@/lib/app-mode';
+import { isOssTenantMode } from '@/lib/app-mode';
 import { authApiClient } from '@/lib/auth-api-client';
 import { featureFlags } from '@/lib/feature-flags';
 import { handleApiError } from '@/lib/handle-api-error';
@@ -153,9 +153,6 @@ export function SettingsHub() {
           item => item.href !== '/settings/billing-usage' || featureFlags.subscription.enabled(),
         )
           .filter(item => item.href !== '/settings/architecture' || isOssTenantMode())
-          // AI Settings relies on the openframe-saas-ai-agent service (/chat/graphql),
-          // which doesn't exist in self-hosted — hide it outside saas-tenant.
-          .filter(item => item.href !== '/settings/ai-settings' || isSaasTenantMode())
           .map(item => (
             <SettingMenuItem
               key={item.href}


### PR DESCRIPTION
AI Settings — reposition LLM Provider & Provider Model.

- On the "Customer AI Assistant" tab (/settings/ai-settings), moved the LLM Provider and Provider Model fields into the top block — left column under Assistant Name, next to Assistant Avatar, matching Figma. They previously sat below the preview block.
- Split AiConfigFields into two reusable components: AiProviderModelFields (provider + model) and AiAnswerStyleFields (answer style + custom prompt). Answer Style stays below the preview.
- Mingo tab untouched (it uses its own AiModelConfig).

Restore AI Settings page access for non-saas users.
- Reverted the over-aggressive gate that hid the entire /settings/ai-settings page from non-saas-tenant users: removed the redirect to /dashboard and restored the settings-hub nav entry. The page works as before for everyone (with its own load/error state).
- Block-level gating kept where appropriate: the "AI-Assistant Appearance" block on /customers/edit is still hidden outside saas-tenant (it's embedded in an otherwise non-AI page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI settings and guardrails are now available to all users.

* **Refactor**
  * Reorganized AI configuration form fields for improved structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->