### PR TITLE
Refactor: migrate app pages to PageLayout wrapper

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
@@ -37,5 +37,12 @@ export function LogsTab({ device }: LogsTabProps) {
     );
   }
 
-  return <LogsTable deviceId={deviceId} ref={logsTableRef} embedded />;
+  // `embedded` cancels the PageLayout TitleBlock's leading pt (so it doesn't
+  // double up); the `mt-6` wrapper then supplies the same top gap the sibling
+  // tabs use, keeping the "Logs" header from sitting flush against the tab bar.
+  return (
+    <div className="mt-6">
+      <LogsTable deviceId={deviceId} ref={logsTableRef} embedded />
+    </div>
+  );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/components/file-manager-container.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/components/file-manager-container.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, DetailPageContainer, Progress } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Button, PageLayout, Progress } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { FileAction, FileItem } from '@flamingo-stack/openframe-frontend-core/components/ui/file-manager';
 import { FileManager, FileManagerSkeleton } from '@flamingo-stack/openframe-frontend-core/components/ui/file-manager';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -272,7 +272,7 @@ export function FileManagerContainer({ deviceId, meshcentralAgentId, hostname, c
   }, [deleteContext, deleteItems, closeDeleteModal]);
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title={'File Manager'}
       subtitle={hostname || `Device ${deviceId}`}
       className={className ? `${className} h-full` : 'h-full'}
@@ -281,7 +281,6 @@ export function FileManagerContainer({ deviceId, meshcentralAgentId, hostname, c
         label: 'Back',
         onClick: handleBackToDevice,
       }}
-      padding="none"
     >
       <div className="flex flex-col flex-1 min-h-0">
         {showFileManagerSkeleton ? (
@@ -405,6 +404,6 @@ export function FileManagerContainer({ deviceId, meshcentralAgentId, hostname, c
         onClose={closeDeleteModal}
         onConfirm={handleDeleteConfirmed}
       />
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { Button, PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { FileManagerSkeleton } from '@flamingo-stack/openframe-frontend-core/components/ui/file-manager';
 import { use } from 'react';
 import { FileManagerContainer } from '@/app/(app)/devices/details/[deviceId]/file-manager/components/file-manager-container';
@@ -8,7 +8,9 @@ import { useDeviceDetails } from '@/app/(app)/devices/hooks/use-device-details';
 import { getMeshCentralAgentId } from '@/app/(app)/devices/utils/device-action-utils';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 
-const PAGE_PADDING = 'pt-4 px-4 md:pt-6 md:px-6';
+// Horizontal padding only — `PageLayout`'s `TitleBlock` already supplies the
+// top padding (`pt-[var(--spacing-system-l)]` = 16/24px, matching the former pt-4/md:pt-6).
+const PAGE_PADDING = 'px-4 md:px-6';
 
 interface FileManagerPageProps {
   params: Promise<{
@@ -31,12 +33,11 @@ export default function FileManagerPage({ params }: FileManagerPageProps) {
 
   if (error) {
     return (
-      <DetailPageContainer
+      <PageLayout
         title="File Manager"
         className={`${PAGE_PADDING} h-full`}
         contentClassName="flex flex-col min-h-0 overflow-hidden"
         backButton={{ label: 'Back', onClick: handleBack }}
-        padding="none"
       >
         <div className="flex-1 flex flex-col items-center justify-center gap-4">
           <div className="text-ods-attention-red-error text-lg">Error: {error}</div>
@@ -44,18 +45,17 @@ export default function FileManagerPage({ params }: FileManagerPageProps) {
             Return to Device Details
           </Button>
         </div>
-      </DetailPageContainer>
+      </PageLayout>
     );
   }
 
   if (!meshcentralAgentId) {
     return (
-      <DetailPageContainer
+      <PageLayout
         title="File Manager"
         className={`${PAGE_PADDING} h-full`}
         contentClassName="flex flex-col min-h-0 overflow-hidden"
         backButton={{ label: 'Back', onClick: handleBack }}
-        padding="none"
       >
         <div className="flex-1 flex flex-col items-center justify-center gap-4">
           <div className="text-ods-attention-red-error text-lg">
@@ -66,7 +66,7 @@ export default function FileManagerPage({ params }: FileManagerPageProps) {
             Return to Device Details
           </Button>
         </div>
-      </DetailPageContainer>
+      </PageLayout>
     );
   }
 
@@ -88,7 +88,7 @@ interface FileManagerPageSkeletonProps {
 
 function FileManagerPageSkeleton({ onBack }: FileManagerPageSkeletonProps) {
   return (
-    <DetailPageContainer
+    <PageLayout
       title="File Manager"
       className={`${PAGE_PADDING} h-full`}
       contentClassName="flex flex-col min-h-0 overflow-hidden"
@@ -96,11 +96,10 @@ function FileManagerPageSkeleton({ onBack }: FileManagerPageSkeletonProps) {
         label: 'Back',
         onClick: onBack,
       }}
-      padding="none"
     >
       <div className="flex flex-col flex-1 min-h-0">
         <FileManagerSkeleton />
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-shell/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-shell/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { Button, PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { TerminalSquare } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
@@ -284,9 +284,9 @@ export default function RemoteShellPage({ params }: RemoteShellPageProps) {
   }
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title="Remote Shell"
-      className="p-4 md:p-6 h-full"
+      className="px-4 md:px-6 pb-4 md:pb-6 h-full"
       contentClassName="flex flex-col"
       backButton={{
         label: 'Back',
@@ -330,6 +330,6 @@ export default function RemoteShellPage({ params }: RemoteShellPageProps) {
           <div ref={containerRef} className="w-full h-full p-2" />
         </div>
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/new/new-device-content.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/new/new-device-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { CommandBox } from '@flamingo-stack/openframe-frontend-core/components/features';
 import { CheckIcon, Copy02Icon, PlayIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import type { AutocompleteOption } from '@flamingo-stack/openframe-frontend-core/components/ui';
@@ -202,11 +202,10 @@ export function NewDeviceContent() {
   }, [command, platform, toast, validateBeforeAction]);
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title="New Device"
       backButton={{ label: 'Back', onClick: handleBack }}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex flex-col gap-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -284,6 +283,6 @@ export function NewDeviceContent() {
         <AntivirusWarning platform={platform} />
         <DoctorModeWarning platform={platform} />
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/new/new-device-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/new/new-device-skeleton.tsx
@@ -1,9 +1,9 @@
-import { DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 
 export function NewDeviceSkeleton() {
   return (
-    <DetailPageContainer padding="none" className="p-[var(--spacing-system-l)]">
+    <PageLayout className="p-[var(--spacing-system-l)]">
       <div className="flex flex-col gap-6">
         <Skeleton className="h-5 w-40" />
 
@@ -44,6 +44,6 @@ export function NewDeviceSkeleton() {
           <Skeleton className="h-5 w-full max-w-xl" />
         </div>
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/log-details/components/log-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/log-details/components/log-details-skeleton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DetailPageContainer, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { PageLayout, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { DeviceInfoSectionSkeleton } from '@/app/components/shared/device-info-section-skeleton';
 
 interface LogDetailsSkeletonProps {
@@ -116,12 +116,11 @@ function DetailsSkeleton() {
 
 export function LogDetailsSkeleton({ onBack }: LogDetailsSkeletonProps) {
   return (
-    <DetailPageContainer
+    <PageLayout
       title="Log Details"
       backButton={{ label: 'Back', onClick: onBack }}
-      headerActions={<Skeleton className="h-12 w-[180px] rounded-[6px] hidden md:block" />}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      selector={<Skeleton className="h-12 w-[180px] rounded-[6px]" />}
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex flex-col gap-6 w-full">
         <StatusTimestampSkeleton />
@@ -130,6 +129,6 @@ export function LogDetailsSkeleton({ onBack }: LogDetailsSkeletonProps) {
         <FullInformationSkeleton />
         <DetailsSkeleton />
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/log-details/components/log-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/log-details/components/log-details-view.tsx
@@ -2,7 +2,7 @@
 
 import { ToolBadge } from '@flamingo-stack/openframe-frontend-core/components';
 import { CheckIcon, Copy02Icon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { Button, DetailPageContainer, Tag } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Button, PageLayout, Tag } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { normalizeToolTypeWithFallback } from '@flamingo-stack/openframe-frontend-core/utils';
 import { ChevronLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -92,7 +92,7 @@ export function LogDetailsView({ logId, ingestDay, toolType, eventType, timestam
   }
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title="Log Details"
       backButton={{
         label: 'Back',
@@ -110,8 +110,7 @@ export function LogDetailsView({ logId, ingestDay, toolType, eventType, timestam
           ),
         },
       ]}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex flex-col gap-6 w-full">
         {/* Status and Timestamp */}
@@ -149,6 +148,6 @@ export function LogDetailsView({ logId, ingestDay, toolType, eventType, timestam
         {/* Details Section */}
         <DetailsSection logDetails={logDetails} />
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
@@ -8,8 +8,8 @@ import {
   ChatInput,
   ChatMessageList,
   ChatSidebar,
-  ContentPageContainer,
   ModelDisplay,
+  PageLayout,
   Skeleton,
 } from '@flamingo-stack/openframe-frontend-core';
 import { MingoIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
@@ -360,7 +360,7 @@ export default function Mingo() {
   }
 
   return (
-    <ContentPageContainer padding="none" showHeader={false} className="h-full" contentClassName="h-full flex flex-col">
+    <PageLayout showHeader={false} className="h-full" contentClassName="h-full flex flex-col">
       {activeDialogId && subscribedDialogs.has(activeDialogId) && (
         <DialogSubscription
           key={activeDialogId}
@@ -473,6 +473,6 @@ export default function Mingo() {
           </div>
         </div>
       </div>
-    </ContentPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/edit-policy-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/edit-policy-page.tsx
@@ -2,11 +2,11 @@
 
 import {
   CardLoader,
-  FormPageContainer,
   Input,
   Label,
   LoadError,
   NotFoundError,
+  PageLayout,
   Textarea,
 } from '@flamingo-stack/openframe-frontend-core';
 import { InfoCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
@@ -224,15 +224,15 @@ export function EditPolicyPage({ policyId }: EditPolicyPageProps) {
   }
 
   return (
-    <FormPageContainer
+    <PageLayout
       title={isExistingPolicy && policyDetails ? policyDetails.name : 'New Policy'}
       backButton={{
         label: 'Back',
         onClick: handleBack,
       }}
       actions={actions}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="space-y-6 md:space-y-8">
         {/* Test Policy Panel */}
@@ -313,6 +313,6 @@ export function EditPolicyPage({ policyId }: EditPolicyPageProps) {
           />
         </div>
       </div>
-    </FormPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/policy-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/components/policy-details-view.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import {
-  Button,
+  type ActionsMenuGroup,
   CardLoader,
-  DetailPageContainer,
   LoadError,
-  MoreActionsMenu,
   NotFoundError,
+  type PageActionButton,
+  PageLayout,
   Tag,
 } from '@flamingo-stack/openframe-frontend-core';
 import { PenEditIcon, TrashIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
@@ -71,35 +71,40 @@ export function PolicyDetailsView({ policyId }: PolicyDetailsViewProps) {
     return <NotFoundError message="Policy not found" />;
   }
 
+  const actions: PageActionButton[] = [
+    {
+      label: 'Edit',
+      icon: <PenEditIcon size={24} className="text-ods-text-secondary" />,
+      variant: 'outline',
+      onClick: handleEditPolicy,
+    },
+  ];
+
+  const menuActions: ActionsMenuGroup[] = [
+    {
+      items: [
+        {
+          id: 'delete-policy',
+          label: 'Delete Policy',
+          icon: <TrashIcon />,
+          onClick: () => setIsDeleteModalOpen(true),
+          disabled: isDeleting,
+        },
+      ],
+    },
+  ];
+
   return (
-    <DetailPageContainer
+    <PageLayout
       title={policyDetails.name}
       backButton={{
         label: 'Back',
         onClick: handleBack,
       }}
-      className="p-[var(--spacing-system-l)]"
-      headerActions={
-        <div className="flex items-center gap-2">
-          <Button
-            leftIcon={<PenEditIcon size={24} className="text-ods-text-secondary" />}
-            variant="outline"
-            onClick={handleEditPolicy}
-          >
-            Edit
-          </Button>
-          <MoreActionsMenu
-            items={[
-              {
-                label: 'Delete Policy',
-                icon: <TrashIcon />,
-                onClick: () => setIsDeleteModalOpen(true),
-                disabled: isDeleting,
-              },
-            ]}
-          />
-        </div>
-      }
+      actions={actions}
+      menuActions={menuActions}
+      actionsVariant="menu-primary"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       {/* Policy Info */}
       <div className="bg-ods-card border border-ods-border rounded-lg p-6">
@@ -162,6 +167,6 @@ export function PolicyDetailsView({ policyId }: PolicyDetailsViewProps) {
         itemType="policy"
         onConfirm={handleDeletePolicy}
       />
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/edit-query-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/edit-query-page.tsx
@@ -2,11 +2,11 @@
 
 import {
   CardLoader,
-  FormPageContainer,
   Input,
   Label,
   LoadError,
   NotFoundError,
+  PageLayout,
   Select,
   SelectContent,
   SelectItem,
@@ -263,15 +263,15 @@ export function EditQueryPage({ queryId }: EditQueryPageProps) {
   }
 
   return (
-    <FormPageContainer
+    <PageLayout
       title={isExistingQuery && queryDetails ? queryDetails.name : 'New Query'}
       backButton={{
         label: 'Back',
         onClick: handleBack,
       }}
       actions={actions}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="space-y-6 md:space-y-8">
         {/* Test Query Panel */}
@@ -403,6 +403,6 @@ export function EditQueryPage({ queryId }: EditQueryPageProps) {
           />
         </div>
       </div>
-    </FormPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import {
-  Button,
+  type ActionsMenuGroup,
   CardLoader,
-  DetailPageContainer,
   LoadError,
-  MoreActionsMenu,
   NotFoundError,
+  type PageActionButton,
+  PageLayout,
   QueryReportTable,
   TabNavigation,
 } from '@flamingo-stack/openframe-frontend-core';
@@ -103,35 +103,40 @@ export function QueryDetailsView({ queryId }: QueryDetailsViewProps) {
     return <NotFoundError message="Query not found" />;
   }
 
+  const actions: PageActionButton[] = [
+    {
+      label: 'Edit',
+      icon: <PenEditIcon size={24} className="text-ods-text-secondary" />,
+      variant: 'outline',
+      onClick: handleEditQuery,
+    },
+  ];
+
+  const menuActions: ActionsMenuGroup[] = [
+    {
+      items: [
+        {
+          id: 'delete-query',
+          label: 'Delete Query',
+          icon: <TrashIcon />,
+          onClick: () => setIsDeleteModalOpen(true),
+          disabled: isDeleting,
+        },
+      ],
+    },
+  ];
+
   return (
-    <DetailPageContainer
+    <PageLayout
       title={queryDetails.name}
       backButton={{
         label: 'Back',
         onClick: handleBack,
       }}
-      className="p-[var(--spacing-system-l)]"
-      headerActions={
-        <div className="flex items-center gap-2">
-          <Button
-            leftIcon={<PenEditIcon size={24} className="text-ods-text-secondary" />}
-            variant="outline"
-            onClick={handleEditQuery}
-          >
-            Edit
-          </Button>
-          <MoreActionsMenu
-            items={[
-              {
-                label: 'Delete Query',
-                icon: <TrashIcon />,
-                onClick: () => setIsDeleteModalOpen(true),
-                disabled: isDeleting,
-              },
-            ]}
-          />
-        </div>
-      }
+      actions={actions}
+      menuActions={menuActions}
+      actionsVariant="menu-primary"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       {/* Query Info */}
       <div className="bg-ods-card border border-ods-border rounded-lg p-6">
@@ -197,6 +202,6 @@ export function QueryDetailsView({ queryId }: QueryDetailsViewProps) {
         itemType="query"
         onConfirm={handleDeleteQuery}
       />
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-assign-devices-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-assign-devices-skeleton.tsx
@@ -74,7 +74,7 @@ function DeviceRowSkeleton() {
 
 /**
  * Full Schedule Assign Devices page loader
- * Matches ScheduleAssignDevicesView inside DetailPageContainer:
+ * Matches ScheduleAssignDevicesView inside PageLayout:
  * - Back link + title + Save button
  * - ScheduleInfoBarFromData
  * - Selection mode radios

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-assign-devices-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-assign-devices-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DetailPageContainer, LoadError, NotFoundError } from '@flamingo-stack/openframe-frontend-core';
+import { LoadError, NotFoundError, PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -181,11 +181,12 @@ export function ScheduleAssignDevicesView({ scheduleId }: ScheduleAssignDevicesV
   const repeat = getRepeatLabel(schedule);
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title="Schedule Devices"
       backButton={{ label: 'Back', onClick: handleBack }}
       actions={actions}
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex flex-col gap-6 overflow-auto">
         <DeviceSelector
@@ -208,6 +209,6 @@ export function ScheduleAssignDevicesView({ scheduleId }: ScheduleAssignDevicesV
           }
         />
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-create-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-create-skeleton.tsx
@@ -63,7 +63,7 @@ function ActionCardSkeleton() {
 
 /**
  * Full Schedule Create/Edit page loader
- * Matches the exact layout of ScheduleCreateView inside DetailPageContainer
+ * Matches the exact layout of ScheduleCreateView inside PageLayout
  */
 export function ScheduleCreateSkeleton() {
   return (

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-create-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-create-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {
-  DetailPageContainer,
+  PageLayout,
   Select,
   SelectContent,
   SelectItem,
@@ -183,14 +183,15 @@ export function ScheduleCreateView({ scheduleId }: ScheduleCreateViewProps = {})
 
   return (
     <FormProvider {...methods}>
-      <DetailPageContainer
+      <PageLayout
         title={isEditMode ? 'Edit Script Schedule' : 'New Script Schedule'}
         backButton={{
           label: isEditMode ? 'Back' : 'Back',
           onClick: handleBack,
         }}
         actions={actions}
-        className="p-[var(--spacing-system-l)]"
+        actionsVariant="primary-buttons"
+        className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
       >
         <div className="flex flex-col gap-6 overflow-auto">
           {/* Schedule Name */}
@@ -349,7 +350,7 @@ export function ScheduleCreateView({ scheduleId }: ScheduleCreateViewProps = {})
             </Button>
           </div>
         </div>
-      </DetailPageContainer>
+      </PageLayout>
     </FormProvider>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-skeleton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 
 /**
@@ -77,7 +77,7 @@ function ScriptCardSkeleton() {
 
 /**
  * Full Schedule Detail page skeleton
- * Matches ScheduleDetailView inside DetailPageContainer:
+ * Matches ScheduleDetailView inside PageLayout:
  * - Back link + title + 2 action buttons
  * - ScheduleInfoBar (4 columns)
  * - TabNavigation (3 tabs with icons)
@@ -85,22 +85,18 @@ function ScriptCardSkeleton() {
  */
 export function ScheduleDetailSkeleton() {
   return (
-    <DetailPageContainer
-      className="p-[var(--spacing-system-l)]"
-      headerContent={
-        <div className="flex items-end justify-between md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between gap-4 w-full pt-8">
-          <div className="flex flex-col gap-2 flex-1 min-w-0">
-            <Skeleton className="h-5 w-48" />
-            <Skeleton className="h-9 w-64 md:h-10 md:w-72" />
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <Skeleton className="h-12 w-[155px] rounded-[6px]" />
-            <Skeleton className="h-12 w-[160px] rounded-[6px]" />
-          </div>
+    <PageLayout showHeader={false} className="p-[var(--spacing-system-l)]">
+      <div className="flex items-end justify-between md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between gap-4 w-full pt-8">
+        <div className="flex flex-col gap-2 flex-1 min-w-0">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-9 w-64 md:h-10 md:w-72" />
         </div>
-      }
-      padding="none"
-    >
+        <div className="flex items-center gap-2 shrink-0">
+          <Skeleton className="h-12 w-[155px] rounded-[6px]" />
+          <Skeleton className="h-12 w-[160px] rounded-[6px]" />
+        </div>
+      </div>
+
       <div className="flex-1 overflow-auto">
         {/* Info bar */}
         <div className="pt-6">
@@ -117,6 +113,6 @@ export function ScheduleDetailSkeleton() {
           </div>
         </div>
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-view.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import {
-  DetailPageContainer,
   getTabComponent,
   LoadError,
   NotFoundError,
+  PageLayout,
   TabContent,
   type TabItem,
   TabNavigation,
@@ -113,13 +113,12 @@ export function ScheduleDetailView({ scheduleId }: ScheduleDetailViewProps) {
   }
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title={schedule.name}
       backButton={{ label: 'Back', onClick: handleBack }}
       actions={actions}
       actionsVariant="icon-buttons"
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex-1 overflow-auto">
         {/* Schedule info bar */}
@@ -142,6 +141,6 @@ export function ScheduleDetailView({ scheduleId }: ScheduleDetailViewProps) {
           </TabNavigation>
         </div>
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/edit-script-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/edit-script-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, FormPageContainer, Label } from '@flamingo-stack/openframe-frontend-core';
+import { Button, Label, PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { Card } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { ArrowLeft } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -78,12 +78,12 @@ export function EditScriptPage({ scriptId }: EditScriptPageProps) {
   }
 
   return (
-    <FormPageContainer
+    <PageLayout
       title={isEditMode && scriptDetails ? 'Edit Script' : 'New Script'}
       backButton={backButton}
       actions={actions}
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       {testRun && (
         <div>
@@ -105,6 +105,6 @@ export function EditScriptPage({ scriptId }: EditScriptPageProps) {
         onDeviceSelected={handleDeviceSelected}
         supportedPlatforms={watchedSupportedPlatforms}
       />
-    </FormPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/run-script-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/run-script-view.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import {
-  DetailPageContainer,
   LoadError,
   NotFoundError,
+  PageLayout,
   ScriptArguments,
   ScriptInfoSection,
 } from '@flamingo-stack/openframe-frontend-core';
@@ -183,11 +183,12 @@ export function RunScriptView({ scriptId }: RunScriptViewProps) {
   }
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title="Run Script"
       backButton={{ label: 'Back', onClick: handleBack }}
       actions={actions}
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <div className="flex-1 overflow-auto">
         <ScriptInfoSection
@@ -268,7 +269,7 @@ export function RunScriptView({ scriptId }: RunScriptViewProps) {
         scriptName={scriptDetails.name || 'Script'}
         onViewLogs={handleViewLogs}
       />
-    </DetailPageContainer>
+    </PageLayout>
   );
 }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-skeleton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DetailPageContainer } from '@flamingo-stack/openframe-frontend-core';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import { Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 
 /**
@@ -60,22 +60,18 @@ function CodeEditorSkeleton() {
  */
 export function ScriptDetailsSkeleton() {
   return (
-    <DetailPageContainer
-      headerContent={
-        <div className="flex items-end justify-between md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between gap-4 w-full pt-8">
-          <div className="flex flex-col gap-2 flex-1 min-w-0">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-9 w-72 md:h-10 md:w-96" />
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <Skeleton className="h-12 w-[150px] rounded-[6px]" />
-            <Skeleton className="h-12 w-[150px] rounded-[6px]" />
-          </div>
+    <PageLayout showHeader={false} className="p-[var(--spacing-system-l)]">
+      <div className="flex items-end justify-between md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between gap-4 w-full pt-8">
+        <div className="flex flex-col gap-2 flex-1 min-w-0">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-9 w-72 md:h-10 md:w-96" />
         </div>
-      }
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
-    >
+        <div className="flex items-center gap-2 shrink-0">
+          <Skeleton className="h-12 w-[150px] rounded-[6px]" />
+          <Skeleton className="h-12 w-[150px] rounded-[6px]" />
+        </div>
+      </div>
+
       <div className="flex flex-col overflow-auto gap-6">
         <ScriptInfoSectionSkeleton />
 
@@ -85,6 +81,6 @@ export function ScriptDetailsSkeleton() {
           <CodeEditorSkeleton />
         </div>
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/script-details-view.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  DetailPageContainer,
-  LoadError,
-  NotFoundError,
-  ScriptInfoSection,
-} from '@flamingo-stack/openframe-frontend-core';
+import { LoadError, NotFoundError, PageLayout, ScriptInfoSection } from '@flamingo-stack/openframe-frontend-core';
 import { ArrowRightUpIcon, PenEditIcon, PlayIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { useMemo } from 'react';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
@@ -67,14 +62,15 @@ export function ScriptDetailsView({ scriptId }: ScriptDetailsViewProps) {
   }
 
   return (
-    <DetailPageContainer
+    <PageLayout
       title={scriptDetails.name}
       backButton={{
         label: 'Back',
         onClick: handleBack,
       }}
       actions={actions}
-      className="p-[var(--spacing-system-l)]"
+      actionsVariant="primary-buttons"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       {/* Main Content */}
       <div className="flex flex-col overflow-auto gap-6">
@@ -106,6 +102,6 @@ export function ScriptDetailsView({ scriptId }: ScriptDetailsViewProps) {
           </div>
         )}{' '}
       </div>
-    </DetailPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/api-keys.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/api-keys.tsx
@@ -5,8 +5,9 @@ import {
   Button,
   type ColumnDef,
   DataTable,
-  ListPageContainer,
   MoreActionsMenu,
+  type PageActionButton,
+  PageLayout,
   type Row,
   Tag,
   TruncateText,
@@ -167,32 +168,26 @@ export function ApiKeysTab() {
     enableSorting: false,
   });
 
-  const headerActions = (
-    <div className="flex items-center gap-3">
-      <Button
-        onClick={() => window.open('/swagger-ui/index.html#/', '_blank', 'noopener,noreferrer')}
-        leftIcon={<DocumentIcon className="w-5 h-5" />}
-        className="bg-ods-card border border-ods-border hover:bg-ods-bg-hover text-ods-text-primary px-4 py-2.5 rounded-[6px] font-['DM_Sans'] font-bold text-[16px]"
-      >
-        API Documentation
-      </Button>
-      <Button
-        onClick={() => setIsCreateOpen(true)}
-        className="bg-ods-card border border-ods-border hover:bg-ods-bg-hover text-ods-text-primary px-4 py-2.5 rounded-[6px] font-['DM_Sans'] font-bold text-[16px]"
-        leftIcon={<PlusCircleIcon iconSize={20} whiteOverlay />}
-      >
-        Create API Key
-      </Button>
-    </div>
-  );
+  const actions: PageActionButton[] = [
+    {
+      label: 'API Documentation',
+      icon: <DocumentIcon className="w-5 h-5" />,
+      variant: 'outline',
+      onClick: () => window.open('/swagger-ui/index.html#/', '_blank', 'noopener,noreferrer'),
+    },
+    {
+      label: 'Create API Key',
+      icon: <PlusCircleIcon iconSize={20} whiteOverlay />,
+      variant: 'outline',
+      onClick: () => setIsCreateOpen(true),
+    },
+  ];
 
   return (
-    <ListPageContainer
+    <PageLayout
       title="API Keys"
-      headerActions={headerActions}
-      background="default"
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      actions={actions}
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)] bg-ods-bg"
       backButton={{ label: 'Back', onClick: handleBack }}
     >
       <DataTable table={table}>
@@ -278,6 +273,6 @@ export function ApiKeysTab() {
           setIsDisableOpen(false);
         }}
       />
-    </ListPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/architecture.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/architecture.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ListPageContainer, ServiceCard, Skeleton } from '@flamingo-stack/openframe-frontend-core';
+import { PageLayout, ServiceCard, Skeleton } from '@flamingo-stack/openframe-frontend-core';
 import { SearchIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Input } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -50,11 +50,9 @@ export function ArchitectureTab({ title = 'Architecture Overview' }: Architectur
   const layerOrder = Object.keys(grouped).sort((a, b) => a.localeCompare(b));
 
   return (
-    <ListPageContainer
+    <PageLayout
       title={title}
-      background="default"
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)] bg-ods-bg"
       backButton={{ label: 'Back', onClick: handleBack }}
     >
       <div>
@@ -135,6 +133,6 @@ export function ArchitectureTab({ title = 'Architecture Overview' }: Architectur
           </div>
         </div>
       ))}
-    </ListPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/sso-configuration.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/tabs/sso-configuration.tsx
@@ -9,8 +9,8 @@ import {
   type ColumnDef,
   DataTable,
   Input,
-  ListPageContainer,
   PageError,
+  PageLayout,
   type Row,
   Skeleton,
   Tag,
@@ -265,11 +265,9 @@ export function SsoConfigurationTab() {
   }
 
   return (
-    <ListPageContainer
+    <PageLayout
       title="SSO Configurations"
-      background="default"
-      padding="none"
-      className="p-[var(--spacing-system-l)]"
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)] bg-ods-bg"
       backButton={{ label: 'Back', onClick: handleBack }}
     >
       <Input
@@ -370,6 +368,6 @@ export function SsoConfigurationTab() {
           await loadData();
         }}
       />
-    </ListPageContainer>
+    </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/create-edit/create-edit-ticket-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/create-edit/create-edit-ticket-page.tsx
@@ -27,6 +27,15 @@ export function CreateEditTicketPage() {
   const actions = useMemo(
     () => [
       {
+        label: 'Cancel',
+        onClick: backButton.onClick,
+        variant: 'outline' as const,
+        disabled: isSubmitting,
+        // Desktop keeps the header "Back" link for cancelling; the explicit
+        // Cancel button is only needed in the mobile/tablet bottom action bar.
+        showOnlyMobile: true,
+      },
+      {
         label: isEditMode ? 'Save Changes' : 'Save Ticket',
         onClick: handleSave,
         variant: 'accent' as const,
@@ -34,7 +43,7 @@ export function CreateEditTicketPage() {
         loading: isSubmitting,
       },
     ],
-    [handleSave, isSubmitting, isLoadingTicket, isEditMode],
+    [backButton, handleSave, isSubmitting, isLoadingTicket, isEditMode],
   );
 
   return (
@@ -43,6 +52,7 @@ export function CreateEditTicketPage() {
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
       backButton={backButton}
       actions={actions}
+      actionsVariant="primary-buttons"
     >
       <TicketFormFields
         form={form}


### PR DESCRIPTION
## Description
Replace the deprecated *PageContainer family (DetailPageContainer, FormPageContainer, ListPageContainer, ContentPageContainer) with the canonical PageLayout across the (app) routes, and fix the layout/UX regressions the swap surfaced.

Containers:
- Map deprecated props to PageLayout: detail/form actions keep their primary-buttons variant; padding="none" dropped; background="default" -> bg-ods-bg token; headerActions/headerContent reworked into actions/menuActions/selector or showHeader={false} children.
- monitoring policy/query details: Edit + delete header buttons become actions + menuActions (actionsVariant="menu-primary"), mirroring the already-migrated scripts-v2 twins.

Padding:
- PageLayout's TitleBlock already supplies a leading pt-[var(--spacing-system-l)]; switch wrappers from p-... to px-... pb-... (and file-manager PAGE_PADDING / remote-shell) so the top padding is no longer doubled.

UX fixes:
- log-details "Copy Log Details": use default icon-buttons so the action stays in the header on mobile instead of the bottom bar.
- tickets new/edit: Save action moves to the mobile/tablet bottom bar (primary-buttons) with a mobile-only Cancel, per 

## Task
[Migrate app pages to PageLayout wrapper](https://app.clickup.com/t/9013925967/86aj9k1hu)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized several device, log, script, schedule, settings, and monitoring pages on a unified layout pattern for more consistent spacing and header behavior.
  * Updated a few loading and empty-state screens to match the new page structure.

* **Bug Fixes**
  * Adjusted page padding and spacing so titles, tabs, and content align more consistently across detail pages.
  * Improved action controls on policy, query, and ticket pages, including clearer placement and a mobile-friendly Cancel option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->