### PR TITLE
fix(client): back off mesh self-heal to hourly after a no-op (+ log .msh target)

### DIFF
--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -22,8 +22,10 @@ const HEALTHY_MARKER: &str = "Received CoreOk from server";
 
 /// How often we scan the agent log.
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
-/// How long continuously stuck before we act; also the sole rate-limiter (streak resets after each attempt). Cooldown may return after dev testing.
+/// How long continuously stuck before we act the first time.
 const STUCK_DURATION: Duration = Duration::from_secs(10 * 60);
+/// After a no-op/failed heal (MeshID unchanged / server-side outage we can't fix) back off to this before retrying, so a persistently-down server doesn't spam the log every STUCK_DURATION.
+const NOOP_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 /// Timeout for the /generate-msh fetch so an unresponsive server can't block the heal loop.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -85,6 +87,8 @@ impl MeshSelfHealService {
 
         let mut offset: u64 = 0;
         let mut stuck_since: Option<Instant> = None;
+        // Set after a no-op/failed heal so further attempts (and their logs) are throttled to NOOP_COOLDOWN.
+        let mut last_attempt: Option<Instant> = None;
 
         loop {
             sleep(POLL_INTERVAL).await;
@@ -94,6 +98,7 @@ impl MeshSelfHealService {
                     for line in &lines {
                         if line.contains(HEALTHY_MARKER) {
                             stuck_since = None;
+                            last_attempt = None;
                         } else if line.contains(FAILURE_MARKER) {
                             stuck_since.get_or_insert_with(Instant::now);
                         }
@@ -113,6 +118,12 @@ impl MeshSelfHealService {
             if stuck_for < STUCK_DURATION {
                 continue;
             }
+            // Throttle: after a no-op/failed heal don't retry (or log) until NOOP_COOLDOWN has passed.
+            if let Some(t) = last_attempt {
+                if t.elapsed() < NOOP_COOLDOWN {
+                    continue;
+                }
+            }
 
             if self.tool_run_manager.is_updating(MESH_TOOL_ID).await {
                 info!("meshcentral-agent is updating — skipping MeshID self-heal this cycle");
@@ -125,14 +136,21 @@ impl MeshSelfHealService {
                 stuck_for.as_secs()
             );
             match self.try_heal().await {
-                Ok(true) => info!("mesh self-heal: adopted a new MeshID and restarted the agent"),
-                Ok(false) => {
-                    debug!("mesh self-heal: MeshID unchanged or server unreachable — no action taken")
+                Ok(true) => {
+                    info!("mesh self-heal: adopted a new MeshID and restarted the agent");
+                    last_attempt = None;
                 }
-                Err(e) => error!("mesh self-heal failed: {e:#}"),
+                Ok(false) => {
+                    last_attempt = Some(Instant::now());
+                    info!("mesh self-heal: MeshID unchanged — likely a server-side mesh outage, not a client problem; backing off for {}s", NOOP_COOLDOWN.as_secs());
+                }
+                Err(e) => {
+                    last_attempt = Some(Instant::now());
+                    error!("mesh self-heal failed: {e:#} — backing off for {}s", NOOP_COOLDOWN.as_secs());
+                }
             }
 
-            // Sole rate-limiter: reset after every attempt; a real heal is cleared by the CoreOk marker.
+            // Reset the stuck streak after each attempt; a real heal is cleared by the CoreOk marker.
             stuck_since = None;
         }
     }

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -175,12 +175,16 @@ impl MeshSelfHealService {
             parse_mesh_id(&body).ok_or_else(|| anyhow!("no MeshID in /generate-msh response"))?;
 
         let msh_path = self.mesh_msh_path().await?;
-        let current_id = tokio::fs::read_to_string(&msh_path)
-            .await
-            .ok()
-            .and_then(|s| parse_mesh_id(&s));
+        let current_msh = tokio::fs::read_to_string(&msh_path).await.ok();
+        let current_id = current_msh.as_deref().and_then(parse_mesh_id);
 
         if current_id.as_deref() == Some(new_id.as_str()) {
+            // No MeshID drift to fix. Log the target the agent is dialing so a server/gateway-side outage is distinguishable from a stale .msh target.
+            let server = current_msh
+                .as_deref()
+                .and_then(|s| parse_msh_field(s, "MeshServer"))
+                .unwrap_or_else(|| "<none>".to_string());
+            info!("mesh self-heal: MeshID unchanged ({new_id}); agent .msh MeshServer={server}");
             return Ok(false);
         }
 
@@ -241,6 +245,14 @@ fn parse_mesh_id(msh: &str) -> Option<String> {
     msh.lines()
         .find_map(|l| l.trim().strip_prefix("MeshID="))
         .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Extract the value of a `Key=` line from an `.msh` body.
+fn parse_msh_field(msh: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    msh.lines()
+        .find_map(|l| l.trim().strip_prefix(prefix.as_str()).map(|v| v.trim().to_string()))
         .filter(|v| !v.is_empty())
 }
 


### PR DESCRIPTION
(Recreated from #1979 after the branch was renamed `fix/` → `hotfix/`.)

## Why

On a server-side mesh outage the agent loops on `Connection FAILED: No HTTP response` with the **MeshID unchanged**, so `try_heal()` no-ops every `STUCK_DURATION` (10 min) forever (321–401 attempts / 0 adoptions on affected machines) — pure noise on a problem the client can't fix.

## Change

- After a no-op/failed heal, back off to `NOOP_COOLDOWN` (1h) before retrying; a successful heal or a `CoreOk` healthy marker clears it. Genuine stale-MeshID heals still happen on the first attempt.
- Surface the no-op at `info` ("likely a server-side mesh outage, not a client problem") instead of invisible `debug`.
- On a no-op, also log the agent's `.msh` `MeshServer=` target, so an offline box's actual mesh target is visible (server/gateway outage vs stale `.msh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated self-heal retries and noisy logs by adding a cooldown after unsuccessful or no-op heal attempts.
  * Improved diagnostics when the generated mesh identity already matches the current configuration by showing the server value from the mesh settings for clearer troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->