### PR TITLE
fix(frontend): add page padding to help-center layout

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/help-center/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/help-center/page.tsx
@@ -86,7 +86,7 @@ const ITEMS: Item[] = [
 // host-specific landing whose links + icons are app-owned.
 export default function HelpCenterPage() {
   return (
-    <PageLayout title="Help Center">
+    <PageLayout title="Help Center" className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-[var(--spacing-system-m)]">
         {ITEMS.map(({ href, title, description, Icon }) => (
           <SettingMenuItem


### PR DESCRIPTION
## Summary
- Add horizontal/bottom padding to the Help Center `PageLayout` so the grid is no longer flush against the viewport edges.

## Changes
- `help-center/page.tsx`: pass `className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"` to `PageLayout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Help Center page spacing so it now has improved horizontal and bottom padding for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->