### PR TITLE
AI-Assistant: customer avatar upload toast + preview flicker

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
@@ -62,7 +62,9 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
     const { view: orgView, isLoading } = useClientView(organizationId);
     // Tenant-wide default, used for the "use default" previews.
     const { view: defaultView } = useClientView(null);
-    const { update } = useUpdateClientView(organizationId);
+    // Opt out of auto-invalidation: commit() refetches once after the avatar
+    // upload, so the preview never flickers the pre-upload image.
+    const { update } = useUpdateClientView(organizationId, { invalidateOnSuccess: false });
     const { reset } = useResetClientView(organizationId);
 
     const [useDefault, setUseDefault] = useState(true);
@@ -107,13 +109,11 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
             accentColor: values.accentColor,
           });
           const clientViewId = savedView?.id ?? orgView?.id;
-          if (clientViewId) {
-            await commitAvatar(clientViewId);
-            // The avatar lives on a separate REST endpoint, so the cached view
-            // is stale after upload. Refetch it now, otherwise an SPA revisit
-            // shows an empty preview until a hard refresh.
-            await queryClient.invalidateQueries({ queryKey: clientViewQueryKeys.detail(organizationId) });
-          }
+          if (clientViewId) await commitAvatar(clientViewId);
+          // Single refetch after the avatar lands: the view and its avatar live
+          // in separate stores, so this is the one point where both are current.
+          // (Also keeps the cache fresh for an SPA revisit — no hard refresh.)
+          await queryClient.invalidateQueries({ queryKey: clientViewQueryKeys.detail(organizationId) });
         },
       }),
       [useDefault, organizationId, orgView, form, update, reset, commitAvatar, queryClient],

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/use-customer-appearance-form.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/use-customer-appearance-form.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -17,6 +18,7 @@ interface UseCustomerAppearanceFormOptions {
 }
 
 export function useCustomerAppearanceForm({ view }: UseCustomerAppearanceFormOptions) {
+  const { toast } = useToast();
   const form = useForm<CustomerAppearanceFormValues>({
     resolver: zodResolver(customerAppearanceSchema),
     defaultValues: getCustomerAppearanceDefaults(view),
@@ -80,9 +82,11 @@ export function useCustomerAppearanceForm({ view }: UseCustomerAppearanceFormOpt
       clearPreview();
       // Bust the content-stable endpoint URL so the new image loads.
       setAvatarUrl(getFullImageUrl(uploadedUrl, String(Date.now())));
+      toast({ title: 'Avatar updated', description: 'Assistant avatar uploaded', variant: 'success' });
     } else if (pendingRemovalRef.current) {
       await deleteWithAuth(imageEndpoint);
       pendingRemovalRef.current = false;
+      toast({ title: 'Avatar removed', description: 'Assistant avatar deleted', variant: 'success' });
     }
   };
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-client-view.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-client-view.ts
@@ -82,7 +82,10 @@ export function useClientView(organizationId: string | null = null, { enabled = 
  * Returns `mutateAsync` so the CLIENT screen can save the view alongside the AI
  * config and surface a single combined toast. Feedback is owned by the caller.
  */
-export function useUpdateClientView(organizationId: string | null = null) {
+export function useUpdateClientView(
+  organizationId: string | null = null,
+  { invalidateOnSuccess = true }: { invalidateOnSuccess?: boolean } = {},
+) {
   const queryClient = useQueryClient();
 
   const result = useMutation({
@@ -108,7 +111,12 @@ export function useUpdateClientView(organizationId: string | null = null) {
       return result?.view ? toClientView(result.view) : null;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: clientViewQueryKeys.detail(organizationId) });
+      // The customer screen attaches the avatar after this resolves, then
+      // invalidates once itself — auto-invalidating here would refetch the
+      // pre-upload avatar and flicker the preview, so it opts out.
+      if (invalidateOnSuccess) {
+        queryClient.invalidateQueries({ queryKey: clientViewQueryKeys.detail(organizationId) });
+      }
     },
   });
 


### PR DESCRIPTION
## Description
Two regressions from the deferred-upload change:

- Restore the success toast on avatar upload/removal. Deferring the upload to commit() dropped the per-avatar feedback; re-add it in commitAvatar.
- Fix the ~1s old-image flicker. updateClientView auto-invalidated the cached view before the avatar finished uploading, so an intermediate refetch reset the preview to the pre-upload image. Add an invalidateOnSuccess option (default true; settings unchanged) and have the customer commit opt out, invalidating once after the avatar lands.