### PR TITLE
AI-settings preview name live-update + default avatar fallback

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.352",
+    "@flamingo-stack/openframe-frontend-core": "0.0.359",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.359",
+    "@flamingo-stack/openframe-frontend-core": "0.0.360",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/clients/openframe-chat/src/views/ChatView.tsx
+++ b/clients/openframe-chat/src/views/ChatView.tsx
@@ -77,6 +77,10 @@ export function ChatView() {
   const [previewTicketId, setPreviewTicketId] = useState<string | null>(null);
   const [activeTicketId, setActiveTicketId] = useState<string | null>(null);
   const [isDialogClosed, setIsDialogClosed] = useState(false);
+  // Hovering a quick-action chip previews its full instruction as ghost text in
+  // the composer (the chip label is short); clears on hover-out / select. Aligns
+  // this client with the other chat surfaces' quick-action preview behaviour.
+  const [quickActionPreview, setQuickActionPreview] = useState<string | null>(null);
   const activeTicketIdRef = useRef<string | null>(null);
   activeTicketIdRef.current = activeTicketId;
   const { showWelcome, completeWelcome } = useWelcomeScreen();
@@ -413,11 +417,20 @@ export function ChatView() {
     };
   }, []);
 
+  const isDialogActive = displayMessages.length > 0 || hasMessages || Boolean(dialogId && isLoadingHistory);
+
+  // The quick-action row only renders on the empty initial screen. If it goes
+  // away (a message is sent, or the chat disconnects) while a chip is still
+  // hovered, drop the in-flight preview so ghost text can't leak into the
+  // active composer. Declared before the `showWelcome` early return so the hook
+  // order stays stable (rules-of-hooks).
+  useEffect(() => {
+    if (isDialogActive || isDisconnected) setQuickActionPreview(null);
+  }, [isDialogActive, isDisconnected]);
+
   if (showWelcome) {
     return <WelcomeScreen onGetStarted={completeWelcome} />;
   }
-
-  const isDialogActive = displayMessages.length > 0 || hasMessages || Boolean(dialogId && isLoadingHistory);
 
   return (
     <ChatContainer className="p-[var(--spacing-system-l)] pb-[var(--spacing-system-xs)]">
@@ -513,7 +526,12 @@ export function ChatView() {
                 chips={quickActions.map(action => ({
                   id: action.id,
                   label: action.name,
-                  onSelect: () => handleQuickAction(action.instructions),
+                  onSelect: () => {
+                    setQuickActionPreview(null);
+                    handleQuickAction(action.instructions);
+                  },
+                  onHoverStart: () => setQuickActionPreview(action.instructions),
+                  onHoverEnd: () => setQuickActionPreview(null),
                 }))}
               />
             )}
@@ -523,6 +541,7 @@ export function ChatView() {
               sending={isStreaming || isCompacting}
               awaitingResponse={isTicketPreview || awaitingTechnicianResponse || isAwaitingTechnician}
               placeholder="Enter your request here..."
+              previewText={quickActionPreview ?? undefined}
             />
           </>
         )}

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.359",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.360",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.359",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.359.tgz",
-      "integrity": "sha512-dXCfVKtU+9B6XNn840PQ1b3IR4X9VxCxxmdiNMUYN1WuHt2VAEZQOqmSlCSnQ4tUcrVyfjXn0g4Qn8/UjQpUSw==",
+      "version": "0.0.360",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.360.tgz",
+      "integrity": "sha512-MMnU5twTm7Sw7RRPS6EGQsFUB1G9b552G3L+aPglod7f85kj9+PRJCZjamdvi4yyGtPQ/Anpn9Dhg+pgZB0G8A==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.358",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.359",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.358",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.358.tgz",
-      "integrity": "sha512-fusZdiJJSnU7G1PwdTRPd0znMPmNroR9qOzy58OlbrqUL+lqxx0ejoPi3LCdD0N2vpYOHleXXXewC/hBAnZ4nw==",
+      "version": "0.0.359",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.359.tgz",
+      "integrity": "sha512-dXCfVKtU+9B6XNn840PQ1b3IR4X9VxCxxmdiNMUYN1WuHt2VAEZQOqmSlCSnQ4tUcrVyfjXn0g4Qn8/UjQpUSw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.358",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.359",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -23,7 +23,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.359",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.360",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/ai-settings-previews.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/ai-settings-previews.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { FAE_AVATAR_DATA_URI } from '@flamingo-stack/openframe-frontend-core/assets';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import type { ApplicationTheme } from '../../types/ai-settings';
 import { FaeChatPreview } from './fae-chat-preview';
@@ -26,6 +27,11 @@ export function AiSettingsPreviews({
 }: AiSettingsPreviewsProps) {
   const resolved = useResolvedTheme(theme);
 
+  // Fall back to the library's packaged default Fae avatar when no custom image
+  // is uploaded — same behavior as the chat, which never renders an empty/broken
+  // avatar. Keeps both previews (and their MSP/chat cards) looking complete.
+  const resolvedAvatarUrl = avatarUrl || FAE_AVATAR_DATA_URI;
+
   // Scope the theme to each card, not the wrapper: `.theme-light` flips
   // `--ods-system-greys-background`, so applying it to the container would turn
   // the whole container white too. Per-card scoping keeps the container on the
@@ -35,12 +41,12 @@ export function AiSettingsPreviews({
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 items-start gap-[var(--spacing-system-l)] rounded-md bg-ods-bg">
       <div className={themeClass}>
-        <MeetFaePreview assistantName={assistantName} avatarUrl={avatarUrl} accentColor={accentColor} />
+        <MeetFaePreview assistantName={assistantName} avatarUrl={resolvedAvatarUrl} accentColor={accentColor} />
       </div>
       <div className={themeClass}>
         <FaeChatPreview
           assistantName={assistantName}
-          avatarUrl={avatarUrl}
+          avatarUrl={resolvedAvatarUrl}
           accentColor={accentColor}
           providerName={providerName}
           modelDisplayName={modelDisplayName}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/fae-chat-preview-messages.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/fae-chat-preview-messages.ts
@@ -1,14 +1,14 @@
 import type { Message } from '@flamingo-stack/openframe-frontend-core/components/chat';
 
 /** Static sample conversation for the read-only chat preview. */
-export function buildFaeChatPreviewMessages(avatarUrl?: string): Message[] {
+export function buildFaeChatPreviewMessages(assistantName: string, avatarUrl?: string): Message[] {
   // Fixed time so every bubble shows the same stamp.
   const at = new Date();
   at.setHours(14, 47, 0, 0);
 
   const base = {
     role: 'assistant' as const,
-    name: 'Fae',
+    name: assistantName,
     assistantType: 'fae' as const,
     avatar: avatarUrl ?? null,
     timestamp: at,

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/fae-chat-preview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/fae-chat-preview.tsx
@@ -31,7 +31,7 @@ export function FaeChatPreview({
   providerName = 'google',
   modelDisplayName = 'Google Gemini 3.5',
 }: FaeChatPreviewProps) {
-  const messages = useMemo(() => buildFaeChatPreviewMessages(avatarUrl), [avatarUrl]);
+  const messages = useMemo(() => buildFaeChatPreviewMessages(assistantName, avatarUrl), [assistantName, avatarUrl]);
 
   // Header shows the MSP company name (from tenant info) in place of the tenant
   // domain; falls back to the sample name so the preview still reads well.

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/previews/meet-fae-preview.tsx
@@ -16,9 +16,8 @@ import { getFullImageUrl } from '@/lib/image-url';
 import { useTenantInfo } from '../../../hooks/use-tenant-info';
 
 interface MeetFaePreviewProps {
+  /** Assistant name woven into the copy and avatar — updates live as the user types. */
   assistantName: string;
-  /** Short name woven into the copy (e.g. "Fae"). */
-  shortName?: string;
   avatarUrl?: string;
   accentColor: string;
   mspName?: string;
@@ -33,7 +32,6 @@ interface FeatureRow {
 
 export function MeetFaePreview({
   assistantName,
-  shortName = 'Fae',
   avatarUrl,
   accentColor,
   mspName = 'TechFlow Solutions',
@@ -53,12 +51,12 @@ export function MeetFaePreview({
     {
       icon: WrenchScrewdiverIcon,
       title: 'Try to Fix It Instantly',
-      description: `${shortName} diagnoses common issues like email problems, password resets, slow performance, or connectivity — and resolves them on the spot.`,
+      description: `${assistantName} diagnoses common issues like email problems, password resets, slow performance, or connectivity — and resolves them on the spot.`,
     },
     {
       icon: SignalBroadcast02Icon,
       title: 'Escalate When Needed',
-      description: `If the issue needs hands-on attention, ${shortName} automatically creates a detailed support ticket so your technician knows exactly what's going on.`,
+      description: `If the issue needs hands-on attention, ${assistantName} automatically creates a detailed support ticket so your technician knows exactly what's going on.`,
     },
     {
       icon: ClockCheckIcon,
@@ -85,15 +83,15 @@ export function MeetFaePreview({
             <SquareAvatar
               src={avatarUrl}
               alt={assistantName}
-              fallback={shortName.charAt(0)}
+              fallback={assistantName.charAt(0)}
               size="xl"
               variant="round"
               style={{ backgroundColor: accentColor }}
             />
 
             <p className="max-w-[504px] text-center text-h3 text-ods-text-primary">
-              Meet {shortName}, your AI IT assistant. She fixes what she can right away — and hands off the rest to your
-              technicians.
+              Meet {assistantName}, your AI IT assistant. She fixes what she can right away — and hands off the rest to
+              your technicians.
             </p>
 
             <div className="w-full overflow-hidden rounded-md border border-ods-border bg-ods-bg">

--- a/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/openframe-embeddable-chat-entry.tsx
@@ -133,6 +133,9 @@ export function OpenframeEmbeddableChatEntry({ open, onOpenChange }: OpenframeEm
         id: action.id,
         label: action.name,
         variant: 'outline',
+        // Hover/focus previews the full instruction (what's actually sent) as
+        // ghost text in the composer; the chip `label` is just the short name.
+        prompt: action.instructions,
         onClick: () => {
           void sendInNewDialog(action.instructions);
         },


### PR DESCRIPTION
## Improvements
- MeetFaePreview: drive heading, feature copy and avatar fallback from the live assistantName instead of a hardcoded shortName (never passed), so the preview updates as the user types.
- Fae chat preview: thread assistantName into the sample messages so the bubble author name follows the input too.
- AiSettingsPreviews: fall back to the library-packaged default Fae avatar (FAE_AVATAR_DATA_URI) when no custom image is uploaded — mirrors the chat, covering both global Settings and the per-Customer appearance section.

## Tasks
[Preview Name Not Updating on AI Settings Example Section](https://app.clickup.com/t/9013925967/86ajb91ax)
[Add Fallback to Default AI Assistant Image When No Custom Image Uploaded](https://app.clickup.com/t/9013925967/86ajb88jp)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI settings previews now consistently show the configured assistant name in both the chat and intro preview cards.
  * Preview avatars now fall back to a default icon when no custom avatar is provided, preventing blank images.

* **Bug Fixes**
  * Fixed preview content so it updates correctly when the assistant name changes.
  * Improved avatar display handling to avoid empty or undefined preview states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->