### PR TITLE
feat(frontend): new onboarding page behind new-onboarding flag

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.328-snapshot.20260626183749",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.329",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.328",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.328.tgz",
-      "integrity": "sha512-sVYJGXc4/NIoPfetcRt+bRfD3YQtAllO8u/F70MbWchpPbU+9MuyQg8/BCfDI5t26wwKm73M2XpBF7SsH1Y05A==",
+      "version": "0.0.329",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.329.tgz",
+      "integrity": "sha512-YD2HSOSkiMl2bonEMFweJfdbZrNZAsXChw2k1KNiC+rqgaDhT1KNWYtnM6/ZoO+MbAIGqi7coTr8CJwwcCj2cg==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "0.0.328",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.328-snapshot.20260626183749",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.328",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.328-snapshot.20260626183749",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.328-snapshot.20260626183749",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.329",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/dashboard-content.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/dashboard-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { isSaasTenantMode } from '@/lib/app-mode';
+import { featureFlags } from '@/lib/feature-flags';
 import { CustomersOverviewSection } from './customers-overview';
 import { DevicesOverviewSection } from './devices-overview';
 import { OnboardingSection } from './onboarding-section';
@@ -12,10 +13,13 @@ import { TicketsOverviewSection } from './tickets-overview';
  */
 export default function DashboardContent() {
   const showTickets = isSaasTenantMode();
+  // The legacy onboarding section is replaced by the standalone `/onboarding` page
+  // once the `new-onboarding` flag is on.
+  const showLegacyOnboarding = !featureFlags.newOnboarding.enabled();
 
   return (
     <div className="space-y-10 p-[var(--spacing-system-l)]">
-      <OnboardingSection />
+      {showLegacyOnboarding && <OnboardingSection />}
       <DevicesOverviewSection />
       {showTickets && <TicketsOverviewSection />}
       <CustomersOverviewSection />

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/company-team-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/company-team-step.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import {
+  CheckCircleIcon,
+  ExternalLinkIcon,
+  PlusCircleIcon,
+  TrashIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import Link from 'next/link';
+import { type ChangeEvent, useMemo, useState } from 'react';
+import { useInvitations } from '../../settings/hooks/use-invitations';
+
+type InviteRow = { email: string; role: string };
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ROLE_OPTIONS = [{ value: 'ADMIN', label: 'Admin' }];
+const newRow = (): InviteRow => ({ email: '', role: 'ADMIN' });
+
+/**
+ * Inner body of the "Company & Team" onboarding step. Reuses the team-invite building
+ * blocks from settings ({@link ../../settings/components/add-users-modal}) — the same
+ * row model and the `useInvitations().inviteUsers` mutation.
+ */
+export function CompanyTeamStep() {
+  const { toast } = useToast();
+  const { inviteUsers } = useInvitations();
+
+  const [rows, setRows] = useState<InviteRow[]>([newRow()]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit = useMemo(() => rows.some(r => EMAIL_REGEX.test(r.email.trim())), [rows]);
+
+  const setRow = (idx: number, patch: Partial<InviteRow>) => {
+    setRows(prev => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  };
+  const addRow = () => setRows(prev => [...prev, newRow()]);
+  const removeRow = (idx: number) => setRows(prev => prev.filter((_, i) => i !== idx));
+
+  const handleSendInvites = async () => {
+    const emails = rows.map(r => r.email.trim()).filter(email => EMAIL_REGEX.test(email));
+    if (emails.length === 0) return;
+    setIsSubmitting(true);
+    try {
+      await inviteUsers(emails);
+      toast({ title: 'Invites sent', description: `${emails.length} user(s) invited`, variant: 'success' });
+      setRows([newRow()]);
+    } catch (err) {
+      toast({
+        title: 'Invite failed',
+        description: err instanceof Error ? err.message : 'Failed to send invites',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      <p className="text-h4 text-ods-text-primary">
+        Invite your technicians to OpenFrame. They&apos;ll receive an email with a link to set up their account.
+      </p>
+
+      <div className="flex flex-col gap-[var(--spacing-system-xs)]">
+        {/* Column labels — shown once above the rows */}
+        <div className="grid grid-cols-1 gap-[var(--spacing-system-xs)] md:grid-cols-2">
+          <Label>User Email</Label>
+          <Label className="hidden md:block">Role</Label>
+        </div>
+
+        {rows.map((row, idx) => (
+          <div key={idx} className="grid grid-cols-1 items-center gap-[var(--spacing-system-xs)] md:grid-cols-2">
+            <Input
+              placeholder="Enter Email Here"
+              value={row.email}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setRow(idx, { email: e.target.value })}
+              invalid={row.email.length > 0 && !EMAIL_REGEX.test(row.email)}
+            />
+            <div className="flex items-center gap-[var(--spacing-system-xs)]">
+              <Select value={row.role} onValueChange={v => setRow(idx, { role: v })}>
+                <SelectTrigger className="flex-1">
+                  <SelectValue placeholder="Select role" />
+                </SelectTrigger>
+                <SelectContent>
+                  {ROLE_OPTIONS.map(opt => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {rows.length > 1 && (
+                <Button variant="outline" size="icon" onClick={() => removeRow(idx)} className="shrink-0">
+                  <TrashIcon className="size-5 text-[var(--ods-attention-red-error-action)]" />
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+
+        <Button
+          type="button"
+          variant="outline"
+          size="small"
+          className="self-start"
+          onClick={addRow}
+          leftIcon={<PlusCircleIcon size={24} className="text-ods-text-primary" />}
+        >
+          Add More Users
+        </Button>
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <Link
+          href="/settings/employees"
+          className="flex flex-1 items-center gap-[var(--spacing-system-xs)] text-ods-text-secondary transition-colors hover:text-ods-text-primary"
+        >
+          <ExternalLinkIcon size={24} className="shrink-0" />
+          <span className="text-h4 underline">Manage Roles</span>
+        </Link>
+        <div className="hidden flex-1 md:block" />
+        <Button
+          variant="outline"
+          leftIcon={<CheckCircleIcon className="size-5" />}
+          onClick={() => toast({ title: 'Step marked complete', variant: 'success' })}
+          className="w-full md:flex-1"
+        >
+          Mark as Complete
+        </Button>
+        <Button
+          variant="accent"
+          onClick={handleSendInvites}
+          disabled={!canSubmit || isSubmitting}
+          loading={isSubmitting}
+          className="w-full md:flex-1"
+        >
+          {isSubmitting ? 'Sending...' : 'Send Invites'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/customer-setup-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/customer-setup-step.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { Button, Input } from '@flamingo-stack/openframe-frontend-core';
+import { ExternalLinkIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { ImageUploader } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { uploadWithAuth } from '@/lib/upload-with-auth';
+import { type CreateCustomerRequest, useCreateCustomer } from '../../customers/hooks/use-create-customer';
+import { dashboardQueryKeys } from '../../dashboard/utils/query-keys';
+
+const emptyAddress = { street1: '', street2: '', city: '', state: '', postalCode: '', country: '' };
+
+/**
+ * Inner body of the "Customers Setup" onboarding step. Reuses the customer-page form
+ * building blocks ({@link ../../customers/components/new-customer-page}) — the
+ * `useCreateCustomer` mutation, `Input` and `ImageUploader` — for a quick first-client
+ * form. The full form lives at `/customers/edit/new`.
+ */
+export function CustomerSetupStep() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { createOrganization } = useCreateCustomer();
+
+  const [name, setName] = useState('');
+  const [website, setWebsite] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // The logo is held in memory until the customer exists, then uploaded to it.
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | undefined>();
+  const previewUrlRef = useRef<string | undefined>(undefined);
+
+  useEffect(
+    () => () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    },
+    [],
+  );
+
+  const replacePreview = useCallback((file: File | null) => {
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    if (file) {
+      const next = URL.createObjectURL(file);
+      previewUrlRef.current = next;
+      setPreviewUrl(next);
+    } else {
+      previewUrlRef.current = undefined;
+      setPreviewUrl(undefined);
+    }
+    setPendingFile(file);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!name.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const payload: CreateCustomerRequest = {
+        name: name.trim(),
+        websiteUrl: website.trim() || undefined,
+        contactInformation: {
+          contacts: [],
+          physicalAddress: { ...emptyAddress },
+          mailingAddress: { ...emptyAddress },
+          mailingAddressSameAsPhysical: true,
+        },
+      };
+
+      const response = await createOrganization(payload);
+      const createdId =
+        (response as { organizationId?: string; id?: string } | null)?.organizationId ??
+        (response as { id?: string } | null)?.id ??
+        null;
+
+      if (createdId && pendingFile) {
+        try {
+          await uploadWithAuth(`/api/organizations/${createdId}/image`, pendingFile);
+        } catch {
+          toast({
+            title: 'Warning',
+            description: 'Customer was created but logo upload failed',
+            variant: 'warning',
+          });
+        }
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['organizations'] }),
+        queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.all }),
+      ]);
+
+      toast({ title: 'Customer created', description: `${name.trim()} has been created`, variant: 'success' });
+    } catch (e) {
+      toast({
+        title: 'Save failed',
+        description: e instanceof Error ? e.message : 'Failed to save customer',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [name, website, pendingFile, isSubmitting, createOrganization, queryClient, toast]);
+
+  const saveDisabled = !name.trim() || isSubmitting;
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      <p className="text-h4 text-ods-text-primary">
+        Add your first client profile. Every device must belong to a Customer, so you&apos;ll need at least one to
+        continue.
+      </p>
+
+      {/* Name + Website (left) / Logo (right) */}
+      <div className="flex w-full flex-col items-start gap-[var(--spacing-system-l)] md:flex-row">
+        <div className="flex w-full min-w-0 flex-1 flex-col gap-[var(--spacing-system-l)]">
+          <Input
+            label="Customer Name"
+            placeholder="Customer Name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            disabled={isSubmitting}
+          />
+          <Input
+            label="Website URL"
+            placeholder="https://www.website.com"
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="w-full min-w-0 flex-1 self-stretch">
+          <ImageUploader
+            value={previewUrl}
+            onChange={replacePreview}
+            onRemove={() => replacePreview(null)}
+            objectFit="contain"
+            maxSize={5 * 1024 * 1024}
+            fieldLabel="Customer Logo"
+            label="Upload customer logo"
+            description="Click to upload or drag and drop"
+            alt={name || 'Customer logo'}
+            // Pin height only on desktop, where it aligns with the two-input column on the left.
+            dropzoneClassName="md:h-[148px]"
+          />
+        </div>
+      </div>
+
+      {/* Full form link (left) / mandatory hint + save (right) */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <Link
+          href="/customers/edit/new"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex flex-1 items-center gap-[var(--spacing-system-xs)] text-ods-text-secondary transition-colors hover:text-ods-text-primary"
+        >
+          <ExternalLinkIcon size={24} className="shrink-0" />
+          <span className="text-h4 underline">Full Organization Form</span>
+        </Link>
+
+        {/* On mobile the button comes first (full width) with the hint centered below it;
+            on desktop the hint sits left of the button, matching the design grid. */}
+        <div className="flex flex-1 flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+          <p className="order-2 flex-1 text-center text-[14px] font-medium leading-5 text-ods-text-secondary md:order-1 md:text-right">
+            This step is mandatory
+          </p>
+          <Button
+            variant="accent"
+            onClick={handleSave}
+            disabled={saveDisabled}
+            className="order-1 w-full md:order-2 md:flex-1"
+          >
+            {isSubmitting ? 'Saving...' : 'Save Customer'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/device-setup-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/device-setup-step.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { DotsLoaderIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Autocomplete, type AutocompleteOption } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { DEFAULT_OS_PLATFORM, type OSPlatformId } from '@flamingo-stack/openframe-frontend-core/utils';
+import { useEffect, useMemo, useState } from 'react';
+import { OrgAvatar } from '@/app/components/shared';
+import { OsPlatformSelector } from '@/app/components/shared/os-platform-selector';
+import { useCopyToClipboard } from '@/app/hooks/use-copy-to-clipboard';
+import { AVAILABLE_PLATFORMS, DISABLED_PLATFORMS } from '@/lib/platforms';
+import { useDeviceOrganizations } from '../../devices/hooks/use-device-organizations';
+import { useInstallCommand } from '../../devices/hooks/use-install-command';
+
+/**
+ * Inner body of the "Device Management" onboarding step. Reuses the device-page building
+ * blocks ({@link ../../devices/new/new-device-content}) — the customer `Autocomplete`,
+ * `OsPlatformSelector`, and the `useDeviceOrganizations` / `useInstallCommand` hooks — to
+ * surface the install command. The step completes automatically once the device connects.
+ */
+export function DeviceSetupStep() {
+  const { toast } = useToast();
+  const orgs = useDeviceOrganizations(100);
+
+  const [organizationId, setOrganizationId] = useState('');
+  const [platform, setPlatform] = useState<OSPlatformId>(DEFAULT_OS_PLATFORM);
+
+  // Default the customer to the tenant's default org (then the first one) once loaded.
+  useEffect(() => {
+    if (orgs.length > 0 && !organizationId) {
+      const defaultOrg = orgs.find(o => o.isDefault) ?? orgs[0];
+      if (defaultOrg) setOrganizationId(defaultOrg.organizationId);
+    }
+  }, [orgs, organizationId]);
+
+  const { command, initialKey } = useInstallCommand({ organizationId, platform });
+
+  const orgOptions: AutocompleteOption[] = useMemo(
+    () => orgs.map(o => ({ label: o.name, value: o.organizationId })),
+    [orgs],
+  );
+  const selectedOrg = orgs.find(o => o.organizationId === organizationId);
+
+  const { copy, copied } = useCopyToClipboard({
+    successDescription: 'Installer command copied to clipboard',
+    errorDescription: 'Could not copy command',
+  });
+
+  const handleCopyCommand = () => {
+    if (!organizationId) {
+      toast({ title: 'Validation error', description: 'Please select a customer', variant: 'destructive' });
+      return;
+    }
+    if (!initialKey) {
+      toast({ title: 'Secret unavailable', description: 'Registration secret not loaded yet', variant: 'destructive' });
+      return;
+    }
+    copy(command);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      <p className="text-h4 text-ods-text-primary">
+        Setup and run command on a client machine to install the OpenFrame agent. Once installed, users will get an
+        in-app AI assistant that helps them troubleshoot and resolve issues. The step completes automatically once the
+        device comes online.
+      </p>
+
+      {/* Select Customer / Select Platform */}
+      <div className="grid grid-cols-1 gap-[var(--spacing-system-m)] md:grid-cols-2">
+        <Autocomplete
+          options={orgOptions}
+          value={organizationId || null}
+          onChange={val => setOrganizationId(val ?? '')}
+          label="Select Customer"
+          placeholder="Choose customer"
+          startAdornment={
+            selectedOrg ? (
+              <span className="group-has-[:focus]:hidden">
+                <OrgAvatar imageUrl={selectedOrg.imageUrl} hash={selectedOrg.imageHash} name={selectedOrg.name} />
+              </span>
+            ) : undefined
+          }
+          renderOption={option => {
+            const org = orgs.find(o => o.organizationId === option.value);
+            return (
+              <div className="flex w-full items-center gap-2">
+                <OrgAvatar imageUrl={org?.imageUrl} hash={org?.imageHash} name={org?.name ?? option.label} />
+                <span>{option.label}</span>
+              </div>
+            );
+          }}
+        />
+        <OsPlatformSelector
+          value={platform}
+          onValueChange={setPlatform}
+          label="Select Platform"
+          disabledPlatforms={DISABLED_PLATFORMS}
+          options={AVAILABLE_PLATFORMS.map(p => ({ platformId: p.id }))}
+        />
+      </div>
+
+      {/* OpenFrame Installation Script — click the box to copy */}
+      <div className="flex flex-col gap-[var(--spacing-system-xxs)]">
+        <p className="text-h4 text-ods-text-primary">OpenFrame Installation Script</p>
+        <button
+          type="button"
+          onClick={handleCopyCommand}
+          className="flex w-full flex-col items-start gap-[var(--spacing-system-s)] overflow-hidden rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-m)] text-left transition-colors hover:bg-ods-bg-hover"
+        >
+          <p className="w-full break-all text-h4 text-ods-text-primary">{command}</p>
+          <p className="text-h4 text-ods-text-secondary">
+            {copied ? 'Copied to clipboard' : 'Click on the command to copy'}
+          </p>
+        </button>
+      </div>
+
+      {/* Auto-complete notice (left) / waiting status (right) */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        {/* One line on mobile, broken into two lines from md up. */}
+        <p className="text-h6 text-ods-text-secondary md:flex-1">
+          This step completes automatically <span className="md:block">No action needed here</span>
+        </p>
+        <div className="flex items-center justify-center gap-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] py-[var(--spacing-system-sf)] text-ods-text-secondary md:justify-end">
+          <DotsLoaderIcon size={24} />
+          <span className="whitespace-nowrap text-h4">Waiting for first device</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/knowledge-base-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/knowledge-base-step.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { CheckCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useRouter } from 'next/navigation';
+
+/**
+ * Inner body of the "Knowledge Base" onboarding step — an intro to building docs for the
+ * AI Assistant. "Create Article" opens the knowledge-base editor.
+ */
+export function KnowledgeBaseStep() {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      <p className="text-h4 text-ods-text-primary">
+        Build your own library of docs: setup guides, common fixes, policies, and FAQs. Organize articles into folders,
+        save drafts before publishing, and keep everything structured so your team always finds the right answer fast.
+      </p>
+
+      {/* Footer actions */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <div className="hidden flex-1 md:block" />
+        <Button
+          variant="outline"
+          leftIcon={<CheckCircleIcon className="size-5" />}
+          onClick={() => toast({ title: 'Step marked complete', variant: 'success' })}
+          className="w-full md:flex-1"
+        >
+          Mark as Complete
+        </Button>
+        <Button variant="accent" onClick={() => router.push('/knowledge-base/new')} className="w-full md:flex-1">
+          Create Article
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/mingo-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/mingo-step.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { CheckCircleIcon, ExternalLinkIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import Link from 'next/link';
+import { useMingoLauncherStore } from '@/app/(app)/mingo/stores/mingo-launcher-store';
+import { useMingoMessagesStore } from '@/app/(app)/mingo/stores/mingo-messages-store';
+
+const GUARDRAILS_HREF = '/settings/ai-settings';
+
+const TRY_ASKING = [
+  'What actions can you take?',
+  'Weekly Log Summary',
+  'Device Online Status',
+  'Tech Required Overview',
+];
+
+/**
+ * Inner body of the "Meet Mingo" onboarding step — an informational intro to the Mingo
+ * AI co-pilot. "Start New Chat" opens the in-layout Mingo drawer (same mechanism as
+ * {@link ../../../components/notifications/open-mingo-dialog}); the Guardrails links go to
+ * AI Settings.
+ */
+export function MingoStep() {
+  const { toast } = useToast();
+
+  const startNewChat = () => {
+    // Clear the active dialog so the drawer opens on a fresh chat.
+    useMingoMessagesStore.getState().setActiveDialogId(null);
+    useMingoLauncherStore.getState().setOpen(true);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      {/* Intro + suggestions (left) / demo video (right) */}
+      <div className="flex w-full flex-col items-start gap-[var(--spacing-system-l)] md:flex-row">
+        <div className="flex min-w-0 flex-1 flex-col gap-[var(--spacing-system-l)]">
+          <p className="text-h4 text-ods-text-primary">
+            Mingo knows your entire OpenFrame workspace - devices, tickets, Customers, team. Mingo can both answer and
+            act. What it&apos;s allowed to do on its own is controlled by your{' '}
+            <Link href={GUARDRAILS_HREF} className="text-ods-accent underline">
+              Guardrail Settings
+            </Link>
+            .
+          </p>
+
+          <div className="flex flex-col gap-[var(--spacing-system-xxs)]">
+            <p className="text-h5 text-ods-text-secondary">Try asking:</p>
+            <div className="flex flex-wrap items-center gap-[var(--spacing-system-xxs)]">
+              {TRY_ASKING.map(prompt => (
+                <span
+                  key={prompt}
+                  className="flex h-8 items-center justify-center rounded-md border border-ods-border bg-ods-card px-[var(--spacing-system-xsf)] text-h5 text-ods-text-primary"
+                >
+                  {prompt}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex aspect-[976/558] w-full flex-1 items-center justify-center rounded-md border border-ods-text-secondary bg-ods-border">
+          <span className="font-mono text-h2 text-ods-text-secondary">DEMO VIDEO</span>
+        </div>
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <Link
+          href={GUARDRAILS_HREF}
+          className="flex flex-1 items-center gap-[var(--spacing-system-xs)] text-ods-text-secondary transition-colors hover:text-ods-text-primary"
+        >
+          <ExternalLinkIcon size={24} className="shrink-0" />
+          <span className="text-h4 underline">Configure Guardrails</span>
+        </Link>
+        <div className="hidden flex-1 md:block" />
+        <Button
+          variant="outline"
+          leftIcon={<CheckCircleIcon className="size-5" />}
+          onClick={() => toast({ title: 'Step marked complete', variant: 'success' })}
+          className="w-full md:flex-1"
+        >
+          Mark as Complete
+        </Button>
+        <Button variant="accent" onClick={startNewChat} className="w-full md:flex-1">
+          Start New Chat
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/msp-setup-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/msp-setup-step.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Button, Input, Label } from '@flamingo-stack/openframe-frontend-core';
+import { CheckCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { ImageUploader } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import { getFullImageUrl } from '@/lib/image-url';
+import { deleteWithAuth, uploadWithAuth } from '@/lib/upload-with-auth';
+import {
+  TENANT_IMAGE_ENDPOINT,
+  tenantInfoQueryKeys,
+  useTenantInfo,
+  useUpdateTenantInfo,
+} from '../../settings/hooks/use-tenant-info';
+import type { TenantImage } from '../../settings/types/tenant-info';
+
+/**
+ * Inner body of the "Complete MSP Setup" onboarding step. Reuses the same tenant-info
+ * data layer and core components as the settings "Edit Organization" form
+ * ({@link ../../settings/components/edit-organization-modal}) so both stay in sync.
+ */
+export function MspSetupStep() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { data: tenantInfo } = useTenantInfo();
+  const updateTenantInfo = useUpdateTenantInfo();
+
+  const [name, setName] = useState('');
+  const [website, setWebsite] = useState('');
+  const [imageUrl, setImageUrl] = useState<string | undefined>();
+  const [imageHash, setImageHash] = useState<string | undefined>();
+  const [isImageBusy, setIsImageBusy] = useState(false);
+
+  useEffect(() => {
+    if (!tenantInfo) return;
+    setName(tenantInfo.name ?? '');
+    setWebsite(tenantInfo.website ?? '');
+    setImageUrl(tenantInfo.image?.imageUrl ?? undefined);
+    setImageHash(tenantInfo.image?.hash ?? undefined);
+  }, [tenantInfo]);
+
+  const handleImageChange = useCallback(
+    async (file: File) => {
+      setIsImageBusy(true);
+      try {
+        const uploadedUrl = await uploadWithAuth(TENANT_IMAGE_ENDPOINT, file);
+        const bust = String(Date.now());
+        setImageUrl(uploadedUrl);
+        setImageHash(bust);
+        queryClient.setQueryData(tenantInfoQueryKeys.all, (prev: { image?: TenantImage | null } | null | undefined) =>
+          prev ? { ...prev, image: { imageUrl: uploadedUrl, hash: bust } } : prev,
+        );
+        toast({ title: 'Upload successful', description: 'Organization logo has been updated', variant: 'success' });
+      } catch (err) {
+        toast({
+          title: 'Upload failed',
+          description: err instanceof Error ? err.message : 'Failed to upload image',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsImageBusy(false);
+      }
+    },
+    [toast, queryClient],
+  );
+
+  const handleImageRemove = useCallback(async () => {
+    setIsImageBusy(true);
+    try {
+      await deleteWithAuth(TENANT_IMAGE_ENDPOINT);
+      setImageUrl(undefined);
+      setImageHash(undefined);
+      queryClient.setQueryData(tenantInfoQueryKeys.all, (prev: { image?: TenantImage | null } | null | undefined) =>
+        prev ? { ...prev, image: null } : prev,
+      );
+      toast({ title: 'Delete successful', description: 'Organization logo has been removed', variant: 'success' });
+    } catch (err) {
+      toast({
+        title: 'Delete failed',
+        description: err instanceof Error ? err.message : 'Failed to remove image',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsImageBusy(false);
+    }
+  }, [toast, queryClient]);
+
+  const handleSave = useCallback(() => {
+    updateTenantInfo.mutate({ name, website });
+  }, [name, website, updateTenantInfo]);
+
+  const displayImageUrl = getFullImageUrl(imageUrl, imageHash);
+  const isSaving = updateTenantInfo.isPending;
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      {/* Name + Website (left) / Logo (right) */}
+      <div className="flex w-full flex-col items-start gap-[var(--spacing-system-l)] md:flex-row">
+        <div className="flex w-full min-w-0 flex-1 flex-col gap-[var(--spacing-system-l)]">
+          <Input
+            id="msp-org-name"
+            label="Organization Name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            disabled={isSaving}
+            placeholder="Organization name"
+          />
+          <Input
+            id="msp-org-website"
+            label="Organization Website"
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+            disabled={isSaving}
+            placeholder="www.example.com"
+          />
+        </div>
+
+        <div className="w-full min-w-0 flex-1 self-stretch">
+          <ImageUploader
+            fieldLabel="Organization Logo"
+            value={displayImageUrl}
+            onChange={handleImageChange}
+            onRemove={handleImageRemove}
+            loading={isImageBusy}
+            objectFit="cover"
+            maxSize={5 * 1024 * 1024}
+            label="Upload organization logo"
+            description="Click to upload or drag and drop"
+            alt={name || 'Organization logo'}
+            // Pin height only on desktop, where it aligns with the two-input column on the
+            // left. On mobile the columns stack, so let the dropzone use its natural height.
+            dropzoneClassName="md:h-[148px]"
+          />
+        </div>
+      </div>
+
+      {/* Mark as Complete + Save — aligned to the right, matching the design grid */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <div className="hidden flex-1 md:block" />
+        <div className="hidden flex-1 md:block" />
+        <Button
+          variant="outline"
+          leftIcon={<CheckCircleIcon className="size-5" />}
+          onClick={() => toast({ title: 'Step marked complete', variant: 'success' })}
+          className="w-full md:flex-1"
+        >
+          Mark as Complete
+        </Button>
+        <Button variant="accent" onClick={handleSave} disabled={isSaving} className="w-full md:flex-1">
+          {isSaving ? 'Saving...' : 'Save Organization'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-accordion.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-accordion.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { CheckCircleIcon, Chevron02DownIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+import React from 'react';
+
+/**
+ * Visual status of an onboarding step.
+ * - `active`    — interactive step, can be expanded/collapsed (uses its own icon)
+ * - `completed` — finished step, shows a green check + "Complete" tag, still expandable
+ * - `disabled`  — locked step, muted styling, not interactive, shows a requirement hint
+ */
+export type OnboardingStepStatus = 'active' | 'completed' | 'disabled';
+
+export interface OnboardingAccordionItemProps {
+  /** Leading icon, expected at 24x24 (e.g. <IdCardIcon size={24} />). Overridden by a green check when completed. */
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  /** @default 'active' */
+  status?: OnboardingStepStatus;
+  /** Right-aligned hint shown for `disabled` steps (e.g. "Added Customer required"). */
+  requirementHint?: string;
+  /** Whether the step starts expanded. Ignored for `disabled`. @default false */
+  defaultExpanded?: boolean;
+  /** Expanded body. Not implemented yet — the step body is wired up later. */
+  children?: React.ReactNode;
+}
+
+/**
+ * A single onboarding accordion row. Renders the header (icon, title, description and
+ * trailing control) and, when expanded, the step body. The inner body content is
+ * intentionally left to the caller — it is wired up in a later iteration.
+ *
+ * Spacing uses the `--spacing-system-*` design tokens; expand/collapse animates via a
+ * `grid-rows` 0fr→1fr transition so it works for content of any height.
+ */
+export function OnboardingAccordionItem({
+  icon,
+  title,
+  description,
+  status = 'active',
+  requirementHint,
+  defaultExpanded = false,
+  children,
+}: OnboardingAccordionItemProps) {
+  const isDisabled = status === 'disabled';
+  const isCompleted = status === 'completed';
+  const [expanded, setExpanded] = React.useState(!isDisabled && defaultExpanded);
+
+  const toggle = React.useCallback(() => {
+    if (!isDisabled) setExpanded(prev => !prev);
+  }, [isDisabled]);
+
+  return (
+    <div
+      className={cn(
+        'w-full border-b border-ods-border transition-colors duration-200 ease-out motion-reduce:transition-none',
+        expanded ? 'bg-ods-bg' : 'bg-ods-card',
+      )}
+    >
+      {/* Header is not interactive — only the chevron button toggles the step. */}
+      <div className="flex w-full items-center gap-[var(--spacing-system-s)] p-[var(--spacing-system-m)] text-left">
+        {/* Icon box — matches the chevron Button's `size="icon"` footprint (44px → 48px). */}
+        <div
+          className={cn(
+            'flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-ods-border md:h-12 md:w-12',
+            '[&_svg]:size-4 md:[&_svg]:size-6',
+            isDisabled ? 'bg-ods-card' : 'bg-ods-bg',
+            // The leading step icon stays grey in every state (active/closed/open/disabled);
+            // only the completed state swaps it for the green success check.
+            isCompleted ? 'text-ods-success' : 'text-ods-text-secondary',
+          )}
+        >
+          {isCompleted ? <CheckCircleIcon /> : icon}
+        </div>
+
+        {/* Title + description */}
+        <div className="flex min-w-0 flex-1 flex-col justify-center">
+          <p className={cn('text-h3 font-bold', isDisabled ? 'text-ods-border' : 'text-ods-text-primary')}>{title}</p>
+          <p
+            className={cn(
+              'text-[14px] font-medium leading-5',
+              isDisabled ? 'text-ods-border' : 'text-ods-text-secondary',
+            )}
+          >
+            {description}
+          </p>
+        </div>
+
+        {/* Trailing: requirement hint (disabled) / complete tag + chevron / chevron */}
+        {isDisabled ? (
+          requirementHint ? (
+            <p className="shrink-0 whitespace-nowrap text-right text-[14px] font-medium leading-5 text-ods-text-secondary">
+              {requirementHint}
+            </p>
+          ) : null
+        ) : (
+          <div className="flex shrink-0 items-center gap-[var(--spacing-system-s)]">
+            {isCompleted ? (
+              <span className="flex h-8 items-center justify-center rounded-md bg-ods-success-secondary px-[var(--spacing-system-xsf)] text-h5 text-ods-success">
+                Complete
+              </span>
+            ) : null}
+            <Button
+              variant="outline"
+              size="icon"
+              type="button"
+              onClick={toggle}
+              aria-expanded={expanded}
+              aria-label={expanded ? `Collapse ${title}` : `Expand ${title}`}
+            >
+              <Chevron02DownIcon
+                className={cn(
+                  'transition-transform duration-300 ease-out motion-reduce:transition-none',
+                  expanded && 'rotate-180',
+                )}
+              />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Step body, animated via grid-rows 0fr→1fr. Not mounted for disabled steps, so a
+          locked step never runs its form's data hooks. */}
+      {!isDisabled && (
+        <div
+          className={cn(
+            'grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none',
+            expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="px-[var(--spacing-system-m)] pb-[var(--spacing-system-xl)]">{children}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface OnboardingAccordionGroupProps {
+  /** Optional uppercase section label rendered above the group. */
+  label?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Groups one or more {@link OnboardingAccordionItem}s inside a bordered, rounded
+ * container with dividers between rows. Use `label` for a section heading.
+ */
+export function OnboardingAccordionGroup({ label, children, className }: OnboardingAccordionGroupProps) {
+  return (
+    <div className={cn('flex w-full flex-col gap-[var(--spacing-system-xxs)]', className)}>
+      {label ? <p className="text-h5 text-ods-text-secondary">{label}</p> : null}
+      <div className="flex w-full flex-col overflow-hidden rounded-md border border-ods-border [&>*:last-child]:border-b-0">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-content.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-content.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { MingoIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
+import {
+  BookBookmarkIcon,
+  BuildingsIcon,
+  IdCardIcon,
+  MonitorIcon,
+  TagIcon,
+  UsersGroupIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { ConfirmDialog } from '@/app/components/shared/confirm-dialog';
+import { CompanyTeamStep } from './company-team-step';
+import { CustomerSetupStep } from './customer-setup-step';
+import { DeviceSetupStep } from './device-setup-step';
+import { KnowledgeBaseStep } from './knowledge-base-step';
+import { MingoStep } from './mingo-step';
+import { MspSetupStep } from './msp-setup-step';
+import { OnboardingAccordionGroup, OnboardingAccordionItem } from './onboarding-accordion';
+import { TicketsStep } from './tickets-step';
+
+export function OnboardingContent() {
+  const router = useRouter();
+
+  // Step dependencies: a device can only be added once a customer exists, and
+  // tickets only unlock once a device is connected. Wired to local state for now —
+  // swap for real onboarding-completion data when the step bodies are implemented.
+  // TODO: temporarily unlocked for development — revert to `false` (or real data) later.
+  const hasCustomer = true;
+  const hasDevice = true;
+
+  // Once every step is finished, the header action turns into a primary "Close
+  // Onboarding" button; until then it's the outline "Skip Onboarding" escape hatch.
+  // TODO: wire to real onboarding-completion data when step tracking lands.
+  const allStepsCompleted = false;
+
+  // Skipping is destructive (leaves setup unfinished), so it asks for confirmation
+  // first. Closing a fully-completed onboarding doesn't — there's nothing to lose.
+  const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
+
+  const leaveOnboarding = () => router.push('/dashboard');
+  const headerAction = allStepsCompleted
+    ? { label: 'Close Onboarding', variant: 'accent' as const, onClick: leaveOnboarding }
+    : { label: 'Skip Onboarding', variant: 'outline' as const, onClick: () => setSkipConfirmOpen(true) };
+
+  return (
+    <PageLayout
+      title="Get Started"
+      subtitle="7 steps to complete"
+      actions={[headerAction]}
+      // Desktop: header action button. Mobile: collapses into a "…" menu.
+      actionsVariant="menu-primary"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
+      contentClassName="flex flex-col gap-[var(--spacing-system-l)]"
+    >
+      {/* Complete MSP Setup — standalone step */}
+      <div className="flex w-full flex-col overflow-hidden rounded-md border border-ods-border [&>*:last-child]:border-b-0">
+        <OnboardingAccordionItem
+          icon={<BuildingsIcon size={24} />}
+          title="Complete MSP Setup"
+          description="Set your company name, upload a logo, and add your website so clients recognize your brand across all touchpoints."
+        >
+          <MspSetupStep />
+        </OnboardingAccordionItem>
+      </div>
+
+      {/* Device Management */}
+      <OnboardingAccordionGroup label="Device Management">
+        <OnboardingAccordionItem
+          icon={<IdCardIcon size={24} />}
+          title="Customers Setup"
+          description="Add your first client - Customer name, service tier, and SLA. Devices need an org to belong to."
+        >
+          <CustomerSetupStep />
+        </OnboardingAccordionItem>
+        <OnboardingAccordionItem
+          icon={<MonitorIcon size={24} />}
+          status={hasCustomer ? 'active' : 'disabled'}
+          title="Device Management"
+          description="Run one command on a client machine to connect it to OpenFrame and start monitoring."
+          requirementHint="Added Customer required"
+        >
+          <DeviceSetupStep />
+        </OnboardingAccordionItem>
+      </OnboardingAccordionGroup>
+
+      {/* AI Experience */}
+      <OnboardingAccordionGroup label="AI Experience">
+        <OnboardingAccordionItem
+          icon={<TagIcon size={24} />}
+          status={hasDevice ? 'active' : 'disabled'}
+          title="Tickets"
+          description="Every client chat is a ticket. AI Assistant resolves them automatically - or your team steps in when needed."
+          requirementHint="A connected device is required"
+        >
+          <TicketsStep />
+        </OnboardingAccordionItem>
+        <OnboardingAccordionItem
+          icon={
+            <MingoIcon
+              className="size-6"
+              color="var(--color-text-secondary)"
+              eyesColor="var(--ods-flamingo-cyan-base)"
+              cornerColor="var(--ods-flamingo-cyan-base)"
+            />
+          }
+          title="Meet Mingo"
+          description="Your AI co-pilot for the OpenFrame workspace. Ask questions, get summaries, or delegate tasks."
+        >
+          <MingoStep />
+        </OnboardingAccordionItem>
+      </OnboardingAccordionGroup>
+
+      {/* Additional Setup */}
+      <OnboardingAccordionGroup label="Additional Setup">
+        <OnboardingAccordionItem
+          icon={<UsersGroupIcon size={24} />}
+          title="Company & Team"
+          description="Invite your technicians and assign roles so everyone has the right access from day one."
+        >
+          <CompanyTeamStep />
+        </OnboardingAccordionItem>
+        <OnboardingAccordionItem
+          icon={<BookBookmarkIcon size={24} />}
+          title="Knowledge Base"
+          description="Build your own docs that AI Assistant will use to answer client questions."
+        >
+          <KnowledgeBaseStep />
+        </OnboardingAccordionItem>
+      </OnboardingAccordionGroup>
+
+      {/* Skip confirmation — leaving onboarding early is reversible from Settings. */}
+      <ConfirmDialog
+        open={skipConfirmOpen}
+        onOpenChange={setSkipConfirmOpen}
+        title="Skip onboarding"
+        description="You can finish setup later from Settings."
+        confirmLabel="Skip Onboarding"
+        cancelLabel="Cancel"
+        variant="destructive"
+        onConfirm={leaveOnboarding}
+      />
+    </PageLayout>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/onboarding-skeleton.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+
+/**
+ * Loading skeleton for the onboarding page. Mirrors {@link ./onboarding-content} exactly:
+ * the `PageLayout` header (title + subtitle + Skip action) followed by the standalone MSP
+ * card and the three accordion groups (7 rows total = "7 steps to complete").
+ *
+ * Used as the `<Suspense>` fallback in {@link ../page} because the always-mounted
+ * `DeviceSetupStep` runs `useDeviceOrganizations` (a `useSuspenseQuery`), which suspends the
+ * page on first load — this renders the page shape instead of a blank screen meanwhile.
+ */
+
+/** A single collapsed accordion row: icon box + title/description + chevron button. */
+function RowSkeleton() {
+  return (
+    <div className="flex w-full items-center gap-[var(--spacing-system-s)] border-b border-ods-border bg-ods-card p-[var(--spacing-system-m)]">
+      {/* Leading icon box — matches the 44px → 48px footprint. */}
+      <Skeleton className="h-11 w-11 shrink-0 rounded-md md:h-12 md:w-12" />
+      {/* Title + description */}
+      <div className="flex min-w-0 flex-1 flex-col gap-[var(--spacing-system-xs)]">
+        <Skeleton className="h-5 w-40 max-w-full" />
+        <Skeleton className="h-4 w-3/4 max-w-full" />
+      </div>
+      {/* Trailing chevron button */}
+      <Skeleton className="h-11 w-11 shrink-0 rounded-md md:h-12 md:w-12" />
+    </div>
+  );
+}
+
+/** A bordered group container (matches `OnboardingAccordionGroup`'s rounded box). */
+function GroupBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-full flex-col overflow-hidden rounded-md border border-ods-border [&>*:last-child]:border-b-0">
+      {children}
+    </div>
+  );
+}
+
+/** A labelled accordion group: section label + box of rows. */
+function GroupSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-xxs)]">
+      {/* Section label (text-h5) */}
+      <Skeleton className="h-4 w-36" />
+      <GroupBox>
+        {Array.from({ length: rows }).map((_, i) => (
+          <RowSkeleton key={i} />
+        ))}
+      </GroupBox>
+    </div>
+  );
+}
+
+export function OnboardingSkeleton() {
+  return (
+    <div
+      className={cn('flex w-full flex-col px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]')}
+      role="status"
+      aria-label="Loading onboarding"
+    >
+      {/* Header — mirrors PageLayout's TitleBlock (title + subtitle on the left, Skip action right) */}
+      <div className="mb-[var(--spacing-system-l)] flex items-end justify-between gap-[var(--spacing-system-m)] pt-[var(--spacing-system-l)] md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex min-h-11 min-w-0 flex-1 flex-col justify-center gap-[var(--spacing-system-xs)] md:min-h-12">
+          <Skeleton className="h-8 w-44" /> {/* "Get Started" — text-h2 */}
+          <Skeleton className="h-5 w-32" /> {/* "7 steps to complete" — text-h6 */}
+        </div>
+        {/* Skip Onboarding — "…" menu button on mobile, labelled button on desktop */}
+        <Skeleton className="h-11 w-11 shrink-0 rounded-md md:h-12 md:w-[160px]" />
+      </div>
+
+      {/* Content — matches the standalone MSP card + 3 accordion groups (7 rows total) */}
+      <div className="flex flex-col gap-[var(--spacing-system-l)]">
+        {/* Complete MSP Setup — standalone */}
+        <GroupBox>
+          <RowSkeleton />
+        </GroupBox>
+
+        {/* Device Management / AI Experience / Additional Setup — 2 rows each */}
+        <GroupSkeleton rows={2} />
+        <GroupSkeleton rows={2} />
+        <GroupSkeleton rows={2} />
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/tickets-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/tickets-step.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import {
+  ChatsIcon,
+  CheckCircleIcon,
+  ComputerMouseIcon,
+  TagIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Autocomplete, type AutocompleteOption, Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useMemo, useState } from 'react';
+import { useDevices } from '../../devices/hooks/use-devices';
+
+/** Icon + title + description row, shared by the numbered steps. */
+function StepRow({ icon, title, description }: { icon: ReactNode; title: string; description: string }) {
+  return (
+    <div className="flex w-full items-start gap-[var(--spacing-system-m)]">
+      <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-ods-border bg-ods-bg text-ods-text-secondary [&_svg]:size-4 md:h-12 md:w-12 md:[&_svg]:size-6">
+        {icon}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <p className="text-h3 font-bold text-ods-text-primary">{title}</p>
+        <p className="text-h4 text-ods-text-primary">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+/** Uppercase section label + content, e.g. "STEP 1". */
+function LabeledBlock({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-xxs)]">
+      <p className="text-h5 text-ods-text-secondary">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+const INSIDE_TICKET_POINTS = [
+  'Set a title and description to document the issue clearly.',
+  'Assign it to a specific technician on your team.',
+  'Attach files, add tags to categorize by issue type or client.',
+  'Leave internal notes visible only to your team - not the client.',
+  'Take over the chat directly. Assistant goes silent and you talk to the client one-on-one.',
+];
+
+/**
+ * Inner body of the "Tickets" onboarding step — an informational walkthrough. The Step 1
+ * device picker reuses the devices list ({@link ../../devices/hooks/use-devices}) and links
+ * into the device's remote shell; the footer links to the Tickets section.
+ */
+export function TicketsStep() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const { devices } = useDevices();
+
+  const [deviceId, setDeviceId] = useState('');
+
+  const deviceOptions: AutocompleteOption[] = useMemo(
+    () => devices.map(d => ({ label: d.displayName || d.hostname || d.machineId, value: d.machineId })),
+    [devices],
+  );
+
+  const connectToDevice = () => {
+    if (!deviceId) {
+      toast({ title: 'Select a device', description: 'Choose a device to connect to', variant: 'destructive' });
+      return;
+    }
+    router.push(`/devices/details/${deviceId}/remote-shell`);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+      {/* Intro (left) / demo video (right) */}
+      <div className="flex w-full flex-col items-start gap-[var(--spacing-system-l)] md:flex-row">
+        <p className="flex-1 text-h4 text-ods-text-primary">
+          Every conversation AI Assistant handles is logged as a ticket. Your team can review what happened, add
+          context, and step in whenever needed.
+        </p>
+        <div className="flex aspect-[976/558] w-full flex-1 items-center justify-center rounded-md border border-ods-text-secondary bg-ods-border">
+          <span className="font-mono text-h2 text-ods-text-secondary">DEMO VIDEO</span>
+        </div>
+      </div>
+
+      {/* Steps */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-l)]">
+        <LabeledBlock label="Step 1">
+          <div className="flex w-full flex-col overflow-hidden rounded-md border border-ods-border bg-ods-card [&>*]:border-b [&>*]:border-ods-border [&>*:last-child]:border-b-0">
+            <div className="p-[var(--spacing-system-m)]">
+              <StepRow
+                icon={<ComputerMouseIcon size={24} />}
+                title="Connect Remotely to Device"
+                description="Use remote access tool to open a session on the device you just connected to your Customer."
+              />
+            </div>
+            <div className="flex flex-col items-stretch gap-[var(--spacing-system-m)] p-[var(--spacing-system-m)] md:flex-row md:items-end">
+              <div className="min-w-0 flex-1">
+                <Autocomplete
+                  options={deviceOptions}
+                  value={deviceId || null}
+                  onChange={val => setDeviceId(val ?? '')}
+                  label="Select Device for Remote Connection"
+                  placeholder="Choose device"
+                />
+              </div>
+              <Button variant="outline" onClick={connectToDevice} className="w-full md:w-auto">
+                Connect to Device
+              </Button>
+            </div>
+          </div>
+        </LabeledBlock>
+
+        <LabeledBlock label="Step 2">
+          <div className="w-full rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-m)]">
+            <StepRow
+              icon={<ChatsIcon size={24} />}
+              title="Send a Message to Assistant"
+              description={'Open OpenFrame and write something like: "Check for software updates".'}
+            />
+          </div>
+        </LabeledBlock>
+
+        <LabeledBlock label="Step 3">
+          <div className="w-full rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-m)]">
+            <StepRow
+              icon={<TagIcon size={24} />}
+              title="Go to Tickets Section"
+              description="You will see a new ticket, the assistant chat history, and all ticket details."
+            />
+          </div>
+        </LabeledBlock>
+      </div>
+
+      {/* Inside a ticket */}
+      <LabeledBlock label="Inside a ticket">
+        <div className="flex w-full flex-col gap-[var(--spacing-system-xs)] rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-m)]">
+          <p className="text-h4 text-ods-text-primary">
+            Once a ticket is open, your team can add context and take action:
+          </p>
+          <ul className="flex w-full flex-col">
+            {INSIDE_TICKET_POINTS.map(point => (
+              <li key={point} className="flex items-start gap-[var(--spacing-system-xs)]">
+                <span className="flex size-6 shrink-0 items-center justify-center">
+                  <span className="size-1.5 rounded-full bg-ods-accent" />
+                </span>
+                <span className="flex-1 text-h4 text-ods-text-primary">{point}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </LabeledBlock>
+
+      {/* Footer actions */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+        <div className="hidden flex-1 md:block" />
+        <div className="hidden flex-1 md:block" />
+        <Button
+          variant="outline"
+          leftIcon={<CheckCircleIcon className="size-5" />}
+          onClick={() => toast({ title: 'Step marked complete', variant: 'success' })}
+          className="w-full md:flex-1"
+        >
+          Mark as Complete
+        </Button>
+        <Button variant="accent" onClick={() => router.push('/tickets')} className="w-full md:flex-1">
+          Go to Tickets
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { featureFlags } from '@/lib/feature-flags';
+import { OnboardingContent } from './components/onboarding-content';
+import { OnboardingSkeleton } from './components/onboarding-skeleton';
+
+export default function OnboardingPage() {
+  // Gated behind the `new-onboarding` flag — when off, the legacy dashboard
+  // onboarding section is shown instead and this route does not exist.
+  if (!featureFlags.newOnboarding.enabled()) {
+    notFound();
+  }
+
+  return (
+    <Suspense fallback={<OnboardingSkeleton />}>
+      <OnboardingContent />
+    </Suspense>
+  );
+}
+
+export const dynamic = 'force-dynamic';

--- a/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/app-layout.tsx
@@ -6,7 +6,6 @@ import {
   AppLayoutDrawerContent,
   AppLayout as CoreAppLayout,
 } from '@flamingo-stack/openframe-frontend-core/components/navigation';
-import { CompactPageLoader } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { NavigationSidebarConfig } from '@flamingo-stack/openframe-frontend-core/types/navigation';
 import { usePathname, useRouter } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
@@ -28,10 +27,6 @@ import { SubscriptionLockContent } from './subscription-lock/subscription-lock-c
 import { useSubscriptionLock } from './subscription-lock/subscription-lock-context';
 import { TimeTrackerHostProvider } from './time-tracker-host-provider';
 import { UnauthorizedOverlay } from './unauthorized-overlay';
-
-function ContentLoading() {
-  return <CompactPageLoader />;
-}
 
 function AppShell({ children, mainClassName }: { children: React.ReactNode; mainClassName?: string }) {
   const router = useRouter();
@@ -224,7 +219,7 @@ function AppShell({ children, mainClassName }: { children: React.ReactNode; main
         <CoreAppLayout
           mainClassName={mainClassName ?? 'pb-20 md:pb-20'}
           sidebarConfig={sidebarConfig}
-          loadingFallback={<ContentLoading />}
+          loadingFallback={null}
           mobileBurgerMenuProps={mobileBurgerMenuProps}
           headerProps={headerProps}
           disabled={showLockContent}

--- a/openframe/services/openframe-frontend/src/app/components/shared/confirm-dialog.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/confirm-dialog.tsx
@@ -1,16 +1,23 @@
 'use client';
 
 import { Loading01Icon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  Button,
+  ModalV2,
+  ModalV2Footer,
+  ModalV2Header,
+  ModalV2Title,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import type { ReactNode } from 'react';
-import { SimpleModal } from './simple-modal';
 
 /**
  * ConfirmDialog — shared confirmation dialog for destructive and reversible
- * actions. Built on top of `SimpleModal` so it shares the responsive layout
- * (centered desktop / bottom-anchored mobile) with every other modal in the
- * app. Adds three confirm-button variants, pending state, and an
- * `extraContent` slot for small accompanying bits (CommandBox, picker, etc.).
+ * actions. Built directly on the `ModalV2*` primitives so it shares the
+ * responsive layout (centered desktop / bottom-anchored mobile) with every
+ * other modal in the app. Buttons are the core `Button` component. Adds three
+ * confirm-button variants, pending state, and an `extraContent` slot for small
+ * accompanying bits (CommandBox, picker, etc.).
  *
  * Parent owns the `open` state. The dialog does NOT auto-close on confirm —
  * the parent decides when to flip `open` to false (typically after the
@@ -33,17 +40,18 @@ interface ConfirmDialogProps {
   extraContent?: ReactNode;
 }
 
-const CANCEL_BUTTON =
-  'flex-1 bg-ods-card border border-ods-border text-ods-text-primary text-h3 px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)] rounded-[6px] hover:bg-ods-bg-surface disabled:opacity-50 disabled:pointer-events-none';
-
-const CONFIRM_BUTTON_BASE =
-  'flex-1 text-h3 px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)] rounded-[6px] inline-flex items-center justify-center gap-[var(--spacing-system-xsf)] disabled:opacity-50 disabled:pointer-events-none';
-
-const CONFIRM_BUTTON_VARIANT = {
-  destructive: 'bg-ods-error text-ods-bg hover:bg-ods-error/90',
-  warning: 'bg-ods-warning text-ods-bg hover:bg-ods-warning/90',
-  default: 'bg-ods-accent text-ods-text-on-accent hover:bg-ods-accent/90',
-} as const;
+/**
+ * Maps the dialog's intent to a core `Button` variant. `warning` has no
+ * first-class Button variant, so it rides on `accent` with a token override.
+ */
+const CONFIRM_VARIANT: Record<
+  NonNullable<ConfirmDialogProps['variant']>,
+  { variant: 'accent' | 'destructive'; className?: string }
+> = {
+  destructive: { variant: 'destructive' },
+  warning: { variant: 'accent', className: 'bg-ods-warning text-ods-bg hover:bg-ods-warning/90' },
+  default: { variant: 'accent' },
+};
 
 export function ConfirmDialog({
   open,
@@ -60,32 +68,31 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const confirmText = isPending && pendingLabel ? pendingLabel : confirmLabel;
   const handleClose = () => onOpenChange(false);
+  const confirm = CONFIRM_VARIANT[variant];
 
   return (
-    <SimpleModal
-      isOpen={open}
-      onClose={handleClose}
-      className="md:max-w-[600px] text-left"
-      title={title}
-      footer={
-        <>
-          <button type="button" onClick={handleClose} disabled={isPending} className={CANCEL_BUTTON}>
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={isPending}
-            className={cn(CONFIRM_BUTTON_BASE, CONFIRM_BUTTON_VARIANT[variant])}
-          >
-            {isPending && <Loading01Icon size={20} className="animate-spin" />}
-            {confirmText}
-          </button>
-        </>
-      }
-    >
+    <ModalV2 isOpen={open} onClose={handleClose} className="text-left md:max-w-[600px]">
+      <ModalV2Header>
+        <ModalV2Title>{title}</ModalV2Title>
+      </ModalV2Header>
+
       <p className="text-h4 text-ods-text-primary">{description}</p>
       {extraContent}
-    </SimpleModal>
+
+      <ModalV2Footer>
+        <Button variant="outline" onClick={handleClose} disabled={isPending} className="flex-1">
+          {cancelLabel}
+        </Button>
+        <Button
+          variant={confirm.variant}
+          onClick={onConfirm}
+          disabled={isPending}
+          leftIcon={isPending ? <Loading01Icon size={20} className="animate-spin" /> : undefined}
+          className={cn('flex-1', confirm.className)}
+        >
+          {confirmText}
+        </Button>
+      </ModalV2Footer>
+    </ModalV2>
   );
 }

--- a/openframe/services/openframe-frontend/src/lib/feature-flags.ts
+++ b/openframe/services/openframe-frontend/src/lib/feature-flags.ts
@@ -17,6 +17,7 @@ export const FEATURE_FLAG_NAMES = [
   'time-tracker',
   'scripts-v2',
   'cancel-subscription',
+  'new-onboarding',
 ] as const;
 
 /**
@@ -95,6 +96,16 @@ export const featureFlags = {
   cancelSubscription: {
     enabled(): boolean {
       return getFlagValue('cancel-subscription', () => false);
+    },
+  },
+  /**
+   * New `/onboarding` page. When enabled, the standalone onboarding route is shown
+   * and the legacy dashboard `OnboardingSection` is hidden; when disabled it's the
+   * reverse (legacy section on the dashboard, `/onboarding` 404s).
+   */
+  newOnboarding: {
+    enabled(): boolean {
+      return getFlagValue('new-onboarding', () => false);
     },
   },
 } as const;


### PR DESCRIPTION
## What

Adds a standalone **`/onboarding`** ("Get Started") page and gates it behind a new
`new-onboarding` feature flag.

The page is a 7-step accordion that reuses existing building blocks from settings,
customers and devices:

1. **Complete MSP Setup** — tenant name / website / logo (settings tenant-info layer)
2. **Customers Setup** — create first customer
3. **Device Management** — install command + customer/platform picker
4. **Tickets** — walkthrough
5. **Meet Mingo** — intro + launch chat
6. **Company & Team** — invite teammates
7. **Knowledge Base** — intro + create article

## Feature flag

Both onboardings are gated by the same `new-onboarding` flag (inversely):

| `new-onboarding` | New `/onboarding` page | Legacy dashboard `OnboardingSection` |
|---|---|---|
| **on** | shown | hidden |
| **off** | 404 | shown |

## Also in this PR

- **Skip Onboarding** now asks for confirmation (`ConfirmDialog`) before leaving.
- **`ConfirmDialog` refactor** — dropped the `SimpleModal` wrapper, built directly on
  `ModalV2*` primitives, buttons now use the core `Button`. Public API unchanged, so all
  ~20 existing usages keep working.
- **Removed** the global brand-logo content loader from `AppLayout` (route transitions no
  longer flash the logo).
- **Route-level Suspense skeleton** for the onboarding page (the device step's
  `useSuspenseQuery` for organizations otherwise blanks the page on first load).
- Bumps `@flamingo-stack/openframe-frontend-core` to the snapshot that ships the
  `dropzoneClassName` prop used by the MSP step's logo uploader.

## Notes

- Onboarding completion is still wired to placeholder constants (`hasCustomer`,
  `hasDevice`, `allStepsCompleted`); the backend contract for real tracking is designed
  but not part of this PR.
- `.env.local` changes were intentionally **not** included (local dev config).

## Test plan

- `npm run type-check` ✅
- `npm run lint:biome` ✅ (pre-commit)
- Flag off → dashboard shows legacy onboarding, `/onboarding` 404s.
- Flag on → dashboard hides legacy onboarding, `/onboarding` renders the 7-step accordion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned onboarding experience with guided steps for setup, customers, devices, tickets, team invitations, knowledge base, and assistant onboarding.
  * Introduced a loading skeleton for the onboarding page and a cleaner confirmation dialog experience.
  * Added onboarding actions like invite sending, customer setup, device install command copy, and quick links to related areas.

* **Bug Fixes**
  * The legacy in-dashboard onboarding section is now hidden when the new onboarding flow is enabled.
  * The onboarding page is unavailable unless the new experience is turned on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->