### PR TITLE
fix(): remote shell path

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-menu-items.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-menu-items.tsx
@@ -28,7 +28,7 @@ export interface DeviceMenuItemContext {
   iconSize?: string;
   /** Controls Remote Shell rendering:
    *   - `true`  → Windows submenu (CMD / PowerShell)
-   *   - `false` → plain link with `?shellType=bash`
+   *   - `false` → plain link with `&shellType=bash`
    *   - `undefined` → plain link without `shellType` param (Tickets style) */
   isWindows?: boolean;
   /** Adds an "open in new tab" arrow icon-action to each item. */
@@ -85,7 +85,7 @@ function buildRemoteShellItem(ctx: DeviceMenuItemContext): ActionsMenuItem {
       type: 'submenu',
       disabled,
       submenu: WINDOWS_SHELLS.map(s => {
-        const href = `${baseHref}?shellType=${s.id}`;
+        const href = `${baseHref}&shellType=${s.id}`;
         return {
           id: s.id,
           label: s.label,
@@ -98,7 +98,7 @@ function buildRemoteShellItem(ctx: DeviceMenuItemContext): ActionsMenuItem {
     };
   }
 
-  const href = ctx.isWindows === false ? `${baseHref}?shellType=bash` : baseHref;
+  const href = ctx.isWindows === false ? `${baseHref}&shellType=bash` : baseHref;
   return {
     id: 'remote-shell',
     label: 'Remote Shell',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Remote Shell links so the shell type is appended correctly to device URLs when an ID is already present.
  * Improved shell menu behavior for Windows options and the default shell choice on other platforms.
  * Updated related wording to match the corrected link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->