### PR TITLE
Сhat: refetch AI appearance on focus/reconnect

### DIFF
--- a/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
+++ b/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
@@ -48,7 +48,11 @@ export function useAiSettingsQuery({ enabled }: { enabled: boolean }) {
     queryFn: () => aiSettingsService.fetchAiSettings(),
     enabled: enabled && connection.isReady,
     retry: 1,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    // Appearance changes rarely but should land without a restart. No polling;
+    // instead refetch when the user refocuses the window or the app reconnects,
+    // with a short staleTime so that refocus actually picks up admin edits.
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 }


### PR DESCRIPTION
Custom appearance (avatar, accent color, assistant name) was cached for 5 minutes with no refetch trigger, so admin changes only appeared after a restart. Refetch on window focus and reconnect (no polling) and shorten staleTime to 60s so a refocus actually picks up the latest settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI settings now refresh more quickly, helping users see recent updates sooner.
  * The app will automatically recheck AI settings when returning to the tab or reconnecting to the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->