### PR TITLE
fix(): time tracker start date

### DIFF
--- a/openframe/services/openframe-frontend/src/app/components/manual-entry-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/manual-entry-modal.tsx
@@ -20,10 +20,11 @@ import { useTicketSearchOptions } from '@/app/(app)/tickets/hooks/use-ticket-opt
 import { SimpleModal } from '@/app/components/shared/simple-modal';
 import { createTimeEntryMutation } from '@/graphql/time-tracker/create-time-entry-mutation';
 import {
+  calendarDayToInstant,
   formatDurationLabel,
+  instantToCalendarDay,
   makeCreateTimeEntryUpdater,
   parseDurationLabel,
-  parseInstant,
   toTicketGlobalId,
 } from '@/graphql/time-tracker/time-tracker-helpers';
 import { updateTimeEntryMutation } from '@/graphql/time-tracker/update-time-entry-mutation';
@@ -116,7 +117,7 @@ export function ManualEntryModal({ isOpen, onClose, userId, entry, onSuccess }: 
       entry
         ? {
             workTime: formatDurationLabel(entry.durationSeconds),
-            startedAt: new Date(parseInstant(entry.startedAt)),
+            startedAt: instantToCalendarDay(entry.startedAt),
             ticketId: entry.ticketId ?? null,
             notes: entry.notes ?? '',
           }
@@ -128,7 +129,7 @@ export function ManualEntryModal({ isOpen, onClose, userId, entry, onSuccess }: 
     const durationSeconds = parseDurationLabel(values.workTime) ?? 0;
     const ticketId = toTicketGlobalId(values.ticketId);
     const notes = values.notes.trim() || null;
-    const startedAt = values.startedAt.toISOString();
+    const startedAt = calendarDayToInstant(values.startedAt);
 
     if (entry) {
       updateTimeEntry({

--- a/openframe/services/openframe-frontend/src/graphql/time-tracker/time-tracker-helpers.ts
+++ b/openframe/services/openframe-frontend/src/graphql/time-tracker/time-tracker-helpers.ts
@@ -46,6 +46,24 @@ export function parseInstant(value: unknown): number {
 }
 
 /**
+ * Calendar-day codec for day-granular fields (e.g. a manual time entry's "Date").
+ * A calendar day has no timezone, but the API stores it as an `Instant`, so we
+ * anchor it at UTC midnight: the stored instant's UTC date always equals the
+ * civil day the user picked, regardless of their timezone. Local midnight would
+ * roll back a day in UTC for east-of-UTC offsets and drop the entry out of its
+ * own day's range. The two functions are exact inverses, so prefill → edit →
+ * save round-trips stably in every timezone.
+ */
+export function calendarDayToInstant(date: Date): string {
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())).toISOString();
+}
+
+export function instantToCalendarDay(value: unknown): Date {
+  const inst = new Date(parseInstant(value));
+  return new Date(inst.getUTCFullYear(), inst.getUTCMonth(), inst.getUTCDate());
+}
+
+/**
  * Maps the backend timer to the core lib's display contract. ALL timer math lives here.
  *
  * The backend keeps `durationSeconds` at 0 for the whole active session (it's only
@@ -115,7 +133,7 @@ export function mapTimeEntryToLastEntry(node: TimeEntryNodeShape): TimeTrackerEn
     id: node.id,
     durationLabel: formatDurationLabel(Number(node.durationSeconds)),
     dateLabel: formatDate(parseInstant(node.startedAt)),
-    title: node.ticketTitle ?? (node.ticketNumber != null ? `#${node.ticketNumber}` : 'Manual entry'),
+    title: node.ticketTitle ?? (node.ticketNumber != null ? `#${node.ticketNumber}` : '–'),
     description: node.notes ?? undefined,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual time entry now handles dates using calendar-day conversion, helping keep the selected day consistent when editing and saving entries.

* **Bug Fixes**
  * Fixed date/time handling in the manual entry modal so submitted values match the intended calendar day.
  * Updated the fallback label for entries without a ticket or title to display a cleaner en-dash placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->