### PR TITLE
fix(): move worktime page

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/settings-hub.tsx
@@ -2,7 +2,6 @@
 
 import { PageLayout } from '@flamingo-stack/openframe-frontend-core';
 import {
-  ClockHistoryIcon,
   CreditCardIcon,
   Hierarchy02Icon,
   Logout01Icon,
@@ -52,12 +51,6 @@ const SETTINGS_NAV_ITEMS = [
     icon: UsersGroupIcon,
     title: 'Employees',
     description: 'Manage employee accounts, roles, and permissions',
-  },
-  {
-    href: '/settings/worktime',
-    icon: ClockHistoryIcon,
-    title: 'Worktime',
-    description: 'Hours logged across your team',
   },
   {
     href: '/settings/api-keys',

--- a/openframe/services/openframe-frontend/src/app/(app)/worktime/components/worktime-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/worktime/components/worktime-view.tsx
@@ -4,11 +4,8 @@ import { PlusCircleIcon } from '@flamingo-stack/openframe-frontend-core/componen
 import { PageLayout } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useState } from 'react';
 import { WorkTimeTable } from '@/app/components/shared/work-time-table';
-import { useSafeBack } from '@/app/hooks/use-safe-back';
 
 export function WorktimeView() {
-  const handleBack = useSafeBack('/settings');
-
   const [addWorkTimeOpen, setAddWorkTimeOpen] = useState(false);
 
   const actions = [
@@ -25,7 +22,6 @@ export function WorktimeView() {
       title="Worktime"
       actions={actions}
       actionsVariant="primary-buttons"
-      backButton={{ label: 'Back', onClick: handleBack }}
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
     >
       <WorkTimeTable

--- a/openframe/services/openframe-frontend/src/app/(app)/worktime/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/worktime/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic';
 
-import { WorktimeView } from '../components/worktime-view';
+import { WorktimeView } from './components/worktime-view';
 
 export default function WorktimePage() {
   return <WorktimeView />;

--- a/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
+++ b/openframe/services/openframe-frontend/src/lib/navigation-config.tsx
@@ -4,6 +4,7 @@ import {
   BracketCurlyIcon,
   ChartDonutIcon,
   ClipboardListIcon,
+  ClockHistoryIcon,
   IdCardIcon,
   MonitorIcon,
   QuestionCircleIcon,
@@ -113,6 +114,16 @@ export const getNavigationItems = (
         isActive: pathname.startsWith('/mingo'),
       });
     }
+  }
+
+  if (featureFlags.timeTracker.enabled()) {
+    baseItems.push({
+      id: 'worktime',
+      label: 'Worktime',
+      icon: <ClockHistoryIcon size={24} />,
+      path: '/worktime',
+      isActive: pathname.startsWith('/worktime'),
+    });
   }
 
   baseItems.push({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Worktime** item to the main sidebar for accounts with time tracking enabled.
* **Bug Fixes**
  * Removed the Worktime entry from Settings to avoid duplicate navigation.
  * Updated the Worktime page layout to no longer show a back button, simplifying the screen.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->