### PR TITLE
Dashboard: Use TitleBlock for dashboard overview titles

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/customers-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/customers-overview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DashboardInfoCard, OrganizationCard, Skeleton } from '@flamingo-stack/openframe-frontend-core';
+import { DashboardInfoCard, OrganizationCard, Skeleton, TitleBlock } from '@flamingo-stack/openframe-frontend-core';
 import { IdCardIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { useMemo } from 'react';
 import { EmptyState } from '@/app/components/shared';
@@ -118,14 +118,11 @@ export function CustomersOverviewSection() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-h2 text-ods-text-primary">Customers Overview</h2>
-        {loading ? (
-          <Skeleton className="h-5 w-48" />
-        ) : (
-          <p className="text-h6 text-ods-text-secondary">{totalOrganizations.toLocaleString()} Customers in Total</p>
-        )}
-      </div>
+      <TitleBlock
+        title="Customers Overview"
+        subtitle={loading ? undefined : `${totalOrganizations.toLocaleString()} Customers in Total`}
+        className="pt-0 mb-0 [&_p]:hidden lg:[&_p]:block"
+      />
 
       <div className="flex flex-col gap-3">{organizationRows}</div>
     </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DashboardInfoCard, Skeleton } from '@flamingo-stack/openframe-frontend-core';
+import { DashboardInfoCard, Skeleton, TitleBlock } from '@flamingo-stack/openframe-frontend-core';
 import { DEVICE_STATUS } from '../../devices/constants/device-statuses';
 import { useDevicesOverview } from '../hooks/use-dashboard-stats';
 
@@ -49,10 +49,7 @@ export function DevicesOverviewSection() {
   if (devices.isLoading) {
     return (
       <div className="space-y-4">
-        <div>
-          <h2 className="text-h2 text-ods-text-primary">Devices Overview</h2>
-          <Skeleton className="h-5 w-48" />
-        </div>
+        <TitleBlock title="Devices Overview" className="pt-0 mb-0" />
 
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           {statusCards.map(card => (
@@ -65,10 +62,11 @@ export function DevicesOverviewSection() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-h2 text-ods-text-primary">Devices Overview</h2>
-        <p className="text-h6 text-ods-text-secondary">{devices.total.toLocaleString()} Devices in Total</p>
-      </div>
+      <TitleBlock
+        title="Devices Overview"
+        subtitle={`${devices.total.toLocaleString()} Devices in Total`}
+        className="pt-1 mb-0 [&_p]:hidden lg:[&_p]:block"
+      />
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {statusCards.map(card => (

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/tickets-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/tickets-overview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DashboardInfoCard, Skeleton, TicketStatusTag } from '@flamingo-stack/openframe-frontend-core';
+import { DashboardInfoCard, Skeleton, TicketStatusTag, TitleBlock } from '@flamingo-stack/openframe-frontend-core';
 import { useTicketsOverview } from '../hooks/use-dashboard-stats';
 
 export function TicketsOverviewSection() {
@@ -9,10 +9,7 @@ export function TicketsOverviewSection() {
   if (tickets.isLoading) {
     return (
       <div className="space-y-4">
-        <div>
-          <h2 className="text-h2 text-ods-text-primary">Tickets Overview</h2>
-          <Skeleton className="h-5 w-48" />
-        </div>
+        <TitleBlock title="Tickets Overview" className="pt-0 mb-0" />
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <Skeleton className="h-20 w-full" />
@@ -26,10 +23,11 @@ export function TicketsOverviewSection() {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-h2 text-ods-text-primary">Tickets Overview</h2>
-        <p className="text-h6 text-ods-text-secondary">{tickets.total.toLocaleString()} Tickets in Total</p>
-      </div>
+      <TitleBlock
+        title="Tickets Overview"
+        subtitle={`${tickets.total.toLocaleString()} Tickets in Total`}
+        className="pt-0 mb-0 [&_p]:hidden lg:[&_p]:block"
+      />
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <DashboardInfoCard


### PR DESCRIPTION
## Description
- Replace the hand-rolled title + subtitle in the Devices, Tickets, and Customers overview sections with the shared <TitleBlock> component.
- Neutralize TitleBlock's page-header pt/mb (pt-0/pt-1 + mb-0) so the existing dashboard spacing rhythm is preserved.