### PR TITLE
auth: disable real-time email validation on registration

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { isSaasSharedMode } from '@/lib/app-mode';
 import { authApiClient, SAAS_DOMAIN_SUFFIX } from '@/lib/auth-api-client';
 import { AUTH_ERROR_CODE } from '../constants/auth-error-codes';
-import { useDomainAvailability, useEmailAvailability } from '../hooks/use-registration-availability';
+import { useDomainAvailability } from '../hooks/use-registration-availability';
 import { ForgotPasswordModal } from './forgot-password-modal';
 
 interface AuthChoiceSectionProps {
@@ -41,8 +41,8 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
   const isOrgEmailValid = emailRegex.test(orgEmail.trim());
   const isSignInEmailValid = emailRegex.test(signInEmail.trim());
 
-  // Real-time availability checks (debounced).
-  const emailStatus = useEmailAvailability(orgEmail);
+  // Real-time domain availability check (debounced). Real-time email validation is
+  // temporarily disabled — pending a dedicated BE endpoint for email registration checks.
   const { status: domainStatus, suggestions: liveDomainSuggestions } = useDomainAvailability(
     domain,
     orgName,
@@ -54,9 +54,6 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
 
   const handleCreateOrganization = async () => {
     if (!orgName.trim() || !isOrgNameValid || !isOrgEmailValid) return;
-
-    // Real-time check already flagged the email as registered — block submit.
-    if (emailStatus === 'taken') return;
 
     if (isSaasShared) {
       if (!accessCode.trim()) {
@@ -218,15 +215,6 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
               {orgEmail.trim() && !isOrgEmailValid && (
                 <p className="text-xs text-ods-error mt-1">Enter a valid email address</p>
               )}
-              {isOrgEmailValid && emailStatus === 'checking' && (
-                <p className="text-xs text-ods-text-secondary mt-1">Checking availability…</p>
-              )}
-              {isOrgEmailValid && emailStatus === 'taken' && (
-                <p className="text-xs text-ods-error mt-1">This email is already registered. Sign in instead.</p>
-              )}
-              {isOrgEmailValid && emailStatus === 'available' && (
-                <p className="text-xs text-ods-success mt-1">Email is available</p>
-              )}
             </div>
             <div className="flex-1 flex flex-col gap-1">
               <Label>Organization Name</Label>
@@ -359,8 +347,6 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
                 disabled={
                   !orgName.trim() ||
                   !isOrgEmailValid ||
-                  emailStatus === 'taken' ||
-                  emailStatus === 'checking' ||
                   (isSaasShared && (!domain.trim() || !accessCode.trim())) ||
                   (isSaasShared && (domainStatus === 'taken' || domainStatus === 'checking')) ||
                   isLoading ||

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-registration-availability.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-registration-availability.ts
@@ -6,44 +6,10 @@ import { authApiClient, SAAS_DOMAIN_SUFFIX } from '@/lib/auth-api-client';
 
 export type AvailabilityStatus = 'idle' | 'checking' | 'available' | 'taken' | 'error';
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-/** Debounced check of whether an email is already registered. Runs only on valid email format. */
-export function useEmailAvailability(email: string, delay = 400): AvailabilityStatus {
-  const debounced = useDebounce(email.trim(), delay);
-  const [status, setStatus] = useState<AvailabilityStatus>('idle');
-
-  useEffect(() => {
-    if (!debounced || !EMAIL_REGEX.test(debounced)) {
-      setStatus('idle');
-      return;
-    }
-
-    let cancelled = false;
-    setStatus('checking');
-
-    authApiClient
-      .discoverTenants(debounced)
-      .then(res => {
-        if (cancelled) return;
-        if (!res.ok || !res.data) {
-          setStatus('error');
-          return;
-        }
-        const { has_existing_accounts } = res.data as { has_existing_accounts?: boolean };
-        setStatus(has_existing_accounts ? 'taken' : 'available');
-      })
-      .catch(() => {
-        if (!cancelled) setStatus('error');
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [debounced]);
-
-  return status;
-}
+// NOTE: real-time email availability is temporarily unimplemented. It previously used
+// `discoverTenants`, which flags any email that belongs to a tenant — too broad to gate
+// registration. A dedicated BE endpoint for "is this email registered" is pending; the
+// email hook will be reintroduced against it.
 
 /** Debounced check of subdomain availability; returns status plus suggested alternatives when taken. */
 export function useDomainAvailability(


### PR DESCRIPTION
## Description
Temporarily remove the debounced email-already-registered check and its inline states from the Create Organization form, and stop gating the Continue button on email status. The previous check used discoverTenants, which flags any email tied to a tenant — too broad to block registration.

Domain availability checking is unchanged. A dedicated BE endpoint for email registration checks is pending; the email hook will be reintroduced against it.


## Task
[Add Real-Time Validation for Email and Domain During Registration](https://app.clickup.com/t/9013925967/86ajat1v7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed real-time email availability checks from the registration flow, avoiding misleading “checking/taken/available” messages.
  * The continue/submit button now validates using organization, email, domain, access code, and loading states without relying on email availability status.
  * Domain availability checking and shared-mode suggestions remain available as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->