### PR TITLE
Frontend: Settings email-verification warning banner

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.333",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.334",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.333",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.333.tgz",
-      "integrity": "sha512-JySEFhi1ZQfCXZWG/f+K1xLGdKMiPG3o9DOX+ytVzH0uXd8iBDaGlrgEcPMCLUMdKgDiwEszaa9rDp+UArTdwA==",
+      "version": "0.0.334",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.334.tgz",
+      "integrity": "sha512-5RiwoPh9/eeLrWI6RI3fXIiK4JlG9h32x1h+DORgtCxfuXNYtwAfH3MbsrSgtxiLI4qqiQd56SiWwje9xZMNiA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.333",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.334",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/email-verification-banner.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/email-verification-banner.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { AlertTriangleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Alert } from '@flamingo-stack/openframe-frontend-core/components/ui';
+
+interface EmailVerificationBannerProps {
+  onResend: () => void;
+}
+
+export function EmailVerificationBanner({ onResend }: EmailVerificationBannerProps) {
+  return (
+    <Alert variant="warning" className="flex items-start gap-[var(--spacing-system-m)] p-[var(--spacing-system-s)]">
+      <span className="shrink-0">
+        <AlertTriangleIcon size={24} />
+      </span>
+      <div className="flex flex-1 flex-col gap-[var(--spacing-system-s)] sm:flex-row sm:items-center sm:gap-[var(--spacing-system-m)]">
+        <p className="flex-1 text-h4 font-bold">Verify your email to keep access to system.</p>
+        <button
+          type="button"
+          onClick={onResend}
+          className="shrink-0 self-start whitespace-nowrap text-h4 font-medium underline transition-opacity hover:opacity-80 sm:self-auto"
+        >
+          Resend Verification Mail
+        </button>
+      </div>
+    </Alert>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
@@ -24,6 +24,7 @@ import { featureFlags } from '@/lib/feature-flags';
 import { handleApiError } from '@/lib/handle-api-error';
 import { AccountSettingsCard } from './account-settings-card';
 import { EditProfileModal } from './edit-profile-modal';
+import { EmailVerificationBanner } from './email-verification-banner';
 import { EmailVerificationModal } from './email-verification-modal';
 import { SettingMenuItem } from './setting-menu-item';
 
@@ -145,11 +146,15 @@ export function SettingsHub() {
       className="min-h-full px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
       contentClassName="gap-[var(--spacing-system-l)] lg:gap-[var(--spacing-system-xl)]"
     >
-      {/* Organization + Profile */}
-      <AccountSettingsCard
-        onEditProfile={() => setIsEditModalOpen(true)}
-        onVerifyEmail={() => setIsVerificationModalOpen(true)}
-      />
+      <div className="flex flex-col gap-[var(--spacing-system-l)]">
+        {/* Organization + Profile */}
+        <AccountSettingsCard
+          onEditProfile={() => setIsEditModalOpen(true)}
+          onVerifyEmail={() => setIsVerificationModalOpen(true)}
+        />
+
+        {user?.emailVerified === false && <EmailVerificationBanner onResend={() => setIsVerificationModalOpen(true)} />}
+      </div>
 
       {/* Navigation Cards Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-[var(--spacing-system-m)]">


### PR DESCRIPTION
## Description
- Add a warning Alert banner to the Settings page, shown when the signed-in user's email is unverified. Its "Resend Verification Mail" action opens the existing EmailVerificationModal. 
- Grouped with the account card under the page title per Figma; 
- Responsive icon/message/action layout for desktop and mobile. 
- Bumps @flamingo-stack/openframe-frontend-core to 0.0.334 (Alert warning variant).

## Task
[Settings — Email Verification Status](https://app.clickup.com/t/9013925967/86aj7w2xp)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an email verification reminder banner in Settings for accounts that haven’t verified their email yet.
  * Included a “Resend Verification Mail” action directly in the banner for quicker access.

* **Bug Fixes**
  * Improved the Settings layout so the verification message appears alongside account details in the right place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->