### PR TITLE
Settings: show Edit Profile/Organization buttons 

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-tickets-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-tickets-tab.tsx
@@ -101,13 +101,25 @@ export function CustomerTicketsTab({ organizationId }: CustomerTicketsTabProps) 
       <CustomerTabHeader
         title="Tickets"
         rightActions={
-          <Button
-            variant="outline"
-            onClick={() => router.push('/tickets/new')}
-            leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
-          >
-            New Ticket
-          </Button>
+          <>
+            {/* Icon + label on desktop; icon-only on mobile. */}
+            <Button
+              variant="outline"
+              onClick={() => router.push('/tickets/new')}
+              leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
+              className="hidden md:inline-flex"
+            >
+              New Ticket
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => router.push('/tickets/new')}
+              aria-label="New Ticket"
+              leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
+              className="md:hidden"
+            />
+          </>
         }
       />
 

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-tickets-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-tickets-tab.tsx
@@ -13,6 +13,7 @@ import {
 import { useDebounce } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
+import { ResponsiveActionButton } from '@/app/components/shared/responsive-action-button';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import { openInNewTab } from '@/lib/open-in-new-tab';
 import { getTicketTableColumns } from '../../../tickets/components/ticket-table-columns';
@@ -101,25 +102,11 @@ export function CustomerTicketsTab({ organizationId }: CustomerTicketsTabProps) 
       <CustomerTabHeader
         title="Tickets"
         rightActions={
-          <>
-            {/* Icon + label on desktop; icon-only on mobile. */}
-            <Button
-              variant="outline"
-              onClick={() => router.push('/tickets/new')}
-              leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
-              className="hidden md:inline-flex"
-            >
-              New Ticket
-            </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => router.push('/tickets/new')}
-              aria-label="New Ticket"
-              leftIcon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
-              className="md:hidden"
-            />
-          </>
+          <ResponsiveActionButton
+            label="New Ticket"
+            icon={<PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />}
+            onClick={() => router.push('/tickets/new')}
+          />
         }
       />
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/msp-organization-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/msp-organization-card.tsx
@@ -43,13 +43,23 @@ export function MspOrganizationCard({
       </div>
 
       <div className="shrink-0 flex items-center gap-3">
+        {/* Icon + label on desktop; icon-only on mobile (matches the page-action buttons). */}
         <Button
           variant="outline"
           onClick={onEditOrganization}
           leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
+          className="hidden md:inline-flex"
         >
           Edit Organization
         </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onEditOrganization}
+          aria-label="Edit Organization"
+          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
+          className="md:hidden"
+        />
       </div>
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/msp-organization-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/msp-organization-card.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Button, Skeleton } from '@flamingo-stack/openframe-frontend-core';
+import { Skeleton } from '@flamingo-stack/openframe-frontend-core';
 import { PenEditIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { SquareAvatar } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { ResponsiveActionButton } from '@/app/components/shared/responsive-action-button';
 
 interface MspOrganizationCardProps {
   name: string;
@@ -43,22 +44,10 @@ export function MspOrganizationCard({
       </div>
 
       <div className="shrink-0 flex items-center gap-3">
-        {/* Icon + label on desktop; icon-only on mobile (matches the page-action buttons). */}
-        <Button
-          variant="outline"
+        <ResponsiveActionButton
+          label="Edit Organization"
+          icon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
           onClick={onEditOrganization}
-          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
-          className="hidden md:inline-flex"
-        >
-          Edit Organization
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onEditOrganization}
-          aria-label="Edit Organization"
-          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
-          className="md:hidden"
         />
       </div>
     </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
@@ -62,13 +62,23 @@ export function ProfileCard({ onEditProfile, onVerifyEmail }: ProfileCardProps) 
       </div>
 
       <div className="shrink-0 flex items-center gap-3">
+        {/* Icon + label on desktop; icon-only on mobile (matches the page-action buttons). */}
         <Button
           variant="outline"
           onClick={onEditProfile}
           leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
+          className="hidden md:inline-flex"
         >
           Edit Profile
         </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onEditProfile}
+          aria-label="Edit Profile"
+          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
+          className="md:hidden"
+        />
       </div>
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Button, Skeleton, Tag } from '@flamingo-stack/openframe-frontend-core';
+import { Skeleton, Tag } from '@flamingo-stack/openframe-frontend-core';
 import { AlertCircleIcon, PenEditIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { PageError, SquareAvatar } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useAuthStore } from '@/app/(auth)/auth/stores';
+import { ResponsiveActionButton } from '@/app/components/shared/responsive-action-button';
 import { getFullImageUrl } from '@/lib/image-url';
 
 interface ProfileCardProps {
@@ -62,22 +63,10 @@ export function ProfileCard({ onEditProfile, onVerifyEmail }: ProfileCardProps) 
       </div>
 
       <div className="shrink-0 flex items-center gap-3">
-        {/* Icon + label on desktop; icon-only on mobile (matches the page-action buttons). */}
-        <Button
-          variant="outline"
+        <ResponsiveActionButton
+          label="Edit Profile"
+          icon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
           onClick={onEditProfile}
-          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
-          className="hidden md:inline-flex"
-        >
-          Edit Profile
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={onEditProfile}
-          aria-label="Edit Profile"
-          leftIcon={<PenEditIcon className="w-5 h-5 text-ods-text-secondary" />}
-          className="md:hidden"
         />
       </div>
     </div>

--- a/openframe/services/openframe-frontend/src/app/components/shared/responsive-action-button.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/responsive-action-button.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Button } from '@flamingo-stack/openframe-frontend-core';
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+import type { ComponentProps, ReactNode } from 'react';
+
+type ButtonProps = ComponentProps<typeof Button>;
+
+interface ResponsiveActionButtonProps {
+  /** Visible label on desktop; also the aria-label for the icon-only mobile button. */
+  label: string;
+  /** Leading icon, rendered on both breakpoints. */
+  icon: ReactNode;
+  onClick?: ButtonProps['onClick'];
+  variant?: ButtonProps['variant'];
+  disabled?: boolean;
+  /** Extra classes applied to both the desktop and mobile button. */
+  className?: string;
+}
+
+/**
+ * Action button that shows an icon + label on desktop (md+) and collapses to an
+ * icon-only button on mobile. Implemented as two CSS-toggled buttons (`md:`) so
+ * there is no SSR/hydration flash — mirrors the lib's PageActions icon-only
+ * pattern.
+ */
+export function ResponsiveActionButton({
+  label,
+  icon,
+  onClick,
+  variant = 'outline',
+  disabled,
+  className,
+}: ResponsiveActionButtonProps) {
+  return (
+    <>
+      {/* Desktop: icon + label */}
+      <Button
+        variant={variant}
+        onClick={onClick}
+        disabled={disabled}
+        leftIcon={icon}
+        className={cn('hidden md:inline-flex', className)}
+      >
+        {label}
+      </Button>
+      {/* Mobile: icon only */}
+      <Button
+        variant={variant}
+        size="icon"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        leftIcon={icon}
+        className={cn('md:hidden', className)}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
The Edit Profile and Edit Organization buttons kept their full label on small screens. Render them as labeled buttons on desktop (md+) and icon-only (size="icon" + aria-label) on mobile, mirroring the page-action buttons (e.g. "Edit Settings").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared **ResponsiveActionButton** that automatically shows a labeled button on desktop and an icon-only button on mobile (with accessible labels).
* **UI Improvements**
  * Updated settings edit controls to use the responsive button for consistent desktop/mobile behavior.
  * Updated the customer **New Ticket** action to use the same responsive button styling and accessibility.
* **Accessibility**
  * Added/ensured `aria-label` for icon-only actions to improve usability with assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->