### PR TITLE
Mingo AI Chat: surface admin quick actions as chat starter chips

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-chat.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-chat.ts
@@ -250,11 +250,20 @@ export function useMingoChat(dialogId: string | null): UseMingoChat {
       return result.id;
     } catch (error) {
       console.error('[MingoChat] Failed to create dialog:', error);
+      // Surface the failure: callers (quick actions, launcher, draft send) only
+      // get a null id back and otherwise bail silently, so without this a dialog
+      // that can't be created leaves the user with no feedback.
+      toast({
+        title: 'Failed to start conversation',
+        description: error instanceof Error ? error.message : 'Could not create a new chat',
+        variant: 'destructive',
+        duration: 5000,
+      });
       return null;
     } finally {
       setCreatingDialog(false);
     }
-  }, [isCreatingDialog, setCreatingDialog, createDialogMutation, queryClient]);
+  }, [isCreatingDialog, setCreatingDialog, createDialogMutation, queryClient, toast]);
 
   const sendMessage = useCallback(
     async (content: string, targetDialogId?: string, context?: MingoSendContext): Promise<boolean> => {

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-quick-actions.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-quick-actions.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { featureFlags } from '@/lib/feature-flags';
+import { useAdminAiConfig } from '../../settings/ai-settings/hooks/use-agent-ai-config';
+import type { AiQuickAction } from '../../settings/ai-settings/types/ai-settings';
+
+/**
+ * Admin-configured Mingo quick actions, for the chat's empty-state chip row.
+ *
+ * Reads the ADMIN `AgentAiConfig.quickActions` — the same record the AI Settings
+ * "Mingo AI Chat" tab edits — so what an admin saves there shows up as starter
+ * chips in the chat. Gated by the same `mingo-ai-chat-settings` flag that gates
+ * that tab, so the feature toggles together (and the query stays idle when off).
+ */
+export function useMingoQuickActions(): AiQuickAction[] {
+  const enabled = featureFlags.mingoAiChatSettings.enabled();
+  const { config } = useAdminAiConfig({ enabled });
+  return enabled ? (config?.quickActions ?? []) : [];
+}

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -27,7 +27,10 @@
  * Coexists with the old `/mingo` page route during migration.
  */
 
-import type { ChatContextPickerConfig } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import type {
+  ChatContextPickerConfig,
+  MingoQuickAction,
+} from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat';
 import { useLocalStorage } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useEffect, useMemo } from 'react';
@@ -37,6 +40,7 @@ import { MINGO_CONTEXT_ENTITY_TYPES } from '../(app)/mingo/context/context-sourc
 import { CONTEXT_ITEMS_MAX } from '../(app)/mingo/context/context-types';
 import { renderMingoContextItem, renderMingoMention } from '../(app)/mingo/context/mention-chips/render-mention';
 import { renderMingoContextItems } from '../(app)/mingo/context/render-context-items';
+import { useMingoQuickActions } from '../(app)/mingo/hooks/use-mingo-quick-actions';
 import { DialogSubscription } from '../(app)/mingo/hooks/use-mingo-realtime-subscription';
 import { useMingoUnifiedChatState } from '../(app)/mingo/hooks/use-mingo-unified-chat-state';
 import { useMingoLauncherStore } from '../(app)/mingo/stores/mingo-launcher-store';
@@ -104,6 +108,23 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
   // undefined makes the lib's composer inert (no `+`, no `@`, no chips).
   const contextEnabled = featureFlags.mingoSidebarContext.enabled();
 
+  // Admin-configured Mingo quick actions (AI Settings → "Mingo AI Chat" tab)
+  // become starter chips in the empty state. Clicking one opens a new dialog
+  // seeded with the action's instructions — same path the launcher prompt uses.
+  const quickActions = useMingoQuickActions();
+  const mingoQuickActions = useMemo<MingoQuickAction[]>(
+    () =>
+      quickActions.map(action => ({
+        id: action.id,
+        label: action.name,
+        variant: 'outline',
+        onClick: () => {
+          void sendInNewDialog(action.instructions);
+        },
+      })),
+    [quickActions, sendInNewDialog],
+  );
+
   return (
     <>
       {/* Realtime tail for the active dialog — writes chunks into the shared
@@ -163,6 +184,10 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
         // the user left on instead of always snapping back to Mingo.
         activeMode={activeMode}
         onActiveModeChange={setActiveMode}
+        // Admin-configured Mingo quick actions appended as chips after the
+        // built-in "Start Guide Chat" in the Mingo empty state. Omitted when
+        // none are configured so the lib keeps its default welcome content.
+        mingoWelcome={mingoQuickActions.length > 0 ? { quickActions: mingoQuickActions } : undefined}
         // Greeting + try-asking quick-action chips are now per-platform,
         // admin-driven: the lib fetches them from `endpoints.emptyStateUrl`
         // (`/content/api/docs/empty-state`) configured in the runtime provider.


### PR DESCRIPTION
## Description
Mingo AI Chat: surface admin quick actions as chat starter chips

## Improvements
- Add useMingoQuickActions hook reading ADMIN AgentAiConfig.quickActions
- Gate it behind the mingo-ai-chat-settings flag (matches the settings tab)
- Map each action to a MingoWelcome chip; click sends instructions via sendInNewDialog
- Wire into OpenframeEmbeddableChatEntry via EmbeddableChat's mingoWelcome prop

## Task
[Customizable Quick Actions for Mingo](https://app.clickup.com/t/9013925967/86aj06cn5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable quick actions to the Mingo AI Chat experience when the feature is enabled.
  * Chat can now show starter action chips in the empty state, making it easier to begin a conversation with one tap.
  * Selecting a quick action opens a new chat with the chosen prompt prefilled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->