### PR TITLE
Update: domain registration 409 capacity error

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
@@ -121,6 +121,22 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
             }
           }
         } else {
+          const errorData = response.data as { code?: string; message?: string } | undefined;
+
+          // 409 Conflict with code TENANT_REGISTRATION_BLOCKED means registration cannot
+          // proceed because there is no available cluster capacity. Surface the backend
+          // message so the user knows to contact the admin or wait for capacity.
+          if (response.status === 409 && errorData?.code === 'TENANT_REGISTRATION_BLOCKED') {
+            toast({
+              title: 'Registration Unavailable',
+              description:
+                errorData.message ||
+                'Registration is currently unavailable because there is no cluster capacity. Please contact your administrator or try again later.',
+              variant: 'destructive',
+            });
+            return;
+          }
+
           throw new Error(response.error || 'Failed to check domain availability');
         }
       } catch (error) {

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useState } from 'react';
 import { isSaasSharedMode } from '@/lib/app-mode';
 import { authApiClient, SAAS_DOMAIN_SUFFIX } from '@/lib/auth-api-client';
+import { AUTH_ERROR_CODE } from '../constants/auth-error-codes';
 import { ForgotPasswordModal } from './forgot-password-modal';
 
 interface AuthChoiceSectionProps {
@@ -56,14 +57,16 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
         if (!validateResponse.ok || !validateResponse.data) {
           const error = validateResponse?.data?.code || 'Failed to validate access code';
 
-          if (error.includes('ACCESS_CODE_ALREADY_USED')) {
+          if (error.includes(AUTH_ERROR_CODE.ACCESS_CODE_ALREADY_USED)) {
             setAccessCodeError('This access code has already been used');
             toast({
               title: 'Access Code Already Used',
               description: 'This access code has already been used.',
               variant: 'destructive',
             });
-          } else if (['ACCESS_CODE_VALIDATION_FAILED', 'INVALID_ACCESS_CODE'].includes(error)) {
+          } else if (
+            [AUTH_ERROR_CODE.ACCESS_CODE_VALIDATION_FAILED, AUTH_ERROR_CODE.INVALID_ACCESS_CODE].includes(error)
+          ) {
             setAccessCodeError('Invalid access code');
             toast({
               title: 'Invalid Access Code',
@@ -126,7 +129,7 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
           // 409 Conflict with code TENANT_REGISTRATION_BLOCKED means registration cannot
           // proceed because there is no available cluster capacity. Surface the backend
           // message so the user knows to contact the admin or wait for capacity.
-          if (response.status === 409 && errorData?.code === 'TENANT_REGISTRATION_BLOCKED') {
+          if (response.status === 409 && errorData?.code === AUTH_ERROR_CODE.TENANT_REGISTRATION_BLOCKED) {
             toast({
               title: 'Registration Unavailable',
               description:

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/constants/auth-error-codes.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/constants/auth-error-codes.ts
@@ -1,0 +1,17 @@
+/**
+ * Backend error codes returned by the SaaS-shared auth & registration endpoints
+ * (access-code validation, domain availability, organization registration).
+ *
+ * Centralized so both the domain-availability check (choice-section) and the
+ * organization registration handler (use-auth) reference the same constants
+ * instead of duplicating string literals.
+ */
+export const AUTH_ERROR_CODE = {
+  INVALID_ARGUMENT: 'INVALID_ARGUMENT',
+  INVALID_ACCESS_CODE: 'INVALID_ACCESS_CODE',
+  ACCESS_CODE_ALREADY_USED: 'ACCESS_CODE_ALREADY_USED',
+  ACCESS_CODE_VALIDATION_FAILED: 'ACCESS_CODE_VALIDATION_FAILED',
+  TENANT_REGISTRATION_BLOCKED: 'TENANT_REGISTRATION_BLOCKED',
+} as const;
+
+export type AuthErrorCode = (typeof AUTH_ERROR_CODE)[keyof typeof AUTH_ERROR_CODE];

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-auth.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-auth.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { isSaasSharedMode } from '@/lib/app-mode';
 import { authApiClient } from '@/lib/auth-api-client';
 import { runtimeEnv } from '@/lib/runtime-config';
+import { AUTH_ERROR_CODE } from '../constants/auth-error-codes';
 import { useAuthStore } from '../stores/auth-store';
 import { authSessionQueryKey } from './use-auth-session';
 import { useTokenStorage } from './use-token-storage';
@@ -150,19 +151,19 @@ export function useAuth() {
         const variant: any = 'destructive';
 
         switch (code) {
-          case 'INVALID_ARGUMENT':
+          case AUTH_ERROR_CODE.INVALID_ARGUMENT:
             userMessage = 'Access code is required';
             break;
-          case 'INVALID_ACCESS_CODE':
+          case AUTH_ERROR_CODE.INVALID_ACCESS_CODE:
             userMessage = 'The access code you entered is invalid. Please check and try again.';
             break;
-          case 'ACCESS_CODE_ALREADY_USED':
+          case AUTH_ERROR_CODE.ACCESS_CODE_ALREADY_USED:
             userMessage = 'This access code has already been used. Please contact support for a new code.';
             break;
-          case 'ACCESS_CODE_VALIDATION_FAILED':
+          case AUTH_ERROR_CODE.ACCESS_CODE_VALIDATION_FAILED:
             userMessage = 'Unable to verify access code. Please try again in a moment.';
             break;
-          case 'TENANT_REGISTRATION_BLOCKED':
+          case AUTH_ERROR_CODE.TENANT_REGISTRATION_BLOCKED:
             title = 'Service Unavailable';
             userMessage = 'Registration is temporarily unavailable. Please try again later.';
             break;


### PR DESCRIPTION
## Description
- Fixed the 409 handling in domain registration. When GET /api/tenant/availability returns 409 Conflict with code TENANT_REGISTRATION_BLOCKED (no cluster capacity), the UI now shows the backend message in a toast instead of a generic "Failed to check domain availability" error.
- Location: choice-section.tsx → handleCreateOrganization (the domain availability step of the Create Organization flow).
- Fallback message included when the backend sends no message, suggesting to contact the admin or wait for capacity.
- Refactor: extracted all auth/registration backend error codes into a shared AUTH_ERROR_CODE constant (auth-error-codes.ts) and reused it in both choice-section.tsx and use-auth.ts, removing duplicated string literals.

## Task
[Show User-Friendly Error on 409 During Domain Registration When Cluster Capacity Is Zero](https://app.clickup.com/t/9013925967/86aj7tm52)
