### PR TITLE
Dashboard: drop redundant top padding for page components embedded in tabs

### DIFF
--- a/openframe/services/openframe-frontend/CLAUDE.md
+++ b/openframe/services/openframe-frontend/CLAUDE.md
@@ -279,6 +279,26 @@ For regular client components, import directly from the core library.
 - **Feature Components** — AuthProvidersList, Terminal, ToolBadge
 - **Navigation** — AppLayout, sidebar config types
 
+### Embedded Page Components (standalone + tab reuse)
+
+Some page components render their own `PageLayout` and are used **both** as a standalone route
+**and** embedded inside another page's tab (e.g. `LogsTable`, `DevicesPanel` inside customer/device
+details). Core `PageLayout`/`TitleBlock` are **FROZEN** — the `TitleBlock` has a hardcoded leading
+`pt-[var(--spacing-system-l)]` that is correct standalone but leaves a redundant gap under the tab bar
+when embedded.
+
+**Convention:** such a component accepts an `embedded?: boolean` prop. When `embedded`, forward
+`EMBEDDED_PAGE_OFFSET` (a `-mt-[var(--spacing-system-l)]` from `@/app/components/shared`) into its
+`PageLayout` `className` to cancel that top padding. The header stays; only the top gap is removed.
+Callers in tabs just pass `embedded`:
+
+```tsx
+<LogsTable organizationId={organizationId} embedded />
+<DevicesPanel embedded /* ... */ />
+```
+
+Do **not** modify `PageLayout`/`TitleBlock` to fix this — they are frozen.
+
 ## Development Patterns
 
 ### CRITICAL: React Hooks Rules

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
@@ -12,6 +12,7 @@ export function CustomerDevicesTab({ organizationId }: CustomerDevicesTabProps) 
 
   return (
     <DevicesPanel
+      embedded
       addDeviceHref={`/devices/new?organizationId=${organizationId}`}
       lockedFilters={lockedFilters}
       hideColumns={['organization']}

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-logs-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-logs-tab.tsx
@@ -12,5 +12,5 @@ interface CustomerLogsTabProps {
  * SOURCE filter to this organization.
  */
 export function CustomerLogsTab({ organizationId }: CustomerLogsTabProps) {
-  return <LogsTable organizationId={organizationId} />;
+  return <LogsTable organizationId={organizationId} embedded />;
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
@@ -37,9 +37,5 @@ export function LogsTab({ device }: LogsTabProps) {
     );
   }
 
-  return (
-    <div className="mt-6">
-      <LogsTable deviceId={deviceId} ref={logsTableRef} />
-    </div>
-  );
+  return <LogsTable deviceId={deviceId} ref={logsTableRef} embedded />;
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
@@ -44,7 +44,7 @@ import type { logsTableRelay_query$key as LogsFragmentKey } from '@/__generated_
 import type { logsTableRelayPaginationQuery as LogsPaginationQueryType } from '@/__generated__/logsTableRelayPaginationQuery.graphql';
 import type { logsTableRelayQuery as LogsQueryType } from '@/__generated__/logsTableRelayQuery.graphql';
 import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
-import { EmptyState, LogDrawer } from '@/app/components/shared';
+import { EMBEDDED_PAGE_OFFSET, EmptyState, LogDrawer } from '@/app/components/shared';
 import { useSearchParam } from '@/app/hooks/use-search-param';
 import { transformOrganizationFilters } from '@/lib/filter-utils';
 import { formatDateTime } from '@/lib/format-date';
@@ -145,6 +145,8 @@ interface LogsTableProps {
   deviceId?: string;
   /** Lock the table to a single organization. When set, the source/organization column filter is hidden. */
   organizationId?: string;
+  /** Render inside a tab (e.g. customer/device details) — drops the standalone top padding. */
+  embedded?: boolean;
 }
 
 export interface LogsTableRef {
@@ -676,7 +678,7 @@ function LogsTableSkeleton() {
 // ----------------------------------------------------------------
 
 export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsTable(
-  { deviceId, organizationId }: LogsTableProps,
+  { deviceId, organizationId, embedded }: LogsTableProps,
   ref,
 ) {
   const { params, setParam, setParams } = useApiParams({
@@ -762,7 +764,7 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
   );
 
   return (
-    <PageLayout title="Logs" actions={actions}>
+    <PageLayout title="Logs" actions={actions} className={embedded ? EMBEDDED_PAGE_OFFSET : undefined}>
       {/* Search toolbar - outside the Suspense boundary so it keeps focus across
           re-queries, and hidden while the empty state is shown. */}
       {!isEmpty && (

--- a/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
@@ -13,6 +13,7 @@ import {
   type Row,
   TabSelector,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { AlertTriangle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { type ReactNode, useCallback, useEffect, useMemo } from 'react';
@@ -30,6 +31,7 @@ import { useGridInfiniteScroll } from '@/app/(app)/devices/hooks/use-grid-infini
 import { useTagFilterModal } from '@/app/(app)/devices/hooks/use-tag-filter-modal';
 import type { Device, DeviceFilterInput } from '@/app/(app)/devices/types/device.types';
 import { DevicesFilterToolbar } from '../devices-filter-toolbar';
+import { EMBEDDED_PAGE_OFFSET } from '../embedded-page';
 
 export interface DevicesPanelProps {
   /** Page title shown in the PageLayout header. */
@@ -53,6 +55,11 @@ export interface DevicesPanelProps {
    * already provides padding).
    */
   className?: string;
+  /**
+   * Render inside a tab (e.g. customer details) — drops the standalone top padding
+   * via `EMBEDDED_PAGE_OFFSET` so the header sits flush under the tab bar.
+   */
+  embedded?: boolean;
   /**
    * Empty state rendered instead of the toolbar + list when there are
    * no devices and no active search/filters. Pass from the standalone Devices
@@ -82,6 +89,7 @@ export function DevicesPanel({
   hideFilters,
   defaultStatuses,
   className = '',
+  embedded = false,
   emptyState,
   noOrganizations = false,
   isCheckingOrganizations = false,
@@ -227,7 +235,7 @@ export function DevicesPanel({
       <PageLayout
         title={title}
         actionsVariant="icon-buttons"
-        className={className}
+        className={cn(embedded && EMBEDDED_PAGE_OFFSET, className)}
         selector={
           <TabSelector
             value={params.viewMode}

--- a/openframe/services/openframe-frontend/src/app/components/shared/embedded-page.ts
+++ b/openframe/services/openframe-frontend/src/app/components/shared/embedded-page.ts
@@ -1,0 +1,8 @@
+/**
+ * Negative top margin that cancels the frozen TitleBlock's leading
+ * `pt-[var(--spacing-system-l)]`. Apply to a shared page component's PageLayout
+ * `className` when it is embedded inside a tab, so its header sits flush under
+ * the tab bar instead of leaving a redundant top gap. The TitleBlock's bottom
+ * `mb-l` (gap between title and content) is preserved.
+ */
+export const EMBEDDED_PAGE_OFFSET = '-mt-[var(--spacing-system-l)]';

--- a/openframe/services/openframe-frontend/src/app/components/shared/index.ts
+++ b/openframe/services/openframe-frontend/src/app/components/shared/index.ts
@@ -3,6 +3,7 @@ export type { DeviceSelectorProps, InfiniteScrollConfig } from './device-selecto
 export { DeviceSelector } from './device-selector';
 export { DevicesFilterToolbar, type DevicesFilterToolbarProps } from './devices-filter-toolbar';
 export { DevicesPanel, type DevicesPanelProps } from './devices-panel';
+export { EMBEDDED_PAGE_OFFSET } from './embedded-page';
 export { EmptyState, type EmptyStateProps } from './empty-state';
 export { LogDrawer, type LogDrawerInfoField } from './log-drawer';
 export { OrgAvatar } from './org-avatar';


### PR DESCRIPTION
## Description
Some page components (LogsTable, DevicesPanel) render their own PageLayout and are reused both as standalone routes and embedded inside another page's tabs (customer/device details). The frozen core TitleBlock has a hardcoded leading pt-[var(--spacing-system-l)] that is correct standalone but leaves a redundant gap under the tab bar when embedded.

## Improvements
- Add EMBEDDED_PAGE_OFFSET (-mt-[var(--spacing-system-l)]) shared constant that cancels the frozen TitleBlock top padding while preserving the title->content spacing (its mb-l).
- Add an `embedded` prop to LogsTable; forward the offset into PageLayout when set.
- Pass `embedded` from customer-logs-tab and device logs-tab; remove the ad-hoc mt-6 wrapper in the device logs tab that conflicted with the customer version.
- Add an `embedded` prop to DevicesPanel (merged via cn) and pass it from customer-devices-tab.
- Do not touch the frozen core PageLayout/TitleBlock; compensate from callers.
- Document the embedded-page convention in the frontend CLAUDE.md.