### PR TITLE
Settings Page: change Mingo ai chat tab icon / update loading state

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.360",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.371",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.360",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.360.tgz",
-      "integrity": "sha512-MMnU5twTm7Sw7RRPS6EGQsFUB1G9b552G3L+aPglod7f85kj9+PRJCZjamdvi4yyGtPQ/Anpn9Dhg+pgZB0G8A==",
+      "version": "0.0.371",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.371.tgz",
+      "integrity": "sha512-U763SuD7U6MuL0NPrAwwEuWE3NwlspRHnYkzSRs02Tby+eRhO1mhXwNQVeLZeLBeD8iT3/Sk7uV5mnwmrgRFdQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.360",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.371",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-tabs.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { MingoIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
-import { ChatsIcon, ShieldCheckIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  ChatsIcon,
+  MingoMonochromeIcon,
+  ShieldCheckIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { type TabItem, TabNavigation } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { ReactNode } from 'react';
 import { featureFlags } from '@/lib/feature-flags';
@@ -11,7 +14,7 @@ export type AiSettingsTabId = (typeof AI_SETTINGS_TAB_IDS)[number];
 
 export const AI_SETTINGS_TABS: TabItem[] = [
   { id: 'customer', label: 'Customer AI Assistant', icon: ChatsIcon },
-  { id: 'mingo', label: 'Mingo AI Chat', icon: MingoIcon },
+  { id: 'mingo', label: 'Mingo AI Chat', icon: MingoMonochromeIcon },
   { id: 'guardrails', label: 'Guardrails', icon: ShieldCheckIcon },
 ];
 

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, CompactPageLoader } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { Button, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback, useState } from 'react';
 import {
@@ -157,35 +157,35 @@ export function AiSettings() {
     onSave: handleSave,
   });
 
-  if (isLoading) {
-    return (
-      <AiSettingsLayout actions={actions}>
-        <CompactPageLoader />
-      </AiSettingsLayout>
-    );
-  }
-
-  // Failed to load and nothing cached: show an error + retry instead of editable
-  // defaults, so the user can't accidentally overwrite real settings on save.
-  if (hasLoadError) {
-    return (
-      <AiSettingsLayout>
-        <div className="flex flex-col items-start gap-[var(--spacing-system-m)]">
-          <p className="text-ods-text-secondary">
-            Couldn't load AI settings. The service may be temporarily unavailable.
-          </p>
-          <Button variant="outline" onClick={refetchActive}>
-            Retry
-          </Button>
-        </div>
-      </AiSettingsLayout>
-    );
-  }
-
   return (
-    <AiSettingsLayout actions={actions} mobileBottomActions={isEditMode}>
+    <AiSettingsLayout actions={hasLoadError ? undefined : actions} mobileBottomActions={isEditMode}>
       <AiSettingsTabs activeTab={effectiveTab} onTabChange={handleTabChange}>
         {activeId => {
+          // Keep the tab bar visible; show skeletons while the tab config loads.
+          if (isLoading) {
+            return (
+              <div className="flex flex-col gap-[var(--spacing-system-l)]">
+                <Skeleton className="h-20 w-full rounded-md" />
+                <Skeleton className="h-64 w-full rounded-md" />
+              </div>
+            );
+          }
+
+          // Load failed with nothing cached: error + retry instead of editable
+          // defaults, so real settings can't be overwritten on save.
+          if (hasLoadError) {
+            return (
+              <div className="flex flex-col items-start gap-[var(--spacing-system-m)]">
+                <p className="text-ods-text-secondary">
+                  Couldn't load AI settings. The service may be temporarily unavailable.
+                </p>
+                <Button variant="outline" onClick={refetchActive}>
+                  Retry
+                </Button>
+              </div>
+            );
+          }
+
           if (activeId === 'guardrails') {
             return <GuardrailsTab isEditMode={isEditMode} onSaved={() => setIsEditMode(false)} />;
           }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
@@ -157,8 +157,15 @@ export function AiSettings() {
     onSave: handleSave,
   });
 
+  // Disabled (not hidden) while loading to avoid a flash; hidden on load error.
+  const headerActions = hasLoadError
+    ? undefined
+    : isLoading
+      ? actions.map(action => ({ ...action, disabled: true }))
+      : actions;
+
   return (
-    <AiSettingsLayout actions={isLoading || hasLoadError ? undefined : actions} mobileBottomActions={isEditMode}>
+    <AiSettingsLayout actions={headerActions} mobileBottomActions={isEditMode}>
       <AiSettingsTabs activeTab={effectiveTab} onTabChange={handleTabChange}>
         {activeId => {
           // Keep the tab bar visible; show skeletons while the tab config loads.

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
@@ -158,7 +158,7 @@ export function AiSettings() {
   });
 
   return (
-    <AiSettingsLayout actions={hasLoadError ? undefined : actions} mobileBottomActions={isEditMode}>
+    <AiSettingsLayout actions={isLoading || hasLoadError ? undefined : actions} mobileBottomActions={isEditMode}>
       <AiSettingsTabs activeTab={effectiveTab} onTabChange={handleTabChange}>
         {activeId => {
           // Keep the tab bar visible; show skeletons while the tab config loads.


### PR DESCRIPTION
## Description
Update Mingo AI Chat tab icon and remove page-level Loading state on AI Settings
## Improvements
- Replace the Mingo AI Chat tab icon with MingoMonochromeIcon from the core library. 
- Remove the full-page loader (icon + "Loading" text) shown on page enter and tab switch. Render the tab bar immediately and show skeletons in the tab content while data loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the AI Settings page with inline loading placeholders for a smoother experience while content loads.
  * Updated the AI tab icon to a newer monochrome style for a more consistent look.

* **Bug Fixes**
  * Error states in AI Settings now display a clearer retry message within the page instead of replacing the whole layout.
  * Actions are hidden when loading errors occur, avoiding confusing empty controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->