### PR TITLE
fix: chat background flag for single instance

### DIFF
--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -358,14 +358,17 @@ pub fn run() {
     builder = builder
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             log::info!("single-instance: second launch intercepted");
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
-            #[cfg(target_os = "macos")]
-            {
-                let _ = app.set_activation_policy(ActivationPolicy::Regular);
-                restore_dock_icon();
+            let background_relaunch = argv.iter().any(|arg| arg == "--background");
+            if !background_relaunch {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    let _ = app.set_activation_policy(ActivationPolicy::Regular);
+                    restore_dock_icon();
+                }
             }
             let mut cfg = config_reader::AppConfig::from_args(&argv);
             if !cfg.is_valid() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app relaunch behavior so a normal second launch brings the existing window to the front and focuses it.
  * Background relaunches now avoid opening the window or changing Dock/app visibility, reducing unexpected UI interruptions on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->