### PR TITLE
Device details page: unify device-details tab content gap

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
@@ -227,6 +227,9 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
               activeTab={tabId}
               TabComponent={getTabComponent(DEVICE_TABS, tabId)}
               componentProps={{ device: normalizedDevice }}
+              // Single source of the gap between the tab bar and tab content, so
+              // every tab (and its empty/loading states) is spaced consistently.
+              className="mt-6"
             />
           )}
         </TabNavigation>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
@@ -114,7 +114,7 @@ export function AgentsTab({ device }: AgentsTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
         {hasAgents ? (
           combinedAgents.map((agent: any, idx: number) => {
             const toolType = normalizeToolTypeWithFallback(agent.toolType);

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/compliance-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/compliance-tab.tsx
@@ -39,7 +39,7 @@ export function ComplianceTab({ device }: ComplianceTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="mt-6">
+      <div>
         {/* Patch Management Section */}
         <div>
           <h3 className="text-h5 text-ods-text-secondary mb-4">PATCH MANAGEMENT</h3>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/hardware-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/hardware-tab.tsx
@@ -272,7 +272,7 @@ export function HardwareTab({ device }: HardwareTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="mt-6">
+      <div>
         {/* Disk Info Section */}
         <div>
           <h3 className="text-h5 text-ods-text-secondary mb-1">DISK INFO</h3>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/logs-tab.tsx
@@ -29,7 +29,7 @@ export function LogsTab({ device }: LogsTabProps) {
 
   if (!deviceId) {
     return (
-      <div className="space-y-4 mt-6">
+      <div className="space-y-4">
         <div className="p-4 bg-ods-card border border-ods-border rounded-[6px] text-ods-text-secondary font-['DM_Sans'] text-[14px]">
           No device ID available to filter logs.
         </div>
@@ -37,12 +37,7 @@ export function LogsTab({ device }: LogsTabProps) {
     );
   }
 
-  // `embedded` cancels the PageLayout TitleBlock's leading pt (so it doesn't
-  // double up); the `mt-6` wrapper then supplies the same top gap the sibling
-  // tabs use, keeping the "Logs" header from sitting flush against the tab bar.
-  return (
-    <div className="mt-6">
-      <LogsTable deviceId={deviceId} ref={logsTableRef} embedded />
-    </div>
-  );
+  // `embedded` cancels the PageLayout TitleBlock's leading pt; the uniform top
+  // gap under the tab bar is supplied centrally by the TabContent wrapper.
+  return <LogsTable deviceId={deviceId} ref={logsTableRef} embedded />;
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/network-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/network-tab.tsx
@@ -74,7 +74,7 @@ export function NetworkTab({ device }: NetworkTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="space-y-4 mt-6">
+      <div className="space-y-4">
         <InfoCard
           data={{
             title: 'Public IP',

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/security-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/security-tab.tsx
@@ -32,7 +32,7 @@ export function SecurityTab({ device }: SecurityTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="mt-6">
+      <div>
         {/* Security Posture Section */}
         <div>
           <h3 className="text-h5 text-ods-text-secondary mb-4">SECURITY POSTURE</h3>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/software-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/software-tab.tsx
@@ -111,7 +111,7 @@ export function SoftwareTab({ device }: SoftwareTabProps) {
   }
 
   return (
-    <div className="space-y-4 mt-6">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="text-h5 text-ods-text-secondary">Installed Software ({software.length})</h3>
       </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/users-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/users-tab.tsx
@@ -30,7 +30,7 @@ export function UsersTab({ device }: UsersTabProps) {
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="space-y-6 mt-6">
+      <div className="space-y-6">
         {/* Logged In User */}
         <div>
           <h3 className="text-h5 text-ods-text-secondary mb-4">CURRENTLY LOGGED IN</h3>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/vulnerabilities-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/vulnerabilities-tab.tsx
@@ -184,7 +184,7 @@ export function VulnerabilitiesTab({ device }: VulnerabilitiesTabProps) {
   }
 
   return (
-    <div className="space-y-4 mt-6">
+    <div className="space-y-4">
       <div className="flex items-center gap-4">
         <h3 className="text-h5 text-ods-text-secondary">Vulnerabilities ({vulnerabilities.length})</h3>
 


### PR DESCRIPTION
## Description
Each device-details tab managed its own top gap (mt-6) under the tab bar, which drifted: the Logs tab sat flush and every "no data" empty state had no gap at all.

Move the gap to a single place — the shared TabContent wrapper in device-details-view (className="mt-6") — and drop the per-tab mt-6 from all nine tabs. Now every tab and every state (loaded, empty, loading) is spaced identically. The embedded LogsTable keeps `embedded` so its TitleBlock pt is cancelled and it lines up with the rest.

### Task
(Fix Page Title Jump on Navigation)[https://app.clickup.com/t/9013925967/86aj8aw1x]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized spacing across device detail tabs for a cleaner, more consistent layout.
  * Updated tab content sections so empty, loading, and populated states align with the same vertical spacing.
  * Refined spacing in several device views, including agents, compliance, hardware, logs, network, security, software, users, and vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->