### PR TITLE
Docs: import canonical ODS token rules from core lib + bump core to 0.0.333

### DIFF
--- a/clients/openframe-chat/CLAUDE.md
+++ b/clients/openframe-chat/CLAUDE.md
@@ -49,9 +49,13 @@ import '@flamingo-stack/openframe-frontend-core/styles'
 
 If a needed component is missing from the core library, raise it in the core lib repo. Don't fork it into the chat client.
 
-### 2. ODS design tokens only — no hardcoded colors or font sizes
+### 2. ODS design tokens only — no hardcoded colors, font sizes, or spacing
 
-Same token system as the rest of the Flamingo stack. Use `bg-ods-card`, `text-ods-text-primary`, `border-ods-border`, `bg-ods-accent`, `text-ods-error`, etc. Never use `bg-gray-800`, raw hex, or `text-[14px]`.
+Same token system as the rest of the Flamingo stack. The full canonical ODS token rules are the
+**single source of truth** maintained in `@flamingo-stack/openframe-frontend-core` and imported here
+from the installed package. Edit the rules in the core lib, not here:
+
+@./node_modules/@flamingo-stack/openframe-frontend-core/src/ODS_TOKEN_RULES.md
 
 ### 3. React hooks at the top, unconditionally
 

--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.319",
+    "@flamingo-stack/openframe-frontend-core": "0.0.333",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/CLAUDE.md
+++ b/openframe/services/openframe-frontend/CLAUDE.md
@@ -743,31 +743,16 @@ export interface UnifiedUser {
 5. **Focus Management** — Handle focus in modals and dynamic content
 
 ### ODS Design Tokens (MANDATORY)
-```typescript
-// GOOD: Using ODS tokens
-<Card className="bg-ods-card border-ods-border">
-  <div className="text-ods-text-primary">Primary text</div>
-  <div className="text-ods-text-secondary">Secondary text</div>
-</Card>
 
-// BAD: Hardcoded values
-<Card className="bg-gray-800 border-gray-700">
-  <div className="text-white">Primary text</div>
-</Card>
-```
+ALL styling must use ODS design tokens — never hardcode colors, font families, font sizes, or spacing.
 
-**Key tokens:**
-```css
---ods-attention-green-success: #5ea62e
---ods-attention-red-error: #f36666
---color-warning: #f59e0b
---ods-card: #212121
---ods-border: #3a3a3a
---ods-text-primary: #fafafa
---ods-text-secondary: #888888
-```
+The full canonical ODS token rules (colors, spacing, typography, Figma workflow) are the **single
+source of truth** maintained in `@flamingo-stack/openframe-frontend-core` and imported here straight
+from the installed package. Edit the rules in the core lib, not here:
 
-**Tailwind preset:** ODS colors are provided via the core library's Tailwind preset (see `tailwind.config.ts`).
+@./node_modules/@flamingo-stack/openframe-frontend-core/src/ODS_TOKEN_RULES.md
+
+**Tailwind preset:** ODS colors/utilities are provided via the core library's Tailwind preset (see `tailwind.config.ts`).
 
 ### Inverted Progress Bar
 ```typescript

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.329",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.333",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.329",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.329.tgz",
-      "integrity": "sha512-YD2HSOSkiMl2bonEMFweJfdbZrNZAsXChw2k1KNiC+rqgaDhT1KNWYtnM6/ZoO+MbAIGqi7coTr8CJwwcCj2cg==",
+      "version": "0.0.333",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.333.tgz",
+      "integrity": "sha512-JySEFhi1ZQfCXZWG/f+K1xLGdKMiPG3o9DOX+ytVzH0uXd8iBDaGlrgEcPMCLUMdKgDiwEszaa9rDp+UArTdwA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.329",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.333",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Description

"Frontend" (tenant) and "chat" now @import the single-source-of-truth ODS_TOKEN_RULES.md from @flamingo-stack/openframe-frontend-core (bumped to 0.0.333) instead of maintaining their own inline ODS token rules. Removes stale hardcoded hex values and keeps the rules in sync via the package.