### PR TITLE
Device details page: agent order device tab

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
@@ -104,12 +104,8 @@ export function AgentsTab({ device }: AgentsTabProps) {
     }
   });
 
-  // Sort agents to show those with agentToolId first
-  combinedAgents.sort((a, b) => {
-    if (a.agentToolId && !b.agentToolId) return -1;
-    if (!a.agentToolId && b.agentToolId) return 1;
-    return 0;
-  });
+  // Sort agents alphabetically by agentType for a stable, predictable order across reloads.
+  combinedAgents.sort((a, b) => a.agentType.localeCompare(b.agentType));
 
   const hasAgents = combinedAgents.length > 0;
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
@@ -105,7 +105,10 @@ export function AgentsTab({ device }: AgentsTabProps) {
   });
 
   // Sort agents alphabetically by agentType for a stable, predictable order across reloads.
-  combinedAgents.sort((a, b) => a.agentType.localeCompare(b.agentType));
+  // Tie-break on the upstream agentToolId so equal types never reorder by API response order.
+  combinedAgents.sort(
+    (a, b) => a.agentType.localeCompare(b.agentType) || (a.agentToolId ?? '').localeCompare(b.agentToolId ?? ''),
+  );
 
   const hasAgents = combinedAgents.length > 0;
 


### PR DESCRIPTION
## Description
Agent order device tab (sort by agentType)

## Task
[Agent Order Randomly Changes in Device Tab](https://app.clickup.com/t/9013925967/86ahyxxk3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent ordering in the Devices view by sorting consistently alphabetically by agent type.
  * Added a stable tie-break when multiple agents share the same type, using agent tool identifier (when available), reducing unexpected reordering across refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->