### PR TITLE
fix(mesh-self-heal): restart agent when errors persist past 20m after a .msh refresh

### DIFF
--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -22,6 +22,8 @@ const HEALTHY_MARKER: &str = "Received CoreOk from server";
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
 /// How long continuously stuck before we act.
 const STUCK_DURATION: Duration = Duration::from_secs(10 * 60);
+/// How long continuously failing (after a .msh refresh) before we restart the agent outright.
+const RESTART_DURATION: Duration = Duration::from_secs(20 * 60);
 /// Minimum wait between heal attempts (success or no-op), so a server-side outage can't spin.
 const NOOP_HEAL_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 /// Timeout for the /generate-msh fetch so an unresponsive server can't block the heal loop.
@@ -84,6 +86,7 @@ impl MeshSelfHealService {
 
         let mut offset: u64 = 0;
         let mut stuck_since: Option<Instant> = None;
+        let mut error_since: Option<Instant> = None;
         let mut last_heal_attempt: Option<Instant> = None;
 
         loop {
@@ -96,15 +99,27 @@ impl MeshSelfHealService {
                     for line in &lines {
                         if line.contains(HEALTHY_MARKER) {
                             stuck_since = None;
+                            error_since = None;
                             last_heal_attempt = None;
                         } else if line.contains(FAILURE_MARKER) {
                             stuck_since.get_or_insert_with(Instant::now);
+                            error_since.get_or_insert_with(Instant::now);
                         }
                     }
                 }
                 Err(e) => {
                     debug!("mesh self-heal: cannot read {}: {e}", log_path.display());
                 }
+            }
+
+            // Errors persisted past RESTART_DURATION after a .msh refresh — restart the agent outright.
+            let persistent = error_since.map_or(false, |t| t.elapsed() >= RESTART_DURATION);
+            if persistent && last_heal_attempt.is_some() && !self.tool_run_manager.is_updating(MESH_TOOL_ID).await {
+                warn!("meshcentral-agent still failing after {}s and a .msh refresh — restarting agent", RESTART_DURATION.as_secs());
+                if let Err(e) = self.restart_agent().await {
+                    error!("mesh self-heal restart failed: {e:#}");
+                }
+                error_since = None;
             }
 
             let stuck = stuck_since.map_or(false, |t| t.elapsed() >= STUCK_DURATION);
@@ -191,13 +206,18 @@ impl MeshSelfHealService {
         tokio::fs::write(&tmp_path, body.as_bytes()).await?;
         tokio::fs::rename(&tmp_path, &msh_path).await?;
 
+        self.restart_agent().await?;
+        Ok(true)
+    }
+
+    async fn restart_agent(&self) -> Result<()> {
         self.tool_kill.stop_tool(MESH_TOOL_ID).await?;
         if let Some(service_name) = self.mesh_service_name().await? {
             if let Err(e) = system_service::start_service(&service_name).await {
                 debug!("mesh self-heal: start_service({service_name}) — likely already running: {e}");
             }
         }
-        Ok(true)
+        Ok(())
     }
 
     async fn current_msh_missing_serverid(&self) -> bool {


### PR DESCRIPTION
## What

Adds a fallback restart to the mesh self-heal watcher (`clients/openframe-client/src/services/mesh_self_heal_service.rs`).

If meshagent control-channel failures persist for more than **`RESTART_DURATION` (20m)** and a `.msh` heal has already been attempted since the last healthy state, the watcher restarts the meshagent the same way `try_heal` already does (`stop_tool` + `start_service`).

## Why

The existing heal path only restarts the agent when `/generate-msh` returns a **changed** `MeshID`/`ServerID`. When the `.msh` is already current — e.g. a server-side issue or a wedged agent process — `try_heal` takes no action, so a persistently disconnected agent never recovers. This fallback kicks the process after we've given the `.msh` remediation a chance.

## How

- New `error_since` timer tracks continuous-failure start (armed on `FAILURE_MARKER`, cleared on `HEALTHY_MARKER`). It's independent of `stuck_since` (which resets after each heal) and of `last_heal_attempt` (the 60m heal cooldown clock), so the restart cadence doesn't entangle with the heal cadence.
- Restart gate: `error_since >= 20m` **and** `last_heal_attempt.is_some()` (a heal was attempted since last healthy) **and** not mid-update. `error_since` resets on restart, so restarts recur at most once per 20m failure window.
- Factored the `stop_tool` + `start_service` sequence into `restart_agent()`, reused by both `try_heal` and the new fallback.

## Testing

- `cargo build` passes (no new warnings in the touched file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the mesh self-heal flow by detecting repeated failures and triggering a full agent restart when recovery does not complete in time.
  * Preserved restart behavior after a successful heal refresh, helping the agent recover more consistently from persistent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->