### PR TITLE
Hotfix: Gate customer ai customization behind flag

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
@@ -21,6 +21,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 import { useClientView } from '@/app/(app)/settings/ai-settings/hooks/use-client-view';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
 import { runtimeEnv } from '@/lib/runtime-config';
 import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
@@ -59,12 +60,14 @@ export function CustomerDetailsView({ id }: CustomerDetailsViewProps) {
 
   const { organization, isLoading, error } = useCustomerDetails(id);
 
-  // The Custom AI Assistant tab depends on the openframe-saas-ai-agent service
-  // (/chat/graphql), so it's saas-tenant only; it appears only when the customer
-  // has a custom appearance override (an org-scoped ClientView exists).
+  // The Custom AI Assistant tab is gated behind the customer-ai-assistant-settings
+  // flag (feature not released yet) and depends on the openframe-saas-ai-agent
+  // service (/chat/graphql), so it's saas-tenant only; it appears only when the
+  // customer has a custom appearance override (an org-scoped ClientView exists).
+  const isCustomerAiEnabled = featureFlags.customerAiAssistantSettings.enabled();
   const isSaasTenant = runtimeEnv.appMode() === 'saas-tenant';
-  const { view: clientView } = useClientView(id, { enabled: isSaasTenant && !!id });
-  const showCustomAiAssistant = isSaasTenant && !!clientView;
+  const { view: clientView } = useClientView(id, { enabled: isCustomerAiEnabled && isSaasTenant && !!id });
+  const showCustomAiAssistant = isCustomerAiEnabled && isSaasTenant && !!clientView;
   const tabs = useMemo(() => getCustomerTabs(showCustomAiAssistant), [showCustomAiAssistant]);
   const activeTab = tabs.some(tab => tab.id === requestedTab) ? requestedTab : 'devices';
 

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/new-customer-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/new-customer-page.tsx
@@ -12,6 +12,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import { safeBackOrReplace, useSafeBack } from '@/app/hooks/use-safe-back';
+import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
 import { runtimeEnv } from '@/lib/runtime-config';
 import { deleteWithAuth, uploadWithAuth } from '@/lib/upload-with-auth';
@@ -424,10 +425,11 @@ export function NewCustomerPage({ organizationId }: NewCustomerPageProps) {
           className="disabled:opacity-60"
         />
 
-        {/* AI-Assistant Appearance — per-customer override. SaaS-only: it relies on
-            the openframe-saas-ai-agent service (/chat/graphql), absent in self-hosted.
-            Edit mode only, since it needs an org id to scope the override. */}
-        {organizationId && isSaasTenant && (
+        {/* AI-Assistant Appearance — per-customer override. Gated behind the
+            customer-ai-assistant-settings flag (feature not released yet). SaaS-only:
+            it relies on the openframe-saas-ai-agent service (/chat/graphql), absent in
+            self-hosted. Edit mode only, since it needs an org id to scope the override. */}
+        {organizationId && isSaasTenant && featureFlags.customerAiAssistantSettings.enabled() && (
           <>
             <div className="border-t border-ods-border" />
             <CustomerAiAssistantAppearance ref={appearanceRef} organizationId={organizationId} />

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
 import type { AgentAiConfig, AiQuickAction, ClientView } from '../types/ai-settings';
 import { AiSettingsCustomerCard } from './ai-settings-customer-card';
@@ -38,7 +39,10 @@ export function AiSettingsOverview({ aiConfig, view, providerModelLabel, quickAc
           />
         </>
       )}
-      {quickActions && <AiSettingsQuickActions actions={quickActions} />}
+      {/* Quick actions are part of the not-yet-released AI customization. */}
+      {featureFlags.customerAiAssistantSettings.enabled() && quickActions && (
+        <AiSettingsQuickActions actions={quickActions} />
+      )}
     </div>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
@@ -18,7 +18,10 @@ export const AI_SETTINGS_TABS: TabItem[] = [
 // Tabs gated behind server feature flags until each feature ships. Guardrails
 // is always visible.
 const TAB_FEATURE_FLAG: Partial<Record<AiSettingsTabId, () => boolean>> = {
-  customer: () => featureFlags.customerAiAssistantSettings.enabled(),
+  // Temporarily always visible: the Customer AI Assistant tab is shown, while the
+  // not-yet-released appearance customization it controls stays gated behind
+  // `featureFlags.customerAiAssistantSettings` at its own call sites.
+  customer: () => true,
   mingo: () => featureFlags.mingoAiChatSettings.enabled(),
 };
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/customer-ai-assistant-tab.tsx
@@ -8,6 +8,7 @@ import {
   TabSelector,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { Controller } from 'react-hook-form';
+import { featureFlags } from '@/lib/feature-flags';
 import { useCustomerAiAssistantForm } from '../hooks/use-customer-ai-assistant-form';
 import { getProviderModelLabel, useSupportedModels } from '../hooks/use-supported-models';
 import type { AgentAiConfig, ClientView } from '../types/ai-settings';
@@ -41,6 +42,10 @@ export function CustomerAiAssistantTab({ aiConfig, view, isEditMode, onSubmit }:
   const providerModel = form.watch('providerModel');
   const applicationTheme = form.watch('applicationTheme');
   const accentColor = form.watch('accentColor');
+
+  // Appearance customization (theme/accent + previews, answer style, quick actions)
+  // is not released yet — keep it behind the feature flag.
+  const showCustomization = featureFlags.customerAiAssistantSettings.enabled();
 
   if (!isEditMode) {
     const modelLabel = getProviderModelLabel(modelsByProvider, aiConfig.llmProvider, aiConfig.providerModel);
@@ -90,55 +95,59 @@ export function CustomerAiAssistantTab({ aiConfig, view, isEditMode, onSubmit }:
         </div>
       </div>
 
-      <div className="flex flex-col gap-[var(--spacing-system-l)] rounded-md border border-ods-border p-[var(--spacing-system-l)]">
-        <div className="flex flex-col gap-[var(--spacing-system-l)] md:flex-row md:items-end">
-          <div className="min-w-0 flex-1">
-            <Controller
-              name="applicationTheme"
-              control={form.control}
-              render={({ field }) => (
-                <TabSelector
-                  label="Application Theme"
-                  variant="primary"
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  items={[
-                    { id: 'DARK', label: 'Dark', icon: <MoonStarIcon className="size-5" /> },
-                    { id: 'LIGHT', label: 'Light', icon: <Sun01Icon className="size-5" /> },
-                    { id: 'SYSTEM', label: 'System', icon: <MonitorIcon className="size-5" /> },
-                  ]}
+      {showCustomization && (
+        <>
+          <div className="flex flex-col gap-[var(--spacing-system-l)] rounded-md border border-ods-border p-[var(--spacing-system-l)]">
+            <div className="flex flex-col gap-[var(--spacing-system-l)] md:flex-row md:items-end">
+              <div className="min-w-0 flex-1">
+                <Controller
+                  name="applicationTheme"
+                  control={form.control}
+                  render={({ field }) => (
+                    <TabSelector
+                      label="Application Theme"
+                      variant="primary"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      items={[
+                        { id: 'DARK', label: 'Dark', icon: <MoonStarIcon className="size-5" /> },
+                        { id: 'LIGHT', label: 'Light', icon: <Sun01Icon className="size-5" /> },
+                        { id: 'SYSTEM', label: 'System', icon: <MonitorIcon className="size-5" /> },
+                      ]}
+                    />
+                  )}
                 />
+              </div>
+
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <p className="text-h3 text-ods-text-primary">Accent Color</p>
+                <Controller
+                  name="accentColor"
+                  control={form.control}
+                  render={({ field }) => <ColorPickerInput value={field.value} onChange={field.onChange} />}
+                />
+              </div>
+            </div>
+
+            <AiSettingsPreviews
+              assistantName={assistantName || view.assistantName}
+              avatarUrl={avatarUrl}
+              accentColor={accentColor || view.accentColor}
+              theme={applicationTheme}
+              providerName={llmProvider}
+              modelDisplayName={getProviderModelLabel(
+                modelsByProvider,
+                llmProvider,
+                providerModel || aiConfig.providerModel,
               )}
             />
           </div>
 
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <p className="text-h3 text-ods-text-primary">Accent Color</p>
-            <Controller
-              name="accentColor"
-              control={form.control}
-              render={({ field }) => <ColorPickerInput value={field.value} onChange={field.onChange} />}
-            />
-          </div>
-        </div>
+          <AiAnswerStyleFields control={form.control} answerStyle={answerStyle} />
 
-        <AiSettingsPreviews
-          assistantName={assistantName || view.assistantName}
-          avatarUrl={avatarUrl}
-          accentColor={accentColor || view.accentColor}
-          theme={applicationTheme}
-          providerName={llmProvider}
-          modelDisplayName={getProviderModelLabel(
-            modelsByProvider,
-            llmProvider,
-            providerModel || aiConfig.providerModel,
-          )}
-        />
-      </div>
-
-      <AiAnswerStyleFields control={form.control} answerStyle={answerStyle} />
-
-      <AiSettingsQuickActionsEditor control={form.control} className="mt-8" />
+          <AiSettingsQuickActionsEditor control={form.control} className="mt-8" />
+        </>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
- Show the Customer AI Assistant settings tab — set TAB_FEATURE_FLAG.customer to true so the tab is always visible (previously hidden by the flag).

- Gate the unreleased customization behind customerAiAssistantSettings instead:
-- Settings tab (customer-ai-assistant-tab.tsx) — hide the appearance block (theme/accent + previews), answer style, and quick actions in edit mode.
-- AiSettingsOverview — hide the read-only quick actions section.
-- Customer edit page (new-customer-page.tsx) — hide the per-customer "AI-Assistant Appearance" block.
-- Customer details page (customer-details-view.tsx) — hide the "Custom AI Assistant" tab and skip the useClientView fetch when the flag is off.

Net effect with the flag off (prod): the tab renders with Assistant Name + LLM Provider/Model + Avatar only; all appearance customization stays hidden until the flag is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature-flag controls for the customer AI assistant experience across customer and AI settings pages.

* **Bug Fixes**
  * Limited customer AI assistant customization and quick actions to supported environments, reducing exposure of unfinished or unavailable controls.
  * Kept the customer AI settings tab visible while only showing customization options when enabled, improving navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->