### PR TITLE
Admin chat: sync Admin chat model row after AI settings change

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/page.tsx
@@ -140,11 +140,19 @@ export default function Mingo() {
     chatInputRef.current?.clear();
   }, [activeDialogId]);
 
+  // Sync the displayed model to the global AI config. Runs on first load
+  // (seeding `currentModel`) and again whenever the global config changes — e.g.
+  // the user picks a new provider/model on /settings/ai-settings — so the model
+  // row under the composer reflects the new selection immediately instead of
+  // only after the next request refines it. React Query's structural sharing
+  // keeps `initialAiModel` referentially stable while its value is unchanged, so
+  // this only fires on a real config change and doesn't clobber per-dialog
+  // metadata refinements (handleMetadataUpdate) in between.
   useEffect(() => {
-    if (initialAiModel && !currentModel) {
+    if (initialAiModel) {
       setCurrentModel(initialAiModel);
     }
-  }, [initialAiModel, currentModel]);
+  }, [initialAiModel]);
 
   // The model is global config; per-dialog metadata only refines it. Falling
   // back to `initialAiModel` means we never have to null `currentModel` on

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-update-ai-configuration.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-update-ai-configuration.ts
@@ -2,6 +2,7 @@
 
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AI_MODEL_QUERY_KEY } from '@/app/hooks/use-ai-model';
 import { apiClient } from '@/lib/api-client';
 import type { AIProvider } from '../types/ai-settings';
 
@@ -30,7 +31,7 @@ export function useUpdateAiConfiguration() {
       // Refresh the cached active model so the Mingo composer's model row picks
       // up the new provider/model immediately, instead of only after the next
       // chat request refines it via streamed metadata.
-      queryClient.invalidateQueries({ queryKey: ['ai-configuration-model'] });
+      queryClient.invalidateQueries({ queryKey: AI_MODEL_QUERY_KEY });
     },
     onError: error => {
       toast({

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-update-ai-configuration.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/hooks/use-update-ai-configuration.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import type { AIProvider } from '../types/ai-settings';
 
@@ -17,6 +17,7 @@ interface UpdateAiConfigurationInput {
  */
 export function useUpdateAiConfiguration() {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (input: UpdateAiConfigurationInput) => {
@@ -24,6 +25,12 @@ export function useUpdateAiConfiguration() {
       if (!response.ok) {
         throw new Error(response.error || 'Failed to update AI configuration');
       }
+    },
+    onSuccess: () => {
+      // Refresh the cached active model so the Mingo composer's model row picks
+      // up the new provider/model immediately, instead of only after the next
+      // chat request refines it via streamed metadata.
+      queryClient.invalidateQueries({ queryKey: ['ai-configuration-model'] });
     },
     onError: error => {
       toast({

--- a/openframe/services/openframe-frontend/src/app/hooks/use-ai-model.ts
+++ b/openframe/services/openframe-frontend/src/app/hooks/use-ai-model.ts
@@ -22,8 +22,10 @@ async function fetchAiConfiguration(): Promise<AiModel | null> {
   return { provider: response.data.provider, displayName: response.data.displayName };
 }
 
+export const AI_MODEL_QUERY_KEY = ['ai-configuration-model'] as const;
+
 const AI_MODEL_QUERY_OPTIONS = {
-  queryKey: ['ai-configuration-model'],
+  queryKey: AI_MODEL_QUERY_KEY,
   queryFn: fetchAiConfiguration,
   staleTime: 5 * 60 * 1000,
   refetchOnWindowFocus: false,


### PR DESCRIPTION
## Improvements

- The current-model row in Mingo AI's Admin chat only updated from streamed request metadata, so changing Provider Model / LLM Provider in /settings/ai-settings had no effect until the next chat request. 
- Invalidate the active-model query on config save and re-sync the composer's displayed model whenever the global config changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI model selection now updates immediately when the default model changes, keeping the active model in sync with the latest setting.
  * Saving AI configuration now refreshes the displayed configuration so the new provider/model appears without needing a manual reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->