### PR TITLE
Add Organization Info to "AI Assistant Welcome Screen"

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.318",
+    "@flamingo-stack/openframe-frontend-core": "0.0.319",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.296",
+    "@flamingo-stack/openframe-frontend-core": "0.0.318",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/clients/openframe-chat/src/components/WelcomeScreen.tsx
+++ b/clients/openframe-chat/src/components/WelcomeScreen.tsx
@@ -1,3 +1,4 @@
+import { MspOrganizationCard } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import {
   BrainAIIcon,
@@ -6,6 +7,9 @@ import {
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button, FeatureList } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import faeAvatar from '../assets/fae-avatar.png';
+import { useAuthenticatedImage } from '../hooks/useAuthenticatedImage';
+import { useTenantInfoQuery } from '../hooks/useTenantInfoQuery';
+import { getFullImageUrl } from '../utils/image-url';
 
 const ICON_COLOR = 'var(--ods-flamingo-pink-base)';
 
@@ -30,11 +34,25 @@ const features = [
   },
 ];
 
+/** Prefix a bare host (e.g. "www.techflow.com") with https so `window.open`
+ *  treats it as an absolute URL rather than a path relative to the app. */
+function toExternalHref(site: string): string {
+  return /^https?:\/\//i.test(site) ? site : `https://${site}`;
+}
+
 interface WelcomeScreenProps {
   onGetStarted: () => void;
 }
 
 export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
+  // Show which organization the user is signing into. Logo bytes sit behind a
+  // Bearer-protected endpoint, so resolve them like the assistant avatar.
+  const { data: tenantInfo } = useTenantInfoQuery({ enabled: true });
+  const rawLogoUrl = tenantInfo?.image ? getFullImageUrl(tenantInfo.image.imageUrl, tenantInfo.image.hash) : undefined;
+  const { url: orgLogoUrl } = useAuthenticatedImage(rawLogoUrl);
+  const orgName = tenantInfo?.name?.trim();
+  const orgWebsite = tenantInfo?.website?.trim();
+
   return (
     <div className="h-screen flex flex-col items-center bg-ods-bg">
       <div className="flex flex-col gap-[var(--spacing-system-lf)] items-center justify-center flex-1 w-full max-w-ods-content-narrow px-[var(--spacing-system-mf)]">
@@ -46,6 +64,18 @@ export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
         </p>
 
         <FeatureList items={features} className="w-full" />
+
+        {orgName ? (
+          <MspOrganizationCard
+            name={orgName}
+            website={orgWebsite || undefined}
+            logoUrl={orgLogoUrl}
+            onOpenWebsite={
+              orgWebsite ? () => window.open(toExternalHref(orgWebsite), '_blank', 'noopener,noreferrer') : undefined
+            }
+            className="w-full"
+          />
+        ) : null}
 
         <Button variant="accent" size="default" onClick={onGetStarted}>
           Get Started

--- a/clients/openframe-chat/src/components/WelcomeScreen.tsx
+++ b/clients/openframe-chat/src/components/WelcomeScreen.tsx
@@ -1,4 +1,7 @@
-import { MspOrganizationCard } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import {
+  MspOrganizationCard,
+  MspOrganizationCardSkeleton,
+} from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import {
   BrainAIIcon,
@@ -47,7 +50,7 @@ interface WelcomeScreenProps {
 export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
   // Show which organization the user is signing into. Logo bytes sit behind a
   // Bearer-protected endpoint, so resolve them like the assistant avatar.
-  const { data: tenantInfo } = useTenantInfoQuery({ enabled: true });
+  const { data: tenantInfo, isLoading } = useTenantInfoQuery({ enabled: true });
   const rawLogoUrl = tenantInfo?.image ? getFullImageUrl(tenantInfo.image.imageUrl, tenantInfo.image.hash) : undefined;
   const { url: orgLogoUrl } = useAuthenticatedImage(rawLogoUrl);
   const orgName = tenantInfo?.name?.trim();
@@ -65,7 +68,9 @@ export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
 
         <FeatureList items={features} className="w-full" />
 
-        {orgName ? (
+        {isLoading ? (
+          <MspOrganizationCardSkeleton className="w-full" />
+        ) : orgName ? (
           <MspOrganizationCard
             name={orgName}
             website={orgWebsite || undefined}

--- a/clients/openframe-chat/src/hooks/useTenantInfoQuery.ts
+++ b/clients/openframe-chat/src/hooks/useTenantInfoQuery.ts
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { type TenantInfo, tenantInfoService } from '../services/tenantInfoService';
+import { tokenService } from '../services/tokenService';
+
+/** Cache key scoped to the active connection so tenant info from a previous
+ *  server/identity is never served after the token or API URL changes. */
+export const tenantInfoQueryKey = (apiBaseUrl: string | null) => ['tenantInfo', { apiBaseUrl }] as const;
+
+interface ConnectionState {
+  isReady: boolean;
+  apiBaseUrl: string | null;
+}
+
+function readConnectionState(): ConnectionState {
+  const token = tokenService.getCurrentToken();
+  const apiBaseUrl = tokenService.getCurrentApiBaseUrl();
+  return { isReady: Boolean(token && apiBaseUrl), apiBaseUrl: apiBaseUrl ?? null };
+}
+
+/**
+ * Loads the current tenant's profile (name, website, logo) from /chat/graphql
+ * for the welcome screen. `data` is `null` when no record exists yet. Waits for
+ * the token/API URL to be available; readiness is recomputed on every token/API
+ * update, and the cache is keyed by the API base URL so a connection change
+ * refetches instead of serving a stale organization.
+ */
+export function useTenantInfoQuery({ enabled }: { enabled: boolean }) {
+  const [connection, setConnection] = useState<ConnectionState>(readConnectionState);
+
+  useEffect(() => {
+    const syncConnection = () => setConnection(readConnectionState());
+
+    syncConnection();
+
+    const unsubToken = tokenService.onTokenUpdate(syncConnection);
+    const unsubUrl = tokenService.onApiUrlUpdate(syncConnection);
+
+    return () => {
+      unsubToken();
+      unsubUrl();
+    };
+  }, []);
+
+  return useQuery<TenantInfo | null>({
+    queryKey: tenantInfoQueryKey(connection.apiBaseUrl),
+    queryFn: () => tenantInfoService.fetchTenantInfo(),
+    enabled: enabled && connection.isReady,
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/clients/openframe-chat/src/services/tenantInfoService.ts
+++ b/clients/openframe-chat/src/services/tenantInfoService.ts
@@ -1,0 +1,81 @@
+import { GraphQLClient, gql, type RequestDocument, type Variables } from 'graphql-request';
+import { tokenService } from './tokenService';
+
+/** Editable tenant (MSP organization) profile shown on the welcome screen. */
+export interface TenantInfo {
+  id: string;
+  name: string | null;
+  website: string | null;
+  image: { imageUrl: string; hash: string | null } | null;
+}
+
+// The welcome screen shows which organization the user is signing into. The
+// tenantInfo query is served by both /api and /chat; the chat client reads it
+// from /chat/graphql like its other GraphQL data.
+const TENANT_INFO_QUERY = gql`
+  query ChatTenantInfo {
+    tenantInfo {
+      id
+      name
+      website
+      image {
+        imageUrl
+        hash
+      }
+    }
+  }
+`;
+
+class TenantInfoService {
+  private graphQlClient: GraphQLClient | null = null;
+  private currentEndpoint: string | null = null;
+
+  private async initializeClient(): Promise<GraphQLClient> {
+    const baseUrl = tokenService.getCurrentApiBaseUrl();
+    const token = tokenService.getCurrentToken();
+
+    if (!baseUrl || !token) {
+      throw new Error('API base URL or token not available');
+    }
+
+    const endpoint = `${baseUrl}/chat/graphql`;
+
+    // Reuse the cached client only while the endpoint is unchanged; a new API
+    // base URL recreates the client so requests never hit a stale server.
+    if (this.graphQlClient && this.currentEndpoint === endpoint) {
+      this.graphQlClient.setHeaders({
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      });
+      return this.graphQlClient;
+    }
+
+    this.graphQlClient = new GraphQLClient(endpoint, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      fetch: fetch,
+    });
+
+    this.currentEndpoint = endpoint;
+    return this.graphQlClient;
+  }
+
+  private async request<T>(document: RequestDocument, variables?: Variables): Promise<T> {
+    const client = await this.initializeClient();
+    return client.request<T>(document, variables);
+  }
+
+  /**
+   * Loads the current authenticated tenant's profile (name, website, logo).
+   * Returns `null` when the tenant has no record. Throws on transport/GraphQL errors.
+   */
+  async fetchTenantInfo(): Promise<TenantInfo | null> {
+    await tokenService.ensureTokenReady();
+    const data = await this.request<{ tenantInfo: TenantInfo | null }>(TENANT_INFO_QUERY);
+    return data.tenantInfo ?? null;
+  }
+}
+
+export const tenantInfoService = new TenantInfoService();

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.314",
+        "@flamingo-stack/openframe-frontend-core": "0.0.318",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.314",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.314.tgz",
-      "integrity": "sha512-xYs0xxlj5QjAOmbgcxw6Lydvdjxz9fInLv8nD9XYE3N4Vxg0e3ed3zLyg9tYMjMDkL6R5hqDMIy8nW7espOycA==",
+      "version": "0.0.318",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.318.tgz",
+      "integrity": "sha512-niZQTkE+pDvZ3sMKTHN6XkhrOBOLtJd8iviU3hrdKZ7SdUo3ZDZyLGajD1R/6+1a7Ti7/gmGxHYi767yazx/CQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.318",
+        "@flamingo-stack/openframe-frontend-core": "0.0.319",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.318",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.318.tgz",
-      "integrity": "sha512-niZQTkE+pDvZ3sMKTHN6XkhrOBOLtJd8iviU3hrdKZ7SdUo3ZDZyLGajD1R/6+1a7Ti7/gmGxHYi767yazx/CQ==",
+      "version": "0.0.319",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.319.tgz",
+      "integrity": "sha512-dFYDs0nmSgkliCRJSJNHRjSXblQ9QSN1wmSIoxYVN+dxIHtccWXeTfkeKlQUmqnOO360xehYUJ7t3HiKPumvWQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.318",
+    "@flamingo-stack/openframe-frontend-core": "0.0.319",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.314",
+    "@flamingo-stack/openframe-frontend-core": "0.0.318",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
@@ -1,15 +1,16 @@
 'use client';
 
+import { MspOrganizationCard } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import {
   ClockCheckIcon,
-  ExternalLinkIcon,
   SignalBroadcast02Icon,
   WrenchScrewdiverIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button, SquareAvatar } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { ComponentType } from 'react';
-import { ChatPreviewLogo } from './chat-preview-logo';
+import { getFullImageUrl } from '@/lib/image-url';
+import { useTenantInfo } from '../../../hooks/use-tenant-info';
 
 interface MeetFaePreviewProps {
   assistantName: string;
@@ -35,6 +36,16 @@ export function MeetFaePreview({
   mspName = 'TechFlow Solutions',
   mspWebsite = 'www.techflow.com',
 }: MeetFaePreviewProps) {
+  // Source the MSP org from the same tenant-info query the /settings card uses
+  // (react-query-cached, so no extra request). Fall back to the sample copy/logo
+  // so the preview still reads well before any org data is configured.
+  const { data: tenantInfo } = useTenantInfo();
+  const orgName = tenantInfo?.name || mspName;
+  const orgWebsite = tenantInfo?.website || mspWebsite;
+  const orgLogoUrl =
+    getFullImageUrl(tenantInfo?.image?.imageUrl, tenantInfo?.image?.hash) ??
+    '/assets/ai-settings/chat-preview-logo.svg';
+
   const features: FeatureRow[] = [
     {
       icon: WrenchScrewdiverIcon,
@@ -96,16 +107,13 @@ export function MeetFaePreview({
             ))}
           </div>
 
-          <div className="flex w-full items-center gap-[var(--spacing-system-m)] rounded-md border border-ods-border bg-ods-bg p-[var(--spacing-system-m)]">
-            <ChatPreviewLogo className="size-12 shrink-0" />
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="truncate text-h3 text-ods-text-primary">Your IT is managed by {mspName}</span>
-              <span className="truncate text-h6 text-ods-text-secondary">{mspWebsite}</span>
-            </div>
-            <Button variant="outline" size="icon" aria-label={`Open ${mspWebsite}`}>
-              <ExternalLinkIcon className="size-6" />
-            </Button>
-          </div>
+          <MspOrganizationCard
+            name={orgName}
+            website={orgWebsite}
+            logoUrl={orgLogoUrl}
+            onOpenWebsite={() => undefined}
+            className="w-full"
+          />
 
           <Button type="button" variant="accent" style={{ backgroundColor: accentColor }}>
             Get Started

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { MspOrganizationCard } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import {
+  MspOrganizationCard,
+  MspOrganizationCardSkeleton,
+} from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { FlamingoLogo } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import {
   ClockCheckIcon,
@@ -39,7 +42,7 @@ export function MeetFaePreview({
   // Source the MSP org from the same tenant-info query the /settings card uses
   // (react-query-cached, so no extra request). Fall back to the sample copy/logo
   // so the preview still reads well before any org data is configured.
-  const { data: tenantInfo } = useTenantInfo();
+  const { data: tenantInfo, isLoading } = useTenantInfo();
   const orgName = tenantInfo?.name || mspName;
   const orgWebsite = tenantInfo?.website || mspWebsite;
   const orgLogoUrl =
@@ -107,13 +110,17 @@ export function MeetFaePreview({
             ))}
           </div>
 
-          <MspOrganizationCard
-            name={orgName}
-            website={orgWebsite}
-            logoUrl={orgLogoUrl}
-            onOpenWebsite={() => undefined}
-            className="w-full"
-          />
+          {isLoading ? (
+            <MspOrganizationCardSkeleton className="w-full" />
+          ) : (
+            <MspOrganizationCard
+              name={orgName}
+              website={orgWebsite}
+              logoUrl={orgLogoUrl}
+              onOpenWebsite={() => undefined}
+              className="w-full"
+            />
+          )}
 
           <Button type="button" variant="accent" style={{ backgroundColor: accentColor }}>
             Get Started


### PR DESCRIPTION
## Add Organization Info to AI Assistant Welcome Screen

Show which organization the user is signing into, so they can confirm
they're in the right place.

- **chat (`WelcomeScreen`)**: add `MspOrganizationCard` between the feature list and Get Started (Figma 1:5516). Real org name/website; logo resolved via `useAuthenticatedImage`; external link opens via `window.open`.
- **chat data**: new `tenantInfoService` + `useTenantInfoQuery` over `/chat/graphql`.
- **frontend (`meet-fae-preview`)**: replace the inline MSP block with the shared `MspOrganizationCard`, sourced from the same `useTenantInfo` query as the /settings card.
- **loading state**: render `MspOrganizationCardSkeleton` while tenant info loads, then the card (chat shows nothing if the tenant has no org).
- **deps**: bump `@flamingo-stack/openframe-frontend-core` → `0.0.319` (ships `MspOrganizationCard` + skeleton).

## Task
[Add Organization Info to AI Assistant Welcome Screen](https://app.clickup.com/t/9013925967/86aj5nft7)
