### PR TITLE
Hotfix/mesh agent resilience

### DIFF
--- a/clients/openframe-client/src/platform/system_service.rs
+++ b/clients/openframe-client/src/platform/system_service.rs
@@ -141,6 +141,45 @@ pub async fn stop_service(service_name: &str) -> Result<()> {
     }
 }
 
+/// Confirm a freshly (re)installed service actually reached RUNNING, starting it if the
+/// installer left it stopped; errors if it cannot be confirmed RUNNING. On non-Windows this is
+/// a no-op — the `StopPending` wedge that motivates it is Windows-specific, and blindly
+/// re-issuing a start on launchd/systemd risks failing an already-loaded unit.
+pub async fn verify_service_running(service_name: &str) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows_service::service::ServiceState;
+        if let Ok(status) = query_service_status_windows(service_name) {
+            if status.current_state == ServiceState::Running {
+                return Ok(());
+            }
+        }
+        start_service(service_name)
+            .await
+            .with_context(|| format!("service {} did not reach RUNNING after install", service_name))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = service_name;
+        Ok(())
+    }
+}
+
+/// True if the service is absent or Stopped — i.e. safe to (re)install over. On non-Windows
+/// always true. Used to abort a reinstall rather than overwrite/register on top of a service
+/// we could not stop or clear (e.g. a wedged `StopPending` or a still-live old agent).
+pub async fn service_clear_for_install(service_name: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        service_stopped_or_missing(&query_service_status_windows(service_name))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = service_name;
+        true
+    }
+}
+
 #[cfg(target_os = "windows")]
 async fn stop_service_windows(service_name: &str) -> Result<()> {
     use windows_service::service::ServiceAccess;

--- a/clients/openframe-client/src/platform/system_service.rs
+++ b/clients/openframe-client/src/platform/system_service.rs
@@ -121,22 +121,26 @@ pub async fn start_service(service_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Stop an OS service via the platform service manager.
-pub async fn stop_service(service_name: &str) -> Result<()> {
+/// Stop an OS service via the platform service manager. `allow_delete` permits the last-resort
+/// SCM delete of a wedged service; pass it only from install/reinstall/uninstall, which recreate
+/// the service. The update/restore paths must pass false (they don't re-register, so a delete bricks the tool).
+pub async fn stop_service(service_name: &str, allow_delete: bool) -> Result<()> {
     info!("Stopping service: {}", service_name);
 
     #[cfg(target_os = "windows")]
     {
-        stop_service_windows(service_name).await
+        stop_service_windows(service_name, allow_delete).await
     }
 
     #[cfg(target_os = "macos")]
     {
+        let _ = allow_delete;
         stop_service_macos(service_name).await
     }
 
     #[cfg(target_os = "linux")]
     {
+        let _ = allow_delete;
         stop_service_linux(service_name).await
     }
 }
@@ -181,7 +185,7 @@ pub async fn service_clear_for_install(service_name: &str) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-async fn stop_service_windows(service_name: &str) -> Result<()> {
+async fn stop_service_windows(service_name: &str, allow_delete: bool) -> Result<()> {
     use windows_service::service::ServiceAccess;
     use winapi::shared::winerror::{
         ERROR_SERVICE_CANNOT_ACCEPT_CTRL, ERROR_SERVICE_DOES_NOT_EXIST, ERROR_SERVICE_NOT_ACTIVE,
@@ -204,12 +208,12 @@ async fn stop_service_windows(service_name: &str) -> Result<()> {
         Err(_elapsed) => {
             warn!("service.stop() for {} timed out after {}s; force-killing service process",
                   service_name, SERVICE_STOP_CALL_TIMEOUT_SECS);
-            return force_stop_service_windows(service_name).await;
+            return force_stop_service_windows(service_name, allow_delete).await;
         }
         Ok(Err(join_err)) => {
             error!("service.stop() task for {} failed: {}; force-killing service process",
                    service_name, join_err);
-            return force_stop_service_windows(service_name).await;
+            return force_stop_service_windows(service_name, allow_delete).await;
         }
         Ok(Ok(result)) => result,
     };
@@ -221,7 +225,7 @@ async fn stop_service_windows(service_name: &str) -> Result<()> {
                 return Ok(());
             }
             warn!("Service {} did not reach STOPPED after stop request; force-killing", service_name);
-            force_stop_service_windows(service_name).await
+            force_stop_service_windows(service_name, allow_delete).await
         }
         Err(windows_service::Error::Winapi(e))
             if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) =>
@@ -240,17 +244,17 @@ async fn stop_service_windows(service_name: &str) -> Result<()> {
         {
             warn!("Service {} cannot accept stop control (error {}); force-killing service process",
                   service_name, ERROR_SERVICE_CANNOT_ACCEPT_CTRL);
-            force_stop_service_windows(service_name).await
+            force_stop_service_windows(service_name, allow_delete).await
         }
         Err(e) => {
             error!("Failed to stop service {} via SCM: {}; force-killing service process", service_name, e);
-            force_stop_service_windows(service_name).await
+            force_stop_service_windows(service_name, allow_delete).await
         }
     }
 }
 
 #[cfg(target_os = "windows")]
-async fn force_stop_service_windows(service_name: &str) -> Result<()> {
+async fn force_stop_service_windows(service_name: &str, allow_delete: bool) -> Result<()> {
     for attempt in 1..=SERVICE_FORCE_KILL_MAX_ATTEMPTS {
         let status = query_service_status_windows(service_name);
         if service_stopped_or_missing(&status) {
@@ -311,13 +315,22 @@ async fn force_stop_service_windows(service_name: &str) -> Result<()> {
         return Ok(());
     }
 
+    let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
+        .unwrap_or_else(|_| "unqueryable".to_string());
+
+    // Only delete when the caller will recreate the service (install/reinstall/uninstall). The
+    // update/restore paths pass allow_delete=false: deleting there would brick the tool because
+    // nothing re-registers the service, so report failure and let the caller retry/repair.
+    if !allow_delete {
+        return Err(anyhow::anyhow!(
+            "Failed to force-stop service {} (state {} after {} attempts)",
+            service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS
+        ));
+    }
+
     // Last resort: the service is wedged (typically StopPending that SCM won't reap, with no
     // killable process). Mark it for deletion via the SCM so the follow-up reinstall recreates
     // it cleanly. This is what lets a reinstall recover the agent without a machine reboot.
-    // Only reachable from stop_for_installation (install/reinstall/uninstall), where the
-    // service is about to be recreated or removed anyway.
-    let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
-        .unwrap_or_else(|_| "unqueryable".to_string());
     warn!("Service {} still not stopped (state {}) after {} force-kill attempts; deleting it via SCM to clear the wedged state",
           service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
     match delete_service_windows(service_name).await {

--- a/clients/openframe-client/src/platform/system_service.rs
+++ b/clients/openframe-client/src/platform/system_service.rs
@@ -238,10 +238,28 @@ async fn force_stop_service_windows(service_name: &str) -> Result<()> {
                 }
             }
             None => {
-                let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
-                    .unwrap_or_else(|_| "unqueryable".to_string());
-                info!("Service {} has no reportable PID (state {}, attempt {}/{}); waiting",
-                      service_name, state, attempt, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
+                // SCM only reports a PID while the service is Running; in StopPending (and
+                // other transitional states) the PID is hidden, so the SCM-PID path can never
+                // act on a wedged service. Fall back to the service's configured image path
+                // and kill any live process running from it directly.
+                match service_image_exe_path_windows(service_name) {
+                    Some(exe) => {
+                        let killed = kill_processes_by_exe_path_windows(&exe).await;
+                        if killed > 0 {
+                            info!("Force-killed {} process(es) for service {} by image path {} (attempt {}/{})",
+                                  killed, service_name, exe.display(), attempt, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
+                        } else {
+                            info!("Service {} has no reportable PID and no live process at {} (attempt {}/{}); waiting for SCM to settle",
+                                  service_name, exe.display(), attempt, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
+                        }
+                    }
+                    None => {
+                        let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
+                            .unwrap_or_else(|_| "unqueryable".to_string());
+                        info!("Service {} has no reportable PID and no resolvable image path (state {}, attempt {}/{}); waiting",
+                              service_name, state, attempt, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
+                    }
+                }
             }
         }
 
@@ -251,16 +269,30 @@ async fn force_stop_service_windows(service_name: &str) -> Result<()> {
     let status = query_service_status_windows(service_name);
     if service_stopped_or_missing(&status) {
         info!("Service {} force-stopped successfully", service_name);
-        Ok(())
-    } else {
-        let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
-            .unwrap_or_else(|_| "unqueryable".to_string());
-        error!("Service {} still not stopped (state {}) after {} force-kill attempts",
-               service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
-        Err(anyhow::anyhow!(
-            "Failed to force-stop service {} (state {} after {} attempts)",
-            service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS
-        ))
+        return Ok(());
+    }
+
+    // Last resort: the service is wedged (typically StopPending that SCM won't reap, with no
+    // killable process). Mark it for deletion via the SCM so the follow-up reinstall recreates
+    // it cleanly. This is what lets a reinstall recover the agent without a machine reboot.
+    // Only reachable from stop_for_installation (install/reinstall/uninstall), where the
+    // service is about to be recreated or removed anyway.
+    let state = status.as_ref().map(|s| format!("{:?}", s.current_state))
+        .unwrap_or_else(|_| "unqueryable".to_string());
+    warn!("Service {} still not stopped (state {}) after {} force-kill attempts; deleting it via SCM to clear the wedged state",
+          service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS);
+    match delete_service_windows(service_name).await {
+        Ok(()) => {
+            info!("Service {} deleted; a fresh install will recreate it", service_name);
+            Ok(())
+        }
+        Err(e) => {
+            error!("Service {} could not be stopped or deleted: {:#}", service_name, e);
+            Err(anyhow::anyhow!(
+                "Failed to force-stop or delete service {} (state {} after {} attempts): {:#}",
+                service_name, state, SERVICE_FORCE_KILL_MAX_ATTEMPTS, e
+            ))
+        }
     }
 }
 
@@ -376,5 +408,113 @@ fn service_stopped_or_missing(
             e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32)
         }
         Err(_) => false,
+    }
+}
+
+/// True only if SCM reports the service does not exist.
+#[cfg(target_os = "windows")]
+fn service_missing_windows(service_name: &str) -> bool {
+    use winapi::shared::winerror::ERROR_SERVICE_DOES_NOT_EXIST;
+    match query_service_status_windows(service_name) {
+        Err(windows_service::Error::Winapi(e)) => {
+            e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32)
+        }
+        _ => false,
+    }
+}
+
+/// The on-disk executable path from the service's SCM image path (`lpBinaryPathName`),
+/// stripped of surrounding quotes and any trailing arguments.
+#[cfg(target_os = "windows")]
+fn service_image_exe_path_windows(service_name: &str) -> Option<std::path::PathBuf> {
+    use windows_service::service::ServiceAccess;
+    let service = open_service_windows(service_name, ServiceAccess::QUERY_CONFIG).ok()?;
+    let config = service.query_config().ok()?;
+    parse_exe_from_image_path(&config.executable_path.to_string_lossy())
+}
+
+/// Extract the executable path from a raw SCM image-path string, e.g.
+/// `"C:\\path\\agent.exe" -arg` or `C:\\path\\agent.exe -arg`.
+#[cfg(target_os = "windows")]
+fn parse_exe_from_image_path(image_path: &str) -> Option<std::path::PathBuf> {
+    let trimmed = image_path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Quoted form: take the contents of the first quoted span.
+    if let Some(rest) = trimmed.strip_prefix('"') {
+        if let Some(end) = rest.find('"') {
+            return Some(std::path::PathBuf::from(&rest[..end]));
+        }
+    }
+    // Unquoted: cut after the first ".exe" (case-insensitive) to drop trailing args.
+    let lower = trimmed.to_lowercase();
+    if let Some(idx) = lower.find(".exe") {
+        return Some(std::path::PathBuf::from(&trimmed[..idx + 4]));
+    }
+    Some(std::path::PathBuf::from(trimmed))
+}
+
+/// Force-kill every running process whose executable is exactly `exe_path`. Matching on the
+/// full path (not the image name) avoids killing sibling tools that share an `agent.exe` name.
+/// Returns the number of processes a kill was issued for.
+#[cfg(target_os = "windows")]
+async fn kill_processes_by_exe_path_windows(exe_path: &std::path::Path) -> usize {
+    use sysinfo::System;
+    let target = exe_path.to_string_lossy().to_lowercase();
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let mut killed = 0usize;
+    for (pid, process) in sys.processes() {
+        let proc_exe = process
+            .exe()
+            .map(|p| p.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        if !proc_exe.is_empty() && proc_exe == target {
+            let _ = Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &pid.to_string()])
+                .output()
+                .await;
+            killed += 1;
+        }
+    }
+    killed
+}
+
+/// Mark a wedged service for deletion via the SCM and wait for it to disappear, so a follow-up
+/// reinstall can recreate it under the same name without hitting `ERROR_SERVICE_MARKED_FOR_DELETE`.
+#[cfg(target_os = "windows")]
+async fn delete_service_windows(service_name: &str) -> Result<()> {
+    use windows_service::service::ServiceAccess;
+
+    if service_missing_windows(service_name) {
+        return Ok(());
+    }
+
+    // Scope the handle so it is closed before we poll — SCM only finalizes removal once the
+    // last open handle is released.
+    {
+        let service = open_service_windows(service_name, ServiceAccess::DELETE)
+            .with_context(|| format!("open service {} for deletion", service_name))?;
+        service
+            .delete()
+            .with_context(|| format!("DeleteService failed for {}", service_name))?;
+    }
+
+    for _ in 1..=SERVICE_STOP_MAX_ATTEMPTS {
+        if service_missing_windows(service_name) {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(PROCESS_CHECK_INTERVAL_MS)).await;
+    }
+
+    if service_missing_windows(service_name) {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "service {} still present after delete request",
+            service_name
+        ))
     }
 }

--- a/clients/openframe-client/src/platform/tool_updater/gui_app.rs
+++ b/clients/openframe-client/src/platform/tool_updater/gui_app.rs
@@ -26,7 +26,7 @@ impl ToolUpdater for GuiAppToolUpdater {
         info!(tool_id = %tool_agent_id, "Preparing GuiApp for update");
 
         info!(tool_id = %tool_agent_id, "Stopping GUI app process");
-        self.deps.tool_kill_service.stop_installed_tool(tool).await
+        self.deps.tool_kill_service.stop_installed_tool(tool, false).await
             .with_context(|| format!("Failed to stop GUI app: {}", tool_agent_id))?;
 
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;

--- a/clients/openframe-client/src/platform/tool_updater/service.rs
+++ b/clients/openframe-client/src/platform/tool_updater/service.rs
@@ -48,7 +48,7 @@ impl ToolUpdater for ServiceToolUpdater {
         info!(tool_id = %tool_agent_id, "Preparing Service tool for update");
 
         info!(tool_id = %tool_agent_id, "Stopping service");
-        if let Err(e) = self.deps.tool_kill_service.stop_installed_tool(tool).await {
+        if let Err(e) = self.deps.tool_kill_service.stop_installed_tool(tool, false).await {
             warn!(tool_id = %tool_agent_id, "Failed to stop service (non-fatal): {:#}", e);
         }
 

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -22,8 +22,12 @@ const HEALTHY_MARKER: &str = "Received CoreOk from server";
 
 /// How often we scan the agent log.
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
-/// How long continuously stuck before we act; also the sole rate-limiter (streak resets after each attempt). Cooldown may return after dev testing.
+/// How long continuously stuck before we act.
 const STUCK_DURATION: Duration = Duration::from_secs(10 * 60);
+/// After a no-op heal (MeshID unchanged / nothing to do), wait at least this long before
+/// trying again, so a persistently-unreachable mesh server doesn't trigger a heal attempt
+/// every STUCK_DURATION.
+const NOOP_HEAL_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 /// Timeout for the /generate-msh fetch so an unresponsive server can't block the heal loop.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -85,6 +89,7 @@ impl MeshSelfHealService {
 
         let mut offset: u64 = 0;
         let mut stuck_since: Option<Instant> = None;
+        let mut last_noop_heal: Option<Instant> = None;
 
         loop {
             sleep(POLL_INTERVAL).await;
@@ -114,6 +119,12 @@ impl MeshSelfHealService {
                 continue;
             }
 
+            if let Some(t) = last_noop_heal {
+                if t.elapsed() < NOOP_HEAL_COOLDOWN {
+                    continue;
+                }
+            }
+
             if self.tool_run_manager.is_updating(MESH_TOOL_ID).await {
                 info!("meshcentral-agent is updating — skipping MeshID self-heal this cycle");
                 stuck_since = None;
@@ -125,9 +136,13 @@ impl MeshSelfHealService {
                 stuck_for.as_secs()
             );
             match self.try_heal().await {
-                Ok(true) => info!("mesh self-heal: adopted a new MeshID and restarted the agent"),
+                Ok(true) => {
+                    info!("mesh self-heal: adopted a new MeshID and restarted the agent");
+                    last_noop_heal = None;
+                }
                 Ok(false) => {
-                    debug!("mesh self-heal: MeshID unchanged or server unreachable — no action taken")
+                    debug!("mesh self-heal: MeshID unchanged or server unreachable — no action taken");
+                    last_noop_heal = Some(Instant::now());
                 }
                 Err(e) => error!("mesh self-heal failed: {e:#}"),
             }

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -1,4 +1,6 @@
-//! Mesh self-heal: when the agent is held/orphaned on a stale MeshID, re-fetch the current .msh and bounce the agent so it re-enrolls.
+//! Mesh self-heal: when the agent can't enroll (stale/old .msh — a re-keyed MeshID or a missing
+//! ServerID), re-fetch the current .msh and bounce the *service* so the agent re-imports it and
+//! reconnects. Restart-only (never `-install`/`-uninstall`) so agent.db / the NodeID is preserved.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -89,10 +91,15 @@ impl MeshSelfHealService {
 
         let mut offset: u64 = 0;
         let mut stuck_since: Option<Instant> = None;
-        let mut last_noop_heal: Option<Instant> = None;
+        let mut last_heal_attempt: Option<Instant> = None;
 
         loop {
             sleep(POLL_INTERVAL).await;
+
+            // Proactive check: a current .msh with no ServerID line makes the agent bail before it
+            // ever connects ("ServerID entry not found in Db!"), so it never logs a connection
+            // failure and the log-based stuck detection below would never fire. Catch it directly.
+            let msh_missing_serverid = self.current_msh_missing_serverid().await;
 
             match read_new_lines(&log_path, &mut offset).await {
                 Ok(lines) => {
@@ -107,52 +114,49 @@ impl MeshSelfHealService {
                 Err(e) => {
                     // Log not present yet (agent not installed/started) — just wait.
                     debug!("mesh self-heal: cannot read {}: {e}", log_path.display());
-                    continue;
                 }
             }
 
-            let stuck_for = match stuck_since {
-                Some(t) => t.elapsed(),
-                None => continue,
-            };
-            if stuck_for < STUCK_DURATION {
+            let stuck = stuck_since.map_or(false, |t| t.elapsed() >= STUCK_DURATION);
+            if !msh_missing_serverid && !stuck {
                 continue;
             }
 
-            if let Some(t) = last_noop_heal {
+            // Rate-limit every attempt (success or no-op) so a down /generate-msh or a purely
+            // server-side outage can't trigger a heal each cycle.
+            if let Some(t) = last_heal_attempt {
                 if t.elapsed() < NOOP_HEAL_COOLDOWN {
                     continue;
                 }
             }
 
             if self.tool_run_manager.is_updating(MESH_TOOL_ID).await {
-                info!("meshcentral-agent is updating — skipping MeshID self-heal this cycle");
+                info!("meshcentral-agent is updating — skipping .msh self-heal this cycle");
                 stuck_since = None;
                 continue;
             }
 
-            warn!(
-                "meshcentral-agent stuck for {}s with no successful connect — attempting MeshID self-heal",
-                stuck_for.as_secs()
-            );
+            let reason = if msh_missing_serverid {
+                "current .msh has no ServerID (agent cannot authenticate the server)".to_string()
+            } else {
+                format!("no successful connect within {}s", STUCK_DURATION.as_secs())
+            };
+            warn!("meshcentral-agent unhealthy: {reason} — attempting .msh self-heal");
+
             match self.try_heal().await {
-                Ok(true) => {
-                    info!("mesh self-heal: adopted a new MeshID and restarted the agent");
-                    last_noop_heal = None;
-                }
-                Ok(false) => {
-                    debug!("mesh self-heal: MeshID unchanged or server unreachable — no action taken");
-                    last_noop_heal = Some(Instant::now());
-                }
+                Ok(true) => info!("mesh self-heal: refreshed .msh and restarted the agent (NodeID preserved)"),
+                Ok(false) => debug!("mesh self-heal: .msh already current — likely a server-side issue, no action taken"),
                 Err(e) => error!("mesh self-heal failed: {e:#}"),
             }
 
-            // Sole rate-limiter: reset after every attempt; a real heal is cleared by the CoreOk marker.
             stuck_since = None;
+            last_heal_attempt = Some(Instant::now());
         }
     }
 
-    /// Fetch the current .msh; if its MeshID differs from the agent's, rewrite it and bounce. Ok(true) only when applied.
+    /// Fetch the current .msh; if it is missing, or its MeshID/ServerID differ from the server's,
+    /// rewrite it and bounce the service so the agent re-imports it. Ok(true) only when applied.
+    /// Restarting the service (never `-install`) preserves agent.db / the NodeID.
     async fn try_heal(&self) -> Result<bool> {
         let host = self.initial_config.get_server_url()?;
         let url = format!("https://{host}/tools/agent/meshcentral-server/generate-msh?host={host}");
@@ -168,24 +172,32 @@ impl MeshSelfHealService {
             return Err(anyhow!("/generate-msh returned HTTP {}", resp.status()));
         }
         let body = resp.text().await?;
-        let new_id =
-            parse_mesh_id(&body).ok_or_else(|| anyhow!("no MeshID in /generate-msh response"))?;
+        let new_mesh = parse_msh_field(&body, "MeshID");
+        let new_server = parse_msh_field(&body, "ServerID");
+        if new_mesh.is_none() && new_server.is_none() {
+            return Err(anyhow!("/generate-msh response has neither MeshID nor ServerID"));
+        }
 
         let msh_path = self.mesh_msh_path().await?;
-        let current_id = tokio::fs::read_to_string(&msh_path)
-            .await
-            .ok()
-            .and_then(|s| parse_mesh_id(&s));
+        let current = tokio::fs::read_to_string(&msh_path).await.ok();
+        let cur_mesh = current.as_deref().and_then(|s| parse_msh_field(s, "MeshID"));
+        let cur_server = current.as_deref().and_then(|s| parse_msh_field(s, "ServerID"));
 
-        if current_id.as_deref() == Some(new_id.as_str()) {
+        // Rewrite when the current .msh is missing or differs from the server's current values.
+        // A missing/changed ServerID is the "ServerID entry not found in Db!" root cause; a changed
+        // MeshID means the device group was re-keyed.
+        let mesh_changed = new_mesh.is_some() && cur_mesh != new_mesh;
+        let server_changed = new_server.is_some() && cur_server != new_server;
+        if !mesh_changed && !server_changed {
             return Ok(false);
         }
 
         info!(
-            "mesh self-heal: MeshID change {} -> {} (writing {})",
-            current_id.as_deref().unwrap_or("<none>"),
-            new_id,
-            msh_path.display()
+            "mesh self-heal: rewriting {} (mesh_changed={}, serverid {} -> {})",
+            msh_path.display(),
+            mesh_changed,
+            if cur_server.is_some() { "present" } else { "missing" },
+            if new_server.is_some() { "present" } else { "missing" }
         );
 
         let tmp_path = msh_path.with_extension("msh.tmp");
@@ -193,6 +205,7 @@ impl MeshSelfHealService {
         tokio::fs::rename(&tmp_path, &msh_path).await?;
 
         // Restart the service to re-import the .msh: kill, then start (redundant start is a no-op under mac KeepAlive).
+        // No -install/-uninstall, so agent.db (SelfNodeCert/NodeID) is preserved.
         self.tool_kill.stop_tool(MESH_TOOL_ID).await?;
         if let Some(service_name) = self.mesh_service_name().await? {
             if let Err(e) = system_service::start_service(&service_name).await {
@@ -200,6 +213,18 @@ impl MeshSelfHealService {
             }
         }
         Ok(true)
+    }
+
+    /// True only when the agent is installed, its .msh exists, and that .msh has no ServerID line.
+    async fn current_msh_missing_serverid(&self) -> bool {
+        let msh_path = match self.mesh_msh_path().await {
+            Ok(p) => p,
+            Err(_) => return false, // not installed / no .msh yet — nothing to heal
+        };
+        match tokio::fs::read_to_string(&msh_path).await {
+            Ok(s) => parse_msh_field(&s, "ServerID").is_none(),
+            Err(_) => false,
+        }
     }
 
     /// Find the .msh the client saved in the tool dir (agent.msh on Windows, meshagent.msh on macOS).
@@ -233,11 +258,11 @@ impl MeshSelfHealService {
     }
 }
 
-/// Extract the value of the `MeshID=` line from an `.msh` body.
-fn parse_mesh_id(msh: &str) -> Option<String> {
+/// Extract the value of a `Key=` line (e.g. `MeshID=`, `ServerID=`) from an `.msh` body.
+fn parse_msh_field(msh: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
     msh.lines()
-        .find_map(|l| l.trim().strip_prefix("MeshID="))
-        .map(|v| v.trim().to_string())
+        .find_map(|l| l.trim().strip_prefix(prefix.as_str()).map(|v| v.trim().to_string()))
         .filter(|v| !v.is_empty())
 }
 

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -1,6 +1,3 @@
-//! Mesh self-heal: re-fetch the .msh and restart the service when the agent can't enroll (stale
-//! MeshID or missing ServerID). Restart-only (no `-install`) so agent.db / the NodeID is preserved.
-
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -16,9 +13,9 @@ use crate::services::{AgentConfigurationService, InitialConfigurationService, In
 
 const MESH_TOOL_ID: &str = "meshcentral-agent";
 
-/// Agent log line for a control channel that can't connect (orphaned/dead-upstream); its authState= field is ignored (unreliable, ill machines show 0).
+/// Agent log line for a control channel that can't connect.
 const FAILURE_MARKER: &str = "Connection FAILED: No HTTP response";
-/// Sent only after the mesh check passes, so an orphaned/dead-upstream agent never prints it (unlike "Server fully authenticated", printed before the hold).
+/// Printed only after a successful server connect.
 const HEALTHY_MARKER: &str = "Received CoreOk from server";
 
 /// How often we scan the agent log.
@@ -64,7 +61,6 @@ impl MeshSelfHealService {
         }
     }
 
-    /// Spawn the self-heal watcher in the background (matches tool_run_manager).
     pub async fn run(&self) -> Result<()> {
         let this = self.clone();
         tokio::spawn(async move {
@@ -107,7 +103,6 @@ impl MeshSelfHealService {
                     }
                 }
                 Err(e) => {
-                    // Log not present yet (agent not installed/started) — just wait.
                     debug!("mesh self-heal: cannot read {}: {e}", log_path.display());
                 }
             }
@@ -117,7 +112,6 @@ impl MeshSelfHealService {
                 continue;
             }
 
-            // Rate-limit attempts.
             if let Some(t) = last_heal_attempt {
                 if t.elapsed() < NOOP_HEAL_COOLDOWN {
                     continue;
@@ -148,7 +142,6 @@ impl MeshSelfHealService {
         }
     }
 
-    /// Re-fetch the .msh; if MeshID/ServerID changed (or it's missing), rewrite and bounce. Ok(true) when applied.
     async fn try_heal(&self) -> Result<bool> {
         let host = self.initial_config.get_server_url()?;
         let url = format!("https://{host}/tools/agent/meshcentral-server/generate-msh?host={host}");
@@ -178,8 +171,6 @@ impl MeshSelfHealService {
         let mesh_changed = new_mesh.is_some() && cur_mesh != new_mesh;
         let server_changed = new_server.is_some() && cur_server != new_server;
         if !mesh_changed && !server_changed {
-            // Nothing to fix; log the server the agent is dialing so a server-side outage is
-            // distinguishable from a stale .msh target.
             let server = current
                 .as_deref()
                 .and_then(|s| parse_msh_field(s, "MeshServer"))
@@ -200,7 +191,6 @@ impl MeshSelfHealService {
         tokio::fs::write(&tmp_path, body.as_bytes()).await?;
         tokio::fs::rename(&tmp_path, &msh_path).await?;
 
-        // Restart the service to re-import the .msh: kill, then start (redundant start is a no-op under mac KeepAlive).
         self.tool_kill.stop_tool(MESH_TOOL_ID).await?;
         if let Some(service_name) = self.mesh_service_name().await? {
             if let Err(e) = system_service::start_service(&service_name).await {
@@ -210,11 +200,10 @@ impl MeshSelfHealService {
         Ok(true)
     }
 
-    /// True only when the agent is installed, its .msh exists, and that .msh has no ServerID line.
     async fn current_msh_missing_serverid(&self) -> bool {
         let msh_path = match self.mesh_msh_path().await {
             Ok(p) => p,
-            Err(_) => return false, // not installed / no .msh yet — nothing to heal
+            Err(_) => return false,
         };
         match tokio::fs::read_to_string(&msh_path).await {
             Ok(s) => parse_msh_field(&s, "ServerID").is_none(),
@@ -222,7 +211,6 @@ impl MeshSelfHealService {
         }
     }
 
-    /// Find the .msh the client saved in the tool dir (agent.msh on Windows, meshagent.msh on macOS).
     async fn mesh_msh_path(&self) -> Result<PathBuf> {
         self.installed_tools
             .get_by_tool_agent_id(MESH_TOOL_ID)
@@ -239,7 +227,6 @@ impl MeshSelfHealService {
         Err(anyhow!("no .msh found in {}", dir.display()))
     }
 
-    /// The service name (launchd/SCM/systemd) if the agent installs as a service.
     async fn mesh_service_name(&self) -> Result<Option<String>> {
         let tool = self
             .installed_tools
@@ -253,7 +240,6 @@ impl MeshSelfHealService {
     }
 }
 
-/// Extract the value of a `Key=` line (e.g. `MeshID=`, `ServerID=`) from an `.msh` body.
 fn parse_msh_field(msh: &str, key: &str) -> Option<String> {
     let prefix = format!("{key}=");
     msh.lines()
@@ -261,7 +247,6 @@ fn parse_msh_field(msh: &str, key: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-/// Read whole new lines since *offset, advancing only to the last newline; resets offset if the file shrank.
 async fn read_new_lines(path: &Path, offset: &mut u64) -> Result<Vec<String>> {
     use tokio::io::{AsyncReadExt, AsyncSeekExt, SeekFrom};
 
@@ -280,7 +265,7 @@ async fn read_new_lines(path: &Path, offset: &mut u64) -> Result<Vec<String>> {
 
     let consume = match buf.iter().rposition(|&b| b == b'\n') {
         Some(i) => i + 1,
-        None => return Ok(Vec::new()), // no complete line yet
+        None => return Ok(Vec::new()),
     };
     *offset += consume as u64;
 

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -1,6 +1,5 @@
-//! Mesh self-heal: when the agent can't enroll (stale/old .msh — a re-keyed MeshID or a missing
-//! ServerID), re-fetch the current .msh and bounce the *service* so the agent re-imports it and
-//! reconnects. Restart-only (never `-install`/`-uninstall`) so agent.db / the NodeID is preserved.
+//! Mesh self-heal: re-fetch the .msh and restart the service when the agent can't enroll (stale
+//! MeshID or missing ServerID). Restart-only (no `-install`) so agent.db / the NodeID is preserved.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -26,9 +25,7 @@ const HEALTHY_MARKER: &str = "Received CoreOk from server";
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
 /// How long continuously stuck before we act.
 const STUCK_DURATION: Duration = Duration::from_secs(10 * 60);
-/// After a no-op heal (MeshID unchanged / nothing to do), wait at least this long before
-/// trying again, so a persistently-unreachable mesh server doesn't trigger a heal attempt
-/// every STUCK_DURATION.
+/// Minimum wait between heal attempts (success or no-op), so a server-side outage can't spin.
 const NOOP_HEAL_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 /// Timeout for the /generate-msh fetch so an unresponsive server can't block the heal loop.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -96,9 +93,6 @@ impl MeshSelfHealService {
         loop {
             sleep(POLL_INTERVAL).await;
 
-            // Proactive check: a current .msh with no ServerID line makes the agent bail before it
-            // ever connects ("ServerID entry not found in Db!"), so it never logs a connection
-            // failure and the log-based stuck detection below would never fire. Catch it directly.
             let msh_missing_serverid = self.current_msh_missing_serverid().await;
 
             match read_new_lines(&log_path, &mut offset).await {
@@ -122,8 +116,7 @@ impl MeshSelfHealService {
                 continue;
             }
 
-            // Rate-limit every attempt (success or no-op) so a down /generate-msh or a purely
-            // server-side outage can't trigger a heal each cycle.
+            // Rate-limit attempts.
             if let Some(t) = last_heal_attempt {
                 if t.elapsed() < NOOP_HEAL_COOLDOWN {
                     continue;
@@ -154,9 +147,7 @@ impl MeshSelfHealService {
         }
     }
 
-    /// Fetch the current .msh; if it is missing, or its MeshID/ServerID differ from the server's,
-    /// rewrite it and bounce the service so the agent re-imports it. Ok(true) only when applied.
-    /// Restarting the service (never `-install`) preserves agent.db / the NodeID.
+    /// Re-fetch the .msh; if MeshID/ServerID changed (or it's missing), rewrite and bounce. Ok(true) when applied.
     async fn try_heal(&self) -> Result<bool> {
         let host = self.initial_config.get_server_url()?;
         let url = format!("https://{host}/tools/agent/meshcentral-server/generate-msh?host={host}");
@@ -183,9 +174,6 @@ impl MeshSelfHealService {
         let cur_mesh = current.as_deref().and_then(|s| parse_msh_field(s, "MeshID"));
         let cur_server = current.as_deref().and_then(|s| parse_msh_field(s, "ServerID"));
 
-        // Rewrite when the current .msh is missing or differs from the server's current values.
-        // A missing/changed ServerID is the "ServerID entry not found in Db!" root cause; a changed
-        // MeshID means the device group was re-keyed.
         let mesh_changed = new_mesh.is_some() && cur_mesh != new_mesh;
         let server_changed = new_server.is_some() && cur_server != new_server;
         if !mesh_changed && !server_changed {
@@ -205,7 +193,6 @@ impl MeshSelfHealService {
         tokio::fs::rename(&tmp_path, &msh_path).await?;
 
         // Restart the service to re-import the .msh: kill, then start (redundant start is a no-op under mac KeepAlive).
-        // No -install/-uninstall, so agent.db (SelfNodeCert/NodeID) is preserved.
         self.tool_kill.stop_tool(MESH_TOOL_ID).await?;
         if let Some(service_name) = self.mesh_service_name().await? {
             if let Err(e) = system_service::start_service(&service_name).await {

--- a/clients/openframe-client/src/services/tool_connection_processing_manager.rs
+++ b/clients/openframe-client/src/services/tool_connection_processing_manager.rs
@@ -17,6 +17,12 @@ use crate::services::tool_connection_service::ToolConnectionService;
 use crate::services::tool_run_manager::ToolRunManager;
 
 const RETRY_DELAY_SECONDS: u64 = 15;
+/// Consecutive agentId-resolution failures tolerated at the normal cadence before the tool
+/// connection is treated as degraded and the retry loop backs off (e.g. a hung `-nodeid-base64`).
+const AGENT_ID_MAX_FAST_RETRIES: u32 = 5;
+/// Back-off delay between agentId attempts once resolution is degraded, so a persistently
+/// unhealthy agent can't spin a tight 15s loop forever while staying invisible.
+const AGENT_ID_DEGRADED_BACKOFF_SECONDS: u64 = 300;
 
 // TODO: refactor class
 #[derive(Clone)]
@@ -131,6 +137,9 @@ impl ToolConnectionProcessingManager {
         let tool_run_manager = self.tool_run_manager.clone();
 
         tokio::spawn(async move {
+            // Counts consecutive agentId-resolution failures so a hung agent backs off
+            // (and is reported as degraded) instead of spinning a tight retry loop forever.
+            let mut agent_id_failures: u32 = 0;
             loop {
                 while tool_run_manager.is_updating(&tool.tool_agent_id).await {
                     info!(tool_id = %tool.tool_id, "Tool is being updated, deferring node-id resolution...");
@@ -157,7 +166,7 @@ impl ToolConnectionProcessingManager {
                                 tool.tool_id,
                                 e
                             );
-                            sleep(Duration::from_secs(RETRY_DELAY_SECONDS)).await;
+                            backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
                     };
@@ -187,13 +196,13 @@ impl ToolConnectionProcessingManager {
                         // Command returned an error before timeout
                         Ok(Err(e)) => {
                             error!("Failed to execute agentId command: {:#} – retrying", e);
-                            sleep(Duration::from_secs(RETRY_DELAY_SECONDS)).await;
+                            backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
                         // Timeout expired
                         Err(_) => {
                             error!("agentId command timed out after 15 seconds – retrying");
-                            sleep(Duration::from_secs(RETRY_DELAY_SECONDS)).await;
+                            backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
                     };
@@ -207,14 +216,14 @@ impl ToolConnectionProcessingManager {
                         // Parse agent_tool_id from command output
                         if !stdout.is_empty() {
                             // TODO: add mechanism to verify that it's correct agent id
+                            agent_id_failures = 0;
                             stdout // Use the command output as agent_tool_id
                         } else {
                             info!(
                                 tool_id = %tool.tool_id,
-                                "agentId command returned empty output - retrying in {} seconds",
-                                RETRY_DELAY_SECONDS
+                                "agentId command returned empty output - retrying"
                             );
-                            sleep(Duration::from_secs(RETRY_DELAY_SECONDS)).await;
+                            backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
                     } else {
@@ -223,12 +232,11 @@ impl ToolConnectionProcessingManager {
                         error!(
                             tool_id = %tool.tool_id,
                             exit_status = %output.status,
-                            "agentId command failed - stdout: {} stderr: {}. Retrying in {} seconds",
+                            "agentId command failed - stdout: {} stderr: {}. Retrying",
                             stdout,
-                            stderr,
-                            RETRY_DELAY_SECONDS
+                            stderr
                         );
-                        sleep(Duration::from_secs(RETRY_DELAY_SECONDS)).await;
+                        backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                         continue;
                     }
                 };
@@ -271,6 +279,32 @@ impl ToolConnectionProcessingManager {
 
         Ok(())
     }
+}
+
+/// Sleep between agentId-resolution attempts, escalating to a longer back-off once failures
+/// are sustained. A persistently failing `-nodeid-base64` (hung agent / missing node identity)
+/// would otherwise spin a tight 15s loop indefinitely and stay invisible; after
+/// `AGENT_ID_MAX_FAST_RETRIES` it logs a one-time degraded error and slows to
+/// `AGENT_ID_DEGRADED_BACKOFF_SECONDS`, while still retrying so it self-recovers if the agent
+/// becomes healthy (e.g. after a server-side reinstall).
+async fn backoff_agent_id_failure(tool_id: &str, failures: &mut u32) {
+    *failures += 1;
+    if *failures == AGENT_ID_MAX_FAST_RETRIES + 1 {
+        error!(
+            tool_id = %tool_id,
+            consecutive_failures = *failures,
+            "agentId resolution is failing repeatedly — tool connection is DEGRADED (agent likely \
+             unhealthy: hung -nodeid-base64 or missing node identity). Backing off to {}s; will keep \
+             retrying. A server-side reinstall may be required to recover.",
+            AGENT_ID_DEGRADED_BACKOFF_SECONDS
+        );
+    }
+    let delay = if *failures > AGENT_ID_MAX_FAST_RETRIES {
+        AGENT_ID_DEGRADED_BACKOFF_SECONDS
+    } else {
+        RETRY_DELAY_SECONDS
+    };
+    sleep(Duration::from_secs(delay)).await;
 }
 
 

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -268,6 +268,19 @@ impl ToolInstallationService {
         }
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
+        // Don't install on top of a service we couldn't clear: if the existing service is still
+        // active (e.g. a wedged StopPending that even delete couldn't remove, or a live process
+        // we couldn't kill), abort so the record stays `Installing` and the install is retried,
+        // rather than overwriting/registering over a live agent.
+        if let Some(Installation::Service { service_name: svc, .. }) = &stop_installation {
+            if !crate::platform::system_service::service_clear_for_install(svc).await {
+                return Err(anyhow::anyhow!(
+                    "Aborting reinstall of {}: existing service '{}' is still active and could not be cleared; will retry",
+                    tool_agent_id, svc
+                ));
+            }
+        }
+
         // Download and install the tool
         let (executable_path, installation_type, bundle_id, config_service_name) = match resolved_config {
             Some(resolved_config) => {
@@ -453,6 +466,16 @@ impl ToolInstallationService {
             info!("Installation command executed successfully for tool {}\nstdout: {}", tool_agent_id, stdout);
         } else {
             info!("No installation command args provided for tool: {} - skip installation", tool_agent_id);
+        }
+
+        // For Service tools, confirm the service actually came up before recording it as
+        // Installed. A `-install` that exits 0 but leaves the service stopped/wedged would
+        // otherwise be marked healthy; failing here keeps the record `Installing` for retry.
+        if let Installation::Service { service_name: svc, .. } = &installation {
+            crate::platform::system_service::verify_service_running(svc)
+                .await
+                .with_context(|| format!("Post-install service verification failed for {}", tool_agent_id))?;
+            info!("Verified service {} is running after install of {}", svc, tool_agent_id);
         }
 
         // Persist installed tool information

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -34,6 +34,16 @@ use std::os::unix::fs::PermissionsExt;
 /// terminated when the timeout fires.
 const TOOL_COMMAND_TIMEOUT_SECS: u64 = 300;
 
+/// TEMP (remove with the agent.db backup/restore): deletes the mesh reinstall backup on every exit path.
+struct ReinstallBackupGuard(Option<std::path::PathBuf>);
+impl Drop for ReinstallBackupGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ToolInstallationService {
     github_download_service: GithubDownloadService,
@@ -113,8 +123,8 @@ impl ToolInstallationService {
 
         // TEMP (remove when the agent persists its identity across a db wipe): back up the mesh
         // agent.db outside the tool dir so it survives the reinstall wipe; restored after install to
-        // preserve the NodeID.
-        let mesh_db_backup: Option<std::path::PathBuf> = if reinstall && tool_agent_id == "meshcentral-agent" {
+        // preserve the NodeID. The guard deletes the backup on every exit path.
+        let mesh_db_backup = ReinstallBackupGuard(if reinstall && tool_agent_id == "meshcentral-agent" {
             let db = tool_folder_path.join("agent.db");
             let backup = base_folder_path.join("meshcentral-agent.db.reinstall-backup");
             if db.exists() {
@@ -133,8 +143,8 @@ impl ToolInstallationService {
             }
         } else {
             None
-        };
-        
+        });
+
         // Check if tool is already installed
         if let Some(installed_tool) = self.installed_tools_service.get_by_tool_agent_id(tool_agent_id).await? {
             if reinstall {
@@ -520,7 +530,7 @@ impl ToolInstallationService {
 
         // TEMP (remove when the agent persists its identity across a db wipe): restore the preserved
         // agent.db so the agent keeps its previous NodeID; the fresh .msh is re-imported on restart.
-        if let Some(backup) = mesh_db_backup {
+        if let Some(backup) = mesh_db_backup.0.as_ref() {
             if let Installation::Service { service_name: svc, .. } = &installation {
                 let db_path = tool_folder_path.join("agent.db");
                 info!("TEMP: restoring preserved mesh agent.db to keep NodeID across reinstall");
@@ -528,15 +538,14 @@ impl ToolInstallationService {
                     warn!("TEMP: failed to stop {} before agent.db restore: {:#}", svc, e);
                 }
                 tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                match fs::copy(&backup, &db_path).await {
+                match fs::copy(backup, &db_path).await {
                     Ok(_) => info!("TEMP: restored mesh agent.db from {}", backup.display()),
                     Err(e) => warn!("TEMP: failed to restore mesh agent.db from {}: {:#}; NodeID will rotate", backup.display(), e),
                 }
-                if let Err(e) = crate::platform::system_service::start_service(svc).await {
-                    warn!("TEMP: failed to restart {} after agent.db restore: {:#}", svc, e);
-                }
+                crate::platform::system_service::start_service(svc)
+                    .await
+                    .with_context(|| format!("Failed to restart {} after agent.db restore", svc))?;
             }
-            let _ = fs::remove_file(&backup).await;
         }
 
         // Persist installed tool information

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -156,7 +156,7 @@ impl ToolInstallationService {
 
                 // Stop the tool process if it's running
                 info!("Stopping existing tool process for {}", tool_agent_id);
-                if let Err(e) = self.tool_kill_service.stop_installed_tool(&installed_tool).await {
+                if let Err(e) = self.tool_kill_service.stop_installed_tool(&installed_tool, true).await {
                     warn!("Failed to stop tool process: {:#}", e);
                 }
         
@@ -293,7 +293,7 @@ impl ToolInstallationService {
         };
         info!("Stopping any leftover holder for {} before download", tool_agent_id);
         if let Some(stop_installation) = &stop_installation {
-            if let Err(e) = self.tool_kill_service.stop_for_installation(tool_agent_id, stop_installation).await {
+            if let Err(e) = self.tool_kill_service.stop_for_installation(tool_agent_id, stop_installation, true).await {
                 warn!("Failed to stop leftover holder before download: {:#}", e);
             }
         }
@@ -534,7 +534,7 @@ impl ToolInstallationService {
             if let Installation::Service { service_name: svc, .. } = &installation {
                 let db_path = tool_folder_path.join("agent.db");
                 info!("TEMP: restoring preserved mesh agent.db to keep NodeID across reinstall");
-                if let Err(e) = crate::platform::system_service::stop_service(svc).await {
+                if let Err(e) = crate::platform::system_service::stop_service(svc, false).await {
                     warn!("TEMP: failed to stop {} before agent.db restore: {:#}", svc, e);
                 }
                 tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -111,11 +111,9 @@ impl ToolInstallationService {
         let base_folder_path = self.directory_manager.app_support_dir();
         let tool_folder_path = base_folder_path.join(tool_agent_id);
 
-        // TEMP (remove when meshagent NodeID-preservation lands): a mesh force-reinstall wipes
-        // agent.db and `-install` regenerates the node identity (new NodeID), orphaning the device on
-        // MeshCentral. Until the agent reuses its persisted cert across a db wipe, back up agent.db
-        // here (outside the tool dir so it survives the wipe) and restore it after install so the
-        // NodeID is preserved. See MESH_AGENT_DB_SAFETY_VERDICT.md.
+        // TEMP (remove when the agent persists its identity across a db wipe): back up the mesh
+        // agent.db outside the tool dir so it survives the reinstall wipe; restored after install to
+        // preserve the NodeID.
         let mesh_db_backup: Option<std::path::PathBuf> = if reinstall && tool_agent_id == "meshcentral-agent" {
             let db = tool_folder_path.join("agent.db");
             let backup = base_folder_path.join("meshcentral-agent.db.reinstall-backup");
@@ -309,11 +307,8 @@ impl ToolInstallationService {
             }
         }
 
-        // On reinstall without a prior registry record (the record was lost on long-broken hosts),
-        // the cleanup branch above is skipped, so stale on-disk state (e.g. the mesh agent.msh and
-        // meshagent.db) would be reused and the agent fails to enroll ("ServerID entry not found in
-        // Db!"). Now that the holder is stopped and the service is confirmed clear, wipe the
-        // directory so the tool re-provisions from scratch.
+        // Reinstall with no registry record: cleanup above was skipped, so wipe the dir now (holder
+        // is stopped and the service confirmed clear) to drop stale on-disk state.
         if reinstall && !reinstall_dir_cleared && tool_folder_path.exists() {
             info!("Reinstall without registry record: removing stale tool directory {}", tool_folder_path.display());
             crate::platform::remove_directory_with_retry(&tool_folder_path, 5)
@@ -374,9 +369,7 @@ impl ToolInstallationService {
                 let asset_original_version = asset.original_version();
                 let asset_effective_version = asset.effective_version();
                 
-                // Download the asset if it's missing. On reinstall, always refresh server-generated
-                // config assets (e.g. the mesh .msh from /generate-msh) even when a stale copy
-                // exists, so the tool never reuses an outdated server identity.
+                // On reinstall, always refresh server-generated config assets (e.g. the mesh .msh).
                 let refresh_config_asset = reinstall && matches!(asset.source, AssetSource::ToolApi);
                 if !asset_path.exists() || refresh_config_asset {
                     if is_executable {
@@ -525,12 +518,8 @@ impl ToolInstallationService {
             info!("Verified service {} is running after install of {}", svc, tool_agent_id);
         }
 
-        // TEMP (remove when meshagent NodeID-preservation lands): the freshly (re)installed mesh
-        // agent generated a NEW node identity. Restore the agent.db backed up before the wipe so the
-        // agent loads its previous SelfNodeCert (same NodeID) on restart instead of the new one,
-        // avoiding an orphaned device on MeshCentral. The fresh .msh on disk is re-imported on the
-        // restart, so server config stays current. Remove once the meshagent reuses its persisted
-        // cert across a db wipe (see MESH_AGENT_DB_SAFETY_VERDICT.md).
+        // TEMP (remove when the agent persists its identity across a db wipe): restore the preserved
+        // agent.db so the agent keeps its previous NodeID; the fresh .msh is re-imported on restart.
         if let Some(backup) = mesh_db_backup {
             if let Installation::Service { service_name: svc, .. } = &installation {
                 let db_path = tool_folder_path.join("agent.db");

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -106,6 +106,7 @@ impl ToolInstallationService {
         let effective_version = tool_installation_message.effective_version().to_string();
         let run_args_clone = tool_installation_message.run_command_args.clone();
         let reinstall = tool_installation_message.reinstall.clone();
+        let mut reinstall_dir_cleared = false;
         // Create tool-specific directory
         let base_folder_path = self.directory_manager.app_support_dir();
         let tool_folder_path = base_folder_path.join(tool_agent_id);
@@ -185,6 +186,7 @@ impl ToolInstallationService {
                 crate::platform::remove_directory_with_retry(&tool_folder_path, 5)
                     .await
                     .with_context(|| format!("Failed to remove existing tool directory: {}", tool_folder_path.display()))?;
+                reinstall_dir_cleared = true;
 
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -281,6 +283,22 @@ impl ToolInstallationService {
             }
         }
 
+        // On reinstall without a prior registry record (the record was lost on long-broken hosts),
+        // the cleanup branch above is skipped, so stale on-disk state (e.g. the mesh agent.msh and
+        // meshagent.db) would be reused and the agent fails to enroll ("ServerID entry not found in
+        // Db!"). Now that the holder is stopped and the service is confirmed clear, wipe the
+        // directory so the tool re-provisions from scratch.
+        if reinstall && !reinstall_dir_cleared && tool_folder_path.exists() {
+            info!("Reinstall without registry record: removing stale tool directory {}", tool_folder_path.display());
+            crate::platform::remove_directory_with_retry(&tool_folder_path, 5)
+                .await
+                .with_context(|| format!("Failed to remove existing tool directory: {}", tool_folder_path.display()))?;
+            fs::create_dir_all(&tool_folder_path)
+                .await
+                .with_context(|| format!("Failed to recreate tool directory: {}", tool_folder_path.display()))?;
+            reinstall_dir_cleared = true;
+        }
+
         // Download and install the tool
         let (executable_path, installation_type, bundle_id, config_service_name) = match resolved_config {
             Some(resolved_config) => {
@@ -330,8 +348,11 @@ impl ToolInstallationService {
                 let asset_original_version = asset.original_version();
                 let asset_effective_version = asset.effective_version();
                 
-                // Download and save asset if it doesn't already exist
-                if !asset_path.exists() {
+                // Download the asset if it's missing. On reinstall, always refresh server-generated
+                // config assets (e.g. the mesh .msh from /generate-msh) even when a stale copy
+                // exists, so the tool never reuses an outdated server identity.
+                let refresh_config_asset = reinstall && matches!(asset.source, AssetSource::ToolApi);
+                if !asset_path.exists() || refresh_config_asset {
                     if is_executable {
                         if let Err(e) = self.tool_kill_service.stop_asset(&asset.id, tool_agent_id).await {
                             warn!("Failed to stop asset process {} before write: {:#}", asset.id, e);

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -110,6 +110,32 @@ impl ToolInstallationService {
         // Create tool-specific directory
         let base_folder_path = self.directory_manager.app_support_dir();
         let tool_folder_path = base_folder_path.join(tool_agent_id);
+
+        // TEMP (remove when meshagent NodeID-preservation lands): a mesh force-reinstall wipes
+        // agent.db and `-install` regenerates the node identity (new NodeID), orphaning the device on
+        // MeshCentral. Until the agent reuses its persisted cert across a db wipe, back up agent.db
+        // here (outside the tool dir so it survives the wipe) and restore it after install so the
+        // NodeID is preserved. See MESH_AGENT_DB_SAFETY_VERDICT.md.
+        let mesh_db_backup: Option<std::path::PathBuf> = if reinstall && tool_agent_id == "meshcentral-agent" {
+            let db = tool_folder_path.join("agent.db");
+            let backup = base_folder_path.join("meshcentral-agent.db.reinstall-backup");
+            if db.exists() {
+                match fs::copy(&db, &backup).await {
+                    Ok(_) => {
+                        info!("TEMP: backed up mesh agent.db to {} to preserve NodeID across reinstall", backup.display());
+                        Some(backup)
+                    }
+                    Err(e) => {
+                        warn!("TEMP: failed to back up mesh agent.db: {:#}; NodeID may rotate on reinstall", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         
         // Check if tool is already installed
         if let Some(installed_tool) = self.installed_tools_service.get_by_tool_agent_id(tool_agent_id).await? {
@@ -497,6 +523,31 @@ impl ToolInstallationService {
                 .await
                 .with_context(|| format!("Post-install service verification failed for {}", tool_agent_id))?;
             info!("Verified service {} is running after install of {}", svc, tool_agent_id);
+        }
+
+        // TEMP (remove when meshagent NodeID-preservation lands): the freshly (re)installed mesh
+        // agent generated a NEW node identity. Restore the agent.db backed up before the wipe so the
+        // agent loads its previous SelfNodeCert (same NodeID) on restart instead of the new one,
+        // avoiding an orphaned device on MeshCentral. The fresh .msh on disk is re-imported on the
+        // restart, so server config stays current. Remove once the meshagent reuses its persisted
+        // cert across a db wipe (see MESH_AGENT_DB_SAFETY_VERDICT.md).
+        if let Some(backup) = mesh_db_backup {
+            if let Installation::Service { service_name: svc, .. } = &installation {
+                let db_path = tool_folder_path.join("agent.db");
+                info!("TEMP: restoring preserved mesh agent.db to keep NodeID across reinstall");
+                if let Err(e) = crate::platform::system_service::stop_service(svc).await {
+                    warn!("TEMP: failed to stop {} before agent.db restore: {:#}", svc, e);
+                }
+                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                match fs::copy(&backup, &db_path).await {
+                    Ok(_) => info!("TEMP: restored mesh agent.db from {}", backup.display()),
+                    Err(e) => warn!("TEMP: failed to restore mesh agent.db from {}: {:#}; NodeID will rotate", backup.display(), e),
+                }
+                if let Err(e) = crate::platform::system_service::start_service(svc).await {
+                    warn!("TEMP: failed to restart {} after agent.db restore: {:#}", svc, e);
+                }
+            }
+            let _ = fs::remove_file(&backup).await;
         }
 
         // Persist installed tool information

--- a/clients/openframe-client/src/services/tool_kill_service.rs
+++ b/clients/openframe-client/src/services/tool_kill_service.rs
@@ -203,11 +203,11 @@ impl ToolKillService {
         self.stop_processes_by_pattern(&pattern, &format!("path: {}", executable_path)).await
     }
 
-    pub async fn stop_installed_tool(&self, tool: &InstalledTool) -> Result<()> {
-        self.stop_for_installation(&tool.tool_agent_id, &tool.installation).await
+    pub async fn stop_installed_tool(&self, tool: &InstalledTool, allow_delete: bool) -> Result<()> {
+        self.stop_for_installation(&tool.tool_agent_id, &tool.installation, allow_delete).await
     }
 
-    pub async fn stop_for_installation(&self, tool_agent_id: &str, installation: &Installation) -> Result<()> {
+    pub async fn stop_for_installation(&self, tool_agent_id: &str, installation: &Installation, allow_delete: bool) -> Result<()> {
         match installation {
             Installation::GuiApp { executable_path, .. } => {
                 info!("Stopping GUI app by executable path: {}", executable_path);
@@ -222,7 +222,7 @@ impl ToolKillService {
             Installation::Service { service_name, executable_path } => {
                 info!(service_name = %service_name,
                       "Stopping Service type tool via system service manager");
-                if let Err(e) = system_service::stop_service(service_name).await {
+                if let Err(e) = system_service::stop_service(service_name, allow_delete).await {
                     warn!("Failed to stop service {} (continuing with process kill by path): {:#}",
                           service_name, e);
                 }

--- a/clients/openframe-client/src/services/tool_uninstall_service.rs
+++ b/clients/openframe-client/src/services/tool_uninstall_service.rs
@@ -158,7 +158,7 @@ impl ToolUninstallService {
     }
 
     async fn stop_tool_process(&self, tool: &InstalledTool) -> Result<()> {
-        self.tool_kill_service.stop_installed_tool(tool).await
+        self.tool_kill_service.stop_installed_tool(tool, true).await
     }
 
     async fn cleanup_tool_processes(&self, tool: &InstalledTool) {


### PR DESCRIPTION
## Problem

On "old mesh" tenants, mesh agents showed as permanently offline in MeshCentral while the machines were actually healthy:

- the agent logged ServerID entry not found in Db! every cycle and never connected; -nodeid-base64 returned empty/hung, so OpenFrame couldn't map the device.
- the mesh agent never came up;

Root cause. These tenants carried a stale, old-format agent.msh (generated before /generate-msh emitted a ServerID line). The agent imports the .msh into its db on every boot; with no ServerID it bails before opening a socket (agentcore.c), so it never enrolls — and because it bails pre-connect it never logs a connection failure either. The existing recovery paths couldn't fix it, amplified by four weaknesses:

1. Self-heal couldn't see this failure — its trigger watched the agent log for a connection-failure marker that an agent which bails pre-connect never prints, and it only acted on a MeshID change (a stale/missing ServerID with unchanged MeshID was ignored).

2. Reinstall reused stale state — a reinstall:true with no installed_tools record silently fell through to a plain install, and the .msh asset was skipped because the file already existed → the agent kept re-importing the same broken .msh.

3. Force reinstall orphaned the device — it wipes agent.db, and the meshagent then regenerates its node certificate → new NodeID, so the server registers a brand-new node and the old record sticks around offline (the "offline but healthy" duplicates).
  
4. No identity-preserving recovery — every recovery path either couldn't run or rotated the NodeID.

## Fix

Three focused commits on this branch (plus a merge with main and comment cleanup):

- 3a5c016 — self-heal on a missing or changed ServerID, preserving NodeID. Broadened the trigger: a proactive check heals immediately when the on-disk agent.msh has no ServerID line (the case that bails pre-connect), alongside the existing connection-marker path. try_heal now re-fetches /generate-msh and rewrites when MeshID or ServerID changed or is absent (was MeshID-only). The heal is restart-only (refresh .msh → stop tool → start service, never-install/-uninstall), so agent.db and the NodeID are preserved and ServerID is re-imported on boot. (Addresses weaknesses 1 & 4.)

- 8946e33 — reinstall cleans stale state without a registry record and refreshes config assets. A reinstall:true now actually cleans even when there is no installed_tools record (instead of degrading to a plain install over stale files), and TOOL_API config assets (the mesh .msh) are re-fetched on reinstall even when a stale copy exists — so a reinstall always re-provisions from a current server-generated .msh. (Addresses weakness 2.)

- a5437f0 — TEMP: preserve mesh NodeID across reinstall via agent.db backup/restore. Until the meshagent persists its identity across a db wipe, the reinstall path backs up agent.db outside the tool dir (so it survives the wipe) and restores it after -install, then restarts — so the agent reloads its previous SelfNodeCert (same NodeID) and the device is recognized rather than orphaned. Cross-platform; clearly tagged TEMP and reverted when the meshagent fix ships. (Addresses weakness 3 in the interim.)

- 3879cc1 — merge origin/main. Reconciled with main's #1981 mesh self-heal (hourly no-op backoff): kept this branch's ServerID-aware self-heal as the base and folded in main's reset-cooldown-on-healthy and "log the MeshServer target on a no-op" diagnostic.

- 90db3dd, 5865233 — chore: trimmed comments to short constant docs and dropped internal-doc references.

Companion change (separate meshagent repo, ships later). The durable fix for weakness 3 on Windows: agentcore.c reuses the node cert already persisted in the Windows certificate store after a db wipe (instead of regenerating), so a reinstall keeps the NodeID natively. When that lands, the a5437f0 TEMP block is reverted. macOS/Linux (no OS cert store) remain covered by the TEMP measure pending a server-side reconciliation that retires the old node by machine_id.

Task [Old Mesh Agents Across Tenants](https://app.clickup.com/t/86aht6u7u)