### PR TITLE
fix(frontend): bump openframe-frontend-core to 0.0.324

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.323",
+        "@flamingo-stack/openframe-frontend-core": "0.0.324",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.323",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.323.tgz",
-      "integrity": "sha512-fYSvCQ1prLcLGI5uHf1kgm6pbw+xLv4BDewfEhlv3gt7eUXQpH61gY4MMfyKUNd72NuGfTdzc/c//QVCZqwRJQ==",
+      "version": "0.0.324",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.324.tgz",
+      "integrity": "sha512-/pGFutHL8ps6xuhgnAjGT+CLlskCQv2qxqNZgktxx7LZKR1UUyYowXOgrH4+2MJRmXHv0tqQoRUJFJm701Y4pg==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.323",
+    "@flamingo-stack/openframe-frontend-core": "0.0.324",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## What

Bumps `@flamingo-stack/openframe-frontend-core` `0.0.322` → `0.0.324`.

## Why

Pulls in the chat composer fix merged in [openframe-oss-lib#1268](https://github.com/flamingo-stack/openframe-oss-lib/pull/1268):

- **Placeholder no longer shifts** in the embeddable chat when the input is disabled / `sending` — the empty `contentEditable` editor was collapsing to 0px height, so `items-center` re-centered the wrapper and dropped the `top-0` placeholder. Fixed by pinning the editor to a single-line `min-h-9`.
- **Composer focus ring restored** — the context-mode card matched focus via `has-[textarea:focus]`, but the input had migrated from `<textarea>` to a `contentEditable` div, so the accent border never lit up. Now targets `has-[[data-editor]:focus]`.

## Scope

Version bump only (`package.json` + `package-lock.json`). No app code changes.