### PR TITLE
Dashboard: switch donut component responsive size to md breakpoint

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.337",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.343",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.337",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.337.tgz",
-      "integrity": "sha512-zown4+9yMZWJCGtmCBcYsN0L2SCD2fL/EN+BVh65ikgB92297UgsGvO6WUqg5ziSeE1F0eJsCTJ67Pl9r4wc4g==",
+      "version": "0.0.343",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.343.tgz",
+      "integrity": "sha512-VqrJx+WDjnSKsUQCUUWlPHcLMhHFNh6YUxgSXz3JTnlifsND8afuL08D+9zHyNmx8puP/CMmvbaz9r1YwmnaDA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.337",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.343",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/customers-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/customers-overview.tsx
@@ -88,7 +88,7 @@ export function CustomersOverviewSection() {
             showProgress
             progressVariant="success"
             percentageDisplay="plain"
-            progressSize={{ base: 24, lg: 56 }}
+            progressSize={{ base: 24, md: 56 }}
             href={
               org.active > 0
                 ? `/devices?organizationIds=${org.organizationId}&statuses=ONLINE`
@@ -104,7 +104,7 @@ export function CustomersOverviewSection() {
             showProgress
             progressVariant="error"
             percentageDisplay="plain"
-            progressSize={{ base: 24, lg: 56 }}
+            progressSize={{ base: 24, md: 56 }}
             href={
               org.inactive > 0
                 ? `/devices?organizationIds=${org.organizationId}&statuses=OFFLINE`

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
@@ -78,7 +78,7 @@ export function DevicesOverviewSection() {
             showProgress
             progressVariant={card.progressVariant}
             percentageDisplay="plain"
-            progressSize={{ base: 24, lg: 56 }}
+            progressSize={{ base: 24, md: 56 }}
             href={`/devices?statuses=${card.status}`}
           />
         ))}


### PR DESCRIPTION
## Improvements
- Tablet should show the full 56px ring (same as desktop), only mobile uses 24px. 
- Change progressSize from { base: 24, lg: 56 } to { base: 24, md: 56 } on the Devices Overview (4 cards) and Customers Overview (2 cards), matching the Figma mobile/tablet/desktop specs.
-Bumps @flamingo-stack/openframe-frontend-core to ^0.0.343 (adds md support to DashboardInfoCard progressSize).

## Task
[Dashboard — Device Statuses update](https://app.clickup.com/t/9013925967/86ahyn0fg)
