### PR TITLE
ai-settings: gate overview previews behind the flag

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-overview.tsx
@@ -29,14 +29,17 @@ export function AiSettingsOverview({ aiConfig, view, providerModelLabel, quickAc
       {aiConfig && view && (
         <>
           <AiSettingsCustomerCard aiConfig={aiConfig} view={view} providerModelLabel={providerModelLabel} />
-          <AiSettingsPreviews
-            assistantName={view.assistantName}
-            avatarUrl={getFullImageUrl(view.assistantAvatar?.imageUrl, view.assistantAvatar?.hash)}
-            accentColor={view.accentColor}
-            theme={view.applicationTheme}
-            providerName={aiConfig.llmProvider}
-            modelDisplayName={providerModelLabel ?? aiConfig.providerModel}
-          />
+          {/* Previews are part of the not-yet-released AI customization. */}
+          {featureFlags.customerAiAssistantSettings.enabled() && (
+            <AiSettingsPreviews
+              assistantName={view.assistantName}
+              avatarUrl={getFullImageUrl(view.assistantAvatar?.imageUrl, view.assistantAvatar?.hash)}
+              accentColor={view.accentColor}
+              theme={view.applicationTheme}
+              providerName={aiConfig.llmProvider}
+              modelDisplayName={providerModelLabel ?? aiConfig.providerModel}
+            />
+          )}
         </>
       )}
       {/* Quick actions are part of the not-yet-released AI customization. */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview content in AI settings now appears only when the AI assistant settings feature is enabled.
  * This prevents preview sections from showing in unsupported or inactive configurations while keeping the displayed preview details unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->