### PR TITLE
Hotfix: Mingo passive context tracking + tab-bar polish

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.357",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.358",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.357",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.357.tgz",
-      "integrity": "sha512-IPBZVa+d11/iWcm9fsZF+pwWrDVbG1AYAgobE8wsE77gUNJxCoua/qQPxPGtsLqQ3zAsGpER68uetqXcp176qA==",
+      "version": "0.0.358",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.358.tgz",
+      "integrity": "sha512-fusZdiJJSnU7G1PwdTRPd0znMPmNroR9qOzy58OlbrqUL+lqxx0ejoPi3LCdD0N2vpYOHleXXXewC/hBAnZ4nw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.357",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.358",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customer-details-view.tsx
@@ -204,7 +204,7 @@ export function CustomerDetailsView({ id }: CustomerDetailsViewProps) {
         contentClassName="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)] md:px-0 md:pb-0"
         headerVariant="card"
       >
-        <TabNavigation tabs={tabs} activeTab={activeTab} onTabChange={handleTabChange} showRightGradient>
+        <TabNavigation tabs={tabs} activeTab={activeTab} onTabChange={handleTabChange}>
           {activeTab => (
             <TabContent
               activeTab={activeTab}

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-tabs.tsx
@@ -54,7 +54,6 @@ export function CustomersTabNavigation({ activeTab, onTabChange }: CustomersTabN
         activeTab={activeTab || 'active'}
         tabs={CUSTOMERS_TABS}
         onTabChange={handleTabChange}
-        showRightGradient
       />
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-skeleton.tsx
@@ -689,13 +689,7 @@ export function DeviceDetailsSkeleton({ activeTab = 'overview' }: DeviceDetailsS
       {/* Reuse the REAL `TabNavigation` (not a copy) so the tab bar is pixel-identical to
           the loaded page and can't drift. `pointer-events-none` keeps it non-interactive
           while loading; `onTabChange` is a required no-op in controlled mode. */}
-      <TabNavigation
-        tabs={DEVICE_TABS}
-        activeTab={activeTab}
-        onTabChange={noop}
-        showRightGradient
-        className="pointer-events-none"
-      >
+      <TabNavigation tabs={DEVICE_TABS} activeTab={activeTab} onTabChange={noop} className="pointer-events-none">
         {() => getTabSkeleton(activeTab)}
       </TabNavigation>
     </PageLayout>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
@@ -183,7 +183,7 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       {/* Tab Navigation */}
-      <TabNavigation tabs={DEVICE_TABS} activeTab={activeTab} onTabChange={handleTabChange} showRightGradient>
+      <TabNavigation tabs={DEVICE_TABS} activeTab={activeTab} onTabChange={handleTabChange}>
         {tabId => (
           <TabContent
             activeTab={tabId}

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/file-manager/page.tsx
@@ -6,6 +6,8 @@ import { use } from 'react';
 import { FileManagerContainer } from '@/app/(app)/devices/details/[deviceId]/file-manager/components/file-manager-container';
 import { useDeviceDetails } from '@/app/(app)/devices/hooks/use-device-details';
 import { getMeshCentralAgentId } from '@/app/(app)/devices/utils/device-action-utils';
+import { CONTEXT_ENTITY_KIND } from '@/app/(app)/mingo/context/context-types';
+import { useTrackOpenView } from '@/app/(app)/mingo/context/use-track-open-view';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 
 // Horizontal padding only — `PageLayout`'s `TitleBlock` already supplies the
@@ -26,6 +28,19 @@ export default function FileManagerPage({ params }: FileManagerPageProps) {
   const { deviceDetails, isLoading, error } = useDeviceDetails(deviceId, { polling: false });
 
   const meshcentralAgentId = deviceDetails ? getMeshCentralAgentId(deviceDetails) : undefined;
+
+  // Keep this device as the Mingo "open view" while on the file-manager surface
+  // (the parent detail page unmounted on navigation, clearing its own openView).
+  // Above the early returns so hook order stays stable.
+  useTrackOpenView(
+    deviceDetails
+      ? {
+          type: CONTEXT_ENTITY_KIND.DEVICE,
+          id: deviceId,
+          label: deviceDetails.hostname || deviceDetails.displayName || deviceId,
+        }
+      : null,
+  );
 
   if (isLoading) {
     return <FileManagerPageSkeleton onBack={handleBack} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-desktop/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-desktop/page.tsx
@@ -18,6 +18,8 @@ import { Loader2 } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { use, useEffect, useMemo, useRef, useState } from 'react';
 import { useDeviceDetails } from '@/app/(app)/devices/hooks/use-device-details';
+import { CONTEXT_ENTITY_KIND } from '@/app/(app)/mingo/context/context-types';
+import { useTrackOpenView } from '@/app/(app)/mingo/context/use-track-open-view';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { MeshControlClient } from '@/lib/meshcentral/meshcentral-control';
 import { type DisplayInfo, MeshDesktop } from '@/lib/meshcentral/meshcentral-desktop';
@@ -93,6 +95,10 @@ export default function RemoteDesktopPage({ params }: RemoteDesktopPageProps) {
     }
     return deviceDetails?.organization;
   }, [legacyDeviceData, deviceDetails]);
+
+  // Keep this device as the Mingo "open view" while on the remote-desktop surface
+  // (the parent detail page unmounted on navigation, clearing its own openView).
+  useTrackOpenView(hostname ? { type: CONTEXT_ENTITY_KIND.DEVICE, id: deviceId, label: hostname } : null);
 
   // Remote desktop state
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-shell/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/details/[deviceId]/remote-shell/page.tsx
@@ -6,6 +6,8 @@ import { TerminalSquare } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { use, useEffect, useMemo, useRef, useState } from 'react';
 import { useDeviceDetails } from '@/app/(app)/devices/hooks/use-device-details';
+import { CONTEXT_ENTITY_KIND } from '@/app/(app)/mingo/context/context-types';
+import { useTrackOpenView } from '@/app/(app)/mingo/context/use-track-open-view';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { MeshControlClient } from '@/lib/meshcentral/meshcentral-control';
 import { MeshTunnel, TunnelState } from '@/lib/meshcentral/meshcentral-tunnel';
@@ -56,6 +58,12 @@ export default function RemoteShellPage({ params }: RemoteShellPageProps) {
   const organizationName = useMemo(() => {
     return deviceDetails?.organization;
   }, [deviceDetails]);
+
+  // Keep this device as the Mingo "open view" while on the remote-shell surface
+  // (the parent detail page unmounted on navigation, clearing its own openView).
+  useTrackOpenView(
+    deviceDetails ? { type: CONTEXT_ENTITY_KIND.DEVICE, id: deviceId, label: hostname || deviceId } : null,
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<any | null>(null);

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-details.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-details.ts
@@ -10,6 +10,7 @@ import {
   parseMeshCentralDeviceStatus,
   parseMeshCentralLastSeen,
 } from '@/lib/meshcentral/meshcentral-api';
+import { tacticalApiClient } from '@/lib/tactical-api-client';
 import { GET_DEVICE_QUERY } from '../queries/devices-queries';
 import type {
   Battery,
@@ -46,6 +47,8 @@ function createDevice(
   fleetData: FleetHost | null,
   meshCentralStatus: 'online' | 'offline' | null,
   meshCentralLastSeen: string | null,
+  tacticalStatus: string | null,
+  tacticalLastSeen: string | null,
 ): Device {
   // Transform Fleet software to unified Software type
   const software: Software[] =
@@ -259,9 +262,16 @@ function createDevice(
     // Tags
     tags: node.tags || [],
 
-    // Tool Connections (enriched with status + lastSeen from Fleet / MeshCentral API)
+    // Tool Connections (enriched with status + lastSeen from Tactical / Fleet / MeshCentral API)
     toolConnections: (node.toolConnections || []).map(tc => {
       const base = { ...tc };
+      if (tc.toolType === 'TACTICAL_RMM') {
+        return {
+          ...base,
+          ...(tacticalStatus != null && { status: tacticalStatus }),
+          ...(tacticalLastSeen != null && { lastSeen: tacticalLastSeen }),
+        };
+      }
       if (tc.toolType === 'FLEET_MDM') {
         return {
           ...base,
@@ -339,7 +349,21 @@ async function fetchDeviceDetails(machineId: string): Promise<Device> {
 
   const node = graphqlResponse.data.device;
 
-  // 2) Fetch Fleet MDM details if present
+  // 2) Fetch Tactical RMM agent — ONLY to surface live agent status/last-seen on the Agents tab.
+  // Tactical is no longer a general device-details data source; we intentionally read just these two
+  // fields. On error we leave both null so the Agents tab simply omits Tactical status/last-seen.
+  const tactical = node.toolConnections?.find(tc => tc.toolType === 'TACTICAL_RMM');
+  let tacticalStatus: string | null = null;
+  let tacticalLastSeen: string | null = null;
+  if (tactical?.agentToolId) {
+    const tResponse = await tacticalApiClient.getAgent(tactical.agentToolId);
+    if (tResponse.ok && tResponse.data) {
+      if (tResponse.data.status != null) tacticalStatus = String(tResponse.data.status).toLowerCase();
+      if (tResponse.data.last_seen != null) tacticalLastSeen = tResponse.data.last_seen;
+    }
+  }
+
+  // 2.5) Fetch Fleet MDM details if present
   const fleet = node.toolConnections?.find(tc => tc.toolType === 'FLEET_MDM');
   let fleetData: any | null = null;
   if (fleet?.agentToolId) {
@@ -371,7 +395,7 @@ async function fetchDeviceDetails(machineId: string): Promise<Device> {
   }
 
   // 3) Create Device object directly - no normalization
-  return createDevice(node, fleetData, meshCentralStatus, meshCentralLastSeen);
+  return createDevice(node, fleetData, meshCentralStatus, meshCentralLastSeen, tacticalStatus, tacticalLastSeen);
 }
 
 interface UseDeviceDetailsOptions {

--- a/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/article-details-page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/knowledge-base/components/article-details-page.tsx
@@ -23,7 +23,10 @@ import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { AssignedItemsView } from '@/components/assignments';
 import { formatDate } from '@/lib/format-date';
 import { getFullImageUrl } from '@/lib/image-url';
+import { decodeGlobalId } from '@/lib/relay-id';
 import { formatFileSize } from '../../devices/utils/file-manager-utils';
+import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
+import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import { getArchivedArticlesConnectionId } from '../hooks/use-archived-articles';
 import { useDownloadArticleAttachment } from '../hooks/use-download-article-attachment';
 import { useKnowledgeBaseItem } from '../hooks/use-knowledge-base-item';
@@ -58,6 +61,16 @@ function ArticleDetailsContent({ articleId }: { articleId: string }) {
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [unarchiveOpen, setUnarchiveOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
+
+  // Mingo context carries the RAW db id (the route's `articleId` is the Relay
+  // global id) — KB_ARTICLE is GraphQL-resolved, so the chip re-encodes it to a
+  // global id for `node(id:)`. Registers the open article as the Mingo "open view".
+  const articleDbId = useMemo(() => decodeGlobalId(articleId)?.rawId ?? articleId, [articleId]);
+  useTrackOpenView(
+    article && article.type === 'ARTICLE'
+      ? { type: CONTEXT_ENTITY_KIND.KB_ARTICLE, id: articleDbId, label: article.name || articleDbId }
+      : null,
+  );
 
   if (!article || article.type !== 'ARTICLE') {
     notFound();

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/monitoring-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/components/tabs/monitoring-tabs.tsx
@@ -50,7 +50,6 @@ export function MonitoringTabNavigation({ activeTab, onTabChange }: MonitoringTa
         activeTab={activeTab || 'policies'}
         tabs={MONITORING_TABS}
         onTabChange={handleTabChange}
-        showRightGradient
       />
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/components/query-details-view.tsx
@@ -169,7 +169,7 @@ export function QueryDetailsView({ queryId }: QueryDetailsViewProps) {
 
       {/* Tabs: Query Results / Assigned Devices */}
       <div className="mt-6">
-        <TabNavigation tabs={QUERY_TABS} activeTab={activeTab} onTabChange={handleTabChange} showRightGradient>
+        <TabNavigation tabs={QUERY_TABS} activeTab={activeTab} onTabChange={handleTabChange}>
           {tabId => (
             <div className="mt-6">
               {tabId === 'devices' ? (

--- a/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-page-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/notifications/components/notifications-page-view.tsx
@@ -129,13 +129,7 @@ export function NotificationsPageView() {
   return (
     <div className="flex w-full flex-col">
       <div className="px-[var(--spacing-system-l)]">
-        <TabNavigation
-          tabs={NOTIFICATIONS_TABS}
-          activeTab={activeTab}
-          urlSync={false}
-          onTabChange={handleTabChange}
-          showRightGradient
-        />
+        <TabNavigation tabs={NOTIFICATIONS_TABS} activeTab={activeTab} urlSync={false} onTabChange={handleTabChange} />
       </div>
 
       {activeTab === 'history' ? (

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/schedule/schedule-details-view.tsx
@@ -128,7 +128,7 @@ export function ScheduleDetailView({ scheduleId }: ScheduleDetailViewProps) {
 
         {/* Tab Navigation */}
         <div className="mt-6">
-          <TabNavigation tabs={SCHEDULE_TABS} activeTab={activeTab} onTabChange={handleTabChange} showRightGradient>
+          <TabNavigation tabs={SCHEDULE_TABS} activeTab={activeTab} onTabChange={handleTabChange}>
             {tabId => (
               <div className="pt-6">
                 <TabContent

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/run-script-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/script/run-script-view.tsx
@@ -18,6 +18,8 @@ import { DeviceSelector } from '@/app/components/shared/device-selector';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { tacticalApiClient } from '@/lib/tactical-api-client';
 import { getTacticalAgentId } from '../../../devices/utils/device-action-utils';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
 import { useRunScriptData } from '../../hooks/use-run-script-data';
 import { scriptArgumentSchema } from '../../types/edit-script.types';
 import { getDevicePrimaryId, resolveOsTypeFromDevices, resolveShellForExecution } from '../../utils/device-helpers';
@@ -47,6 +49,13 @@ export function RunScriptView({ scriptId }: RunScriptViewProps) {
     devices: allDevices,
     isLoadingDevices,
   } = useRunScriptData({ scriptId });
+
+  // Keep this script as the Mingo "open view" while on the run surface (the detail
+  // page unmounted on navigation). v1 is REST-backed — `scriptId` is already the
+  // raw db id the backend SCRIPT resolver expects (no global-id decode needed).
+  useTrackOpenView(
+    scriptDetails ? { type: CONTEXT_ENTITY_KIND.SCRIPT, id: scriptId, label: scriptDetails.name || scriptId } : null,
+  );
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/components/scripts-tabs.tsx
@@ -47,7 +47,6 @@ export function ScriptsTabNavigation({ activeTab, onTabChange }: ScriptsTabNavig
         activeTab={activeTab || 'list'}
         tabs={SCRIPTS_TABS}
         onTabChange={handleTabChange}
-        showRightGradient
       />
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/run-script-view.tsx
@@ -15,7 +15,10 @@ import { DeviceSelector } from '@/app/components/shared/device-selector';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { batchRunScriptMutation } from '@/graphql/scripts/batch-run-script-mutation';
 import { scriptDetailRelayQuery } from '@/graphql/scripts/script-detail-relay';
+import { decodeGlobalId } from '@/lib/relay-id';
 import type { Device } from '../../../devices/types/device.types';
+import { CONTEXT_ENTITY_KIND } from '../../../mingo/context/context-types';
+import { useTrackOpenView } from '../../../mingo/context/use-track-open-view';
 import { ExecutionStartedModal } from '../../components/script/execution-started-modal';
 import { scriptArgumentSchema } from '../../types/edit-script.types';
 import { getDevicePrimaryId } from '../../utils/device-helpers';
@@ -53,6 +56,14 @@ function RunScriptContent({ scriptId }: RunScriptViewProps) {
     { fetchPolicy: 'store-and-network' },
   );
   const script = data.script;
+
+  // Keep this script as the Mingo "open view" while on the run surface (the detail
+  // page unmounted on navigation). Raw db id — the route's `scriptId` is the Relay
+  // global id (SCRIPT is GraphQL-resolved; the chip re-encodes it for `node(id:)`).
+  const scriptDbId = useMemo(() => decodeGlobalId(scriptId)?.rawId ?? scriptId, [scriptId]);
+  useTrackOpenView(
+    script ? { type: CONTEXT_ENTITY_KIND.SCRIPT, id: scriptDbId, label: script.name || scriptDbId } : null,
+  );
 
   const supportedPlatforms = useMemo(() => platformsToIds(script?.supportedPlatforms), [script?.supportedPlatforms]);
 

--- a/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-executions-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/scripts/v2/components/script-executions-tab.tsx
@@ -515,11 +515,16 @@ export function ScriptExecutionsTab({ scriptId }: ScriptExecutionsTabProps) {
   );
 
   return (
-    <div className="flex flex-col" style={containerStyle}>
+    // `-mt-6` cancels the `gap-6` the parent (script-details-view) puts between the
+    // tab bar and this content: TabNavigation renders as a fragment, so its tab bar
+    // and this body are sibling flex items and the gap leaks in as a top offset.
+    // Without this it stacks with the toolbar's `pt-l` below → doubled top padding.
+    <div className="flex flex-col -mt-6" style={containerStyle}>
       {/* Search stays pinned to the top of the scroll area; its measured height
-          feeds the sticky column header offset. `pt-l` separates it from the tab
-          bar above (TabNavigation renders its content flush), `pb-l` from the
-          table below — the `bg-ods-bg` hides rows scrolling underneath. */}
+          feeds the sticky column header offset. `pt-l` sits above the input (and,
+          once the `-mt-6` cancels the parent gap, is the sole top spacing), `pb-l`
+          separates it from the table below — the `bg-ods-bg` hides rows scrolling
+          underneath while the toolbar is pinned. */}
       <div
         ref={toolbarRef}
         className="sticky top-0 z-20 flex items-center gap-[var(--spacing-system-xs)] bg-ods-bg pt-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
@@ -43,12 +43,7 @@ export function AiSettingsTabs({ activeTab, onTabChange, children }: AiSettingsT
   const tabs = getVisibleAiSettingsTabs();
 
   return (
-    <TabNavigation
-      tabs={tabs}
-      activeTab={activeTab}
-      onTabChange={tabId => onTabChange(tabId as AiSettingsTabId)}
-      showRightGradient
-    >
+    <TabNavigation tabs={tabs} activeTab={activeTab} onTabChange={tabId => onTabChange(tabId as AiSettingsTabId)}>
       {activeId => <div className="pt-[var(--spacing-system-l)]">{children(activeId as AiSettingsTabId)}</div>}
     </TabNavigation>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/employee-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/employee-details-view.tsx
@@ -11,6 +11,8 @@ import { InfoCell } from '@/app/components/shared/info-cell';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 import { featureFlags } from '@/lib/feature-flags';
 import { getFullImageUrl } from '@/lib/image-url';
+import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
+import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import { useUser } from '../hooks/use-user';
 import { UserStatus, useDeleteUser, useUpdateProfile } from '../hooks/use-users';
 import { ConfirmDeleteUserModal } from './confirm-delete-user-modal';
@@ -64,6 +66,19 @@ export function EmployeeDetailsView({ userId }: EmployeeDetailsViewProps) {
   const updateProfile = useUpdateProfile();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
+
+  // Register the open employee as the Mingo "open view". `user.id` is the raw db
+  // id the backend USER resolver / `@user:id` marker expects (USER is REST-resolved
+  // — no global-id round-trip). Called before the early returns to keep hooks order stable.
+  useTrackOpenView(
+    user
+      ? {
+          type: CONTEXT_ENTITY_KIND.USER,
+          id: user.id,
+          label: `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.email,
+        }
+      : null,
+  );
 
   if (error) {
     return <LoadError message={`Error loading employee: ${error}`} />;

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/ticket-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/ticket-details-view.tsx
@@ -62,6 +62,8 @@ import { useAuthStore } from '@/stores';
 import { useDeviceActionsMenu } from '../../devices/hooks/use-device-actions-menu';
 import { useDeviceDetails } from '../../devices/hooks/use-device-details';
 import { formatFileSize } from '../../devices/utils/file-manager-utils';
+import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
+import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import {
   APPROVAL_STATUS,
   ASSISTANT_CONFIG,
@@ -137,6 +139,13 @@ export function TicketDetailsView({ ticketId }: TicketDetailsViewProps) {
 
   const queryClient = useQueryClient();
   const { ticket: dialog, isPending: isLoading, error: dialogError } = useTicketDetail(ticketId);
+
+  // Register the open ticket as the Mingo "open view" so it rides on the sidebar
+  // chat's context. `dialog.id` is the raw db id the backend TICKET resolver /
+  // `@ticket:id` marker expects (TICKET is REST-resolved — no global-id round-trip).
+  useTrackOpenView(
+    dialog ? { type: CONTEXT_ENTITY_KIND.TICKET, id: dialog.id, label: dialog.title || dialog.id } : null,
+  );
 
   // Device referenced by the ticket. Same hook & availability utility used by
   // the Devices view, so remote-action gating stays in sync across views.

--- a/openframe/services/openframe-frontend/src/app/components/shared/device-selector/device-selector.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/device-selector/device-selector.tsx
@@ -546,9 +546,7 @@ export function DeviceSelector({
         </div>
       )}
 
-      {!singleSelect && (
-        <TabNavigation tabs={assignTabs} activeTab={activeSubTab} onTabChange={handleTabChange} showRightGradient />
-      )}
+      {!singleSelect && <TabNavigation tabs={assignTabs} activeTab={activeSubTab} onTabChange={handleTabChange} />}
 
       <DevicesFilterToolbar
         sticky={false}

--- a/openframe/services/openframe-frontend/src/lib/tactical-api-client.ts
+++ b/openframe/services/openframe-frontend/src/lib/tactical-api-client.ts
@@ -64,6 +64,15 @@ class TacticalApiClient {
 
   // Tactical RMM specific methods
 
+  /**
+   * Fetch a single Tactical RMM agent. Used only to enrich the Tactical tool
+   * connection's live status/last-seen on the device-details Agents tab —
+   * Tactical is otherwise no longer a device-details data source.
+   */
+  async getAgent(agentId: string): Promise<ApiResponse<any>> {
+    return this.get(`/agents/${agentId}/`);
+  }
+
   async runScript(
     agentId: string,
     scriptData: {


### PR DESCRIPTION
## Summary
- Register open ticket / employee / KB article / device sub-pages (remote shell, remote desktop, file manager) / script run views as the Mingo "open view" via `useTrackOpenView` — matching the existing pattern already used on device/script/customer/policy/query detail pages, so these entities now ride on the sidebar chat's context.
- Remove the `showRightGradient` force-prop from every `TabNavigation` call site so the right-edge shadow only renders when the tab strip actually overflows (was previously always shown regardless of scroll state).
- Fix doubled top padding on the scripts-v2 "Execution History" tab (`TabNavigation` renders as a fragment, so the parent's `gap-6` leaked in on top of the toolbar's own `pt-l`).
- Bump `@flamingo-stack/openframe-frontend-core` to `0.0.358`, which adds:
  - mouse-wheel horizontal scrolling for the tab strip (with native scroll chaining at the edges, `deltaMode` normalization for Firefox, and pinch-zoom passthrough)
  - auto-scrolling the active tab into view on change (instant on first mount, smooth afterward)
  - a height cap + internal scroll for both tooltip components (`FloatingTooltip` and Radix `TooltipContent`) so very long content no longer overflows off-screen

## Test plan
- [ ] Open `/tickets/dialog?id=<id>` and `/settings/employees/details/<id>` and `/knowledge-base/details/<id>` — confirm the entity now shows up in Mingo's context (previously missing)
- [ ] Open a device, then navigate to remote shell / remote desktop / file manager — confirm the device stays in Mingo context on those sub-pages
- [ ] Open a script's "Run Script" page (v1 and v2) — confirm the script stays in Mingo context
- [ ] Load a wide device-details page (e.g. `/devices/details/<id>?tab=software`) — confirm no stray shadow on the right edge of the tab bar when all tabs fit
- [ ] Open scripts-v2 script details → "Execution History" tab — confirm the top spacing matches the "Script Details" tab (no longer doubled)
- [ ] On a narrow window with overflowing tabs: scroll with a plain mouse wheel (works now), trackpad (still works), Shift+wheel (still works); scroll to either edge and confirm the page still scrolls normally (no stuck/hijacked scroll)
- [ ] Deep-link to an off-screen tab (e.g. last tab in a long list) — tab strip should already be positioned correctly on load, no visible slide animation
- [ ] Hover a very long tooltip (e.g. a long device note) — confirm it caps to the viewport height and scrolls internally instead of overflowing off-screen