### PR TITLE
AI-Assistant: upload customer avatar to its own ClientView

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
@@ -77,7 +77,7 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
     const effectiveView = orgView ?? defaultView ?? getDefaultClientView(organizationId);
     const fallbackDefault = defaultView ?? getDefaultClientView(null);
 
-    const { form, avatarUrl, handleAvatarChange, handleAvatarRemove } = useCustomerAppearanceForm({
+    const { form, avatarUrl, handleAvatarChange, handleAvatarRemove, commitAvatar } = useCustomerAppearanceForm({
       view: effectiveView,
     });
 
@@ -97,14 +97,17 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
             return;
           }
           const values = form.getValues();
-          await update({
+
+          const savedView = await update({
             assistantName: values.assistantName,
             applicationTheme: values.applicationTheme,
             accentColor: values.accentColor,
           });
+          const clientViewId = savedView?.id ?? orgView?.id;
+          if (clientViewId) await commitAvatar(clientViewId);
         },
       }),
-      [useDefault, orgView, form, update, reset],
+      [useDefault, orgView, form, update, reset, commitAvatar],
     );
 
     const handleToggle = (checked: boolean) => {

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/use-customer-appearance-form.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/use-customer-appearance-form.ts
@@ -1,8 +1,7 @@
 'use client';
 
-import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { ClientView } from '@/app/(app)/settings/ai-settings/types/ai-settings';
 import { getFullImageUrl } from '@/lib/image-url';
@@ -18,78 +17,72 @@ interface UseCustomerAppearanceFormOptions {
 }
 
 export function useCustomerAppearanceForm({ view }: UseCustomerAppearanceFormOptions) {
-  const { toast } = useToast();
   const form = useForm<CustomerAppearanceFormValues>({
     resolver: zodResolver(customerAppearanceSchema),
     defaultValues: getCustomerAppearanceDefaults(view),
   });
 
-  // The avatar lives on the ClientView via a separate REST endpoint, not GraphQL.
-  // imageUrl from the API is relative (/images/...), so resolve it for <img src>.
-  const imageEndpoint = `/api/client-agent-settings/${view.id}/image`;
   const [avatarUrl, setAvatarUrl] = useState(
     getFullImageUrl(view.assistantAvatar?.imageUrl, view.assistantAvatar?.hash),
   );
 
-  // Re-sync form + avatar when the underlying record changes (initial load,
-  // after a save+refetch, or when switching which record we're editing).
+  // Avatar upload/removal is deferred to commit() so it targets the customer's
+  // own ClientView id, not the tenant default `view` borrowed while editing.
+  const pendingFileRef = useRef<File | null>(null);
+  const pendingRemovalRef = useRef(false);
+  const previewUrlRef = useRef<string | null>(null);
+
+  const clearPreview = useCallback(() => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+  }, []);
+
+  // Re-sync form + avatar when the underlying record changes.
   const syncKey = `${view.id}:${view.updatedAt ?? ''}`;
   const lastSyncRef = useRef<string | null>(null);
   useEffect(() => {
     if (lastSyncRef.current === syncKey) return;
     lastSyncRef.current = syncKey;
+    clearPreview();
+    pendingFileRef.current = null;
+    pendingRemovalRef.current = false;
     form.reset(getCustomerAppearanceDefaults(view));
     setAvatarUrl(getFullImageUrl(view.assistantAvatar?.imageUrl, view.assistantAvatar?.hash));
-  }, [syncKey, view, form]);
+  }, [syncKey, view, form, clearPreview]);
 
-  const handleAvatarChange = async (file: File) => {
-    if (!view.id) {
-      toast({
-        title: 'Save appearance first',
-        description: 'Save the custom appearance before uploading an avatar',
-        variant: 'destructive',
-      });
-      return;
-    }
-    const previous = avatarUrl;
+  useEffect(() => () => clearPreview(), [clearPreview]);
+
+  const handleAvatarChange = (file: File) => {
+    clearPreview();
     const preview = URL.createObjectURL(file);
+    previewUrlRef.current = preview;
+    pendingFileRef.current = file;
+    pendingRemovalRef.current = false;
     setAvatarUrl(preview);
-    try {
-      const uploadedUrl = await uploadWithAuth(imageEndpoint, file);
-      // The image endpoint URL is content-stable, so the browser would otherwise
-      // serve the previously cached avatar. Bust the cache so the freshly
-      // uploaded image actually loads.
-      setAvatarUrl(getFullImageUrl(uploadedUrl, String(Date.now())));
-      toast({ title: 'Avatar updated', description: 'Assistant avatar uploaded', variant: 'success' });
-    } catch (err) {
-      setAvatarUrl(previous);
-      toast({
-        title: 'Upload failed',
-        description: err instanceof Error ? err.message : 'Failed to upload avatar',
-        variant: 'destructive',
-      });
-    } finally {
-      URL.revokeObjectURL(preview);
-    }
   };
 
-  const handleAvatarRemove = async () => {
-    if (!view.id) {
-      setAvatarUrl(undefined);
-      return;
-    }
-    const previous = avatarUrl;
+  const handleAvatarRemove = () => {
+    clearPreview();
+    pendingFileRef.current = null;
+    // Delete on the backend only if there is a persisted avatar.
+    pendingRemovalRef.current = Boolean(view.assistantAvatar);
     setAvatarUrl(undefined);
-    try {
+  };
+
+  // Flush the pending avatar change to the saved ClientView id. Throws on failure.
+  const commitAvatar = async (clientViewId: string) => {
+    const imageEndpoint = `/api/client-agent-settings/${clientViewId}/image`;
+    if (pendingFileRef.current) {
+      const uploadedUrl = await uploadWithAuth(imageEndpoint, pendingFileRef.current);
+      pendingFileRef.current = null;
+      clearPreview();
+      // Bust the content-stable endpoint URL so the new image loads.
+      setAvatarUrl(getFullImageUrl(uploadedUrl, String(Date.now())));
+    } else if (pendingRemovalRef.current) {
       await deleteWithAuth(imageEndpoint);
-      toast({ title: 'Avatar removed', description: 'Assistant avatar deleted', variant: 'success' });
-    } catch (err) {
-      setAvatarUrl(previous);
-      toast({
-        title: 'Delete failed',
-        description: err instanceof Error ? err.message : 'Failed to delete avatar',
-        variant: 'destructive',
-      });
+      pendingRemovalRef.current = false;
     }
   };
 
@@ -98,5 +91,6 @@ export function useCustomerAppearanceForm({ view }: UseCustomerAppearanceFormOpt
     avatarUrl,
     handleAvatarChange,
     handleAvatarRemove,
+    commitAvatar,
   };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-client-view.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-client-view.ts
@@ -86,9 +86,9 @@ export function useUpdateClientView(organizationId: string | null = null) {
   const queryClient = useQueryClient();
 
   const result = useMutation({
-    mutationFn: async (input: ClientViewInput) => {
+    mutationFn: async (input: ClientViewInput): Promise<ClientView | null> => {
       const response = await apiClient.post<
-        GraphqlResponse<{ updateClientView: { userErrors: { message: string }[] } }>
+        GraphqlResponse<{ updateClientView: { view: ClientViewGql | null; userErrors: { message: string }[] } }>
       >('/chat/graphql', { query: UPDATE_CLIENT_VIEW_MUTATION, variables: { organizationId, input } });
 
       if (!response.ok || !response.data) {
@@ -98,10 +98,14 @@ export function useUpdateClientView(organizationId: string | null = null) {
         throw new Error(response.data.errors.map(e => e.message).join(', '));
       }
 
-      const userErrors = response.data.data?.updateClientView.userErrors ?? [];
+      const result = response.data.data?.updateClientView;
+      const userErrors = result?.userErrors ?? [];
       if (userErrors.length > 0) {
         throw new Error(userErrors.map(e => e.message).join(', '));
       }
+
+      // Return the saved view so the caller can attach the avatar to its id.
+      return result?.view ? toClientView(result.view) : null;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: clientViewQueryKeys.detail(organizationId) });


### PR DESCRIPTION
## Description
Problem.
On customers/edit → "AI-Assistant Appearance", the avatar was uploaded immediately on file pick to `view.id`. When the customer had no per-org override yet, `view` is the tenant-default ClientView, so the image was attached to the default record instead of the customer's. This caused three symptoms (one root cause):
- the avatar leaked onto the tenant-default appearance;
- the per-org override was saved without an avatar → chat showed the
  fallback;
- the customer preview stayed empty after save.

## Improvements
Fix. 
Defer the avatar upload from file-pick to save time, so it always targets the customer's own ClientView id:
- use-client-view.ts: `updateClientView` now returns the saved view (with id).
- use-customer-appearance-form.ts: file pick only shows a local preview; the actual upload/removal is deferred to a new `commitAvatar(clientViewId)`.
- customer-ai-assistant-appearance.tsx: `commit()` saves the per-org ClientView first, then attaches the avatar to the returned id. 

Result: avatar is stored on the customer's record; the tenant default is left untouched.