### PR TITLE
Customers page: fix AI appearance loading state, deep-link default appearance editing, persist reset on confirm

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
@@ -15,6 +15,7 @@ import {
   Skeleton,
   TabSelector,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
@@ -52,7 +53,7 @@ export interface CustomerAppearanceHandle {
  * It owns no Save button — the page's "Save Customer" drives persistence via the
  * `validate()` / `commit()` ref handle. "Use the default AI-Assistant appearance"
  * on means the customer inherits the tenant default (an existing override is
- * removed on save via resetClientView); off edits a per-customer override.
+ * deleted immediately once the user confirms); off edits a per-customer override.
  */
 export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle, CustomerAiAssistantAppearanceProps>(
   function CustomerAiAssistantAppearance({ organizationId }, ref) {
@@ -65,7 +66,8 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
     // Opt out of auto-invalidation: commit() refetches once after the avatar
     // upload, so the preview never flickers the pre-upload image.
     const { update } = useUpdateClientView(organizationId, { invalidateOnSuccess: false });
-    const { reset } = useResetClientView(organizationId);
+    const { reset, isPending: isResetting } = useResetClientView(organizationId);
+    const { toast } = useToast();
 
     const [useDefault, setUseDefault] = useState(true);
     const [confirmResetOpen, setConfirmResetOpen] = useState(false);
@@ -125,8 +127,7 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
         setUseDefault(false);
         return;
       }
-      // Switching to default: confirm before dropping an existing override (the
-      // actual delete happens on "Save Customer").
+      // Switching to default: confirm first; the override is deleted on confirm.
       if (orgView) {
         setConfirmResetOpen(true);
         return;
@@ -249,12 +250,28 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
           open={confirmResetOpen}
           onOpenChange={setConfirmResetOpen}
           title="Use default appearance?"
-          description="The custom AI-Assistant appearance for this customer will be removed when you save. They will use the tenant default instead."
+          description="The custom AI-Assistant appearance for this customer will be removed. They will use the tenant default instead."
           confirmLabel="Use default"
           variant="destructive"
-          onConfirm={() => {
-            setUseDefault(true);
-            setConfirmResetOpen(false);
+          isPending={isResetting}
+          pendingLabel="Removing..."
+          onConfirm={async () => {
+            try {
+              await reset();
+              setUseDefault(true);
+              setConfirmResetOpen(false);
+              toast({
+                title: 'Saved',
+                description: 'Customer now uses the default AI-Assistant appearance',
+                variant: 'success',
+              });
+            } catch (err) {
+              toast({
+                title: 'Save failed',
+                description: err instanceof Error ? err.message : 'Failed to remove the custom appearance',
+                variant: 'destructive',
+              });
+            }
           }}
         />
       </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/ai-assistant-appearance/customer-ai-assistant-appearance.tsx
@@ -10,9 +10,9 @@ import {
   Button,
   CheckboxBlock,
   ColorPickerInput,
-  CompactPageLoader,
   ImageUploader,
   Input,
+  Skeleton,
   TabSelector,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -140,7 +140,7 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
         <Button
           type="button"
           variant="outline"
-          onClick={() => router.push('/settings/ai-settings')}
+          onClick={() => router.push('/settings/ai-settings?tab=customer&edit=true')}
           className="shrink-0"
         >
           <PenEditIcon className="size-5 text-ods-text-secondary" />
@@ -164,7 +164,7 @@ export const CustomerAiAssistantAppearance = forwardRef<CustomerAppearanceHandle
         <div className="flex flex-col gap-[var(--spacing-system-l)]">
           {header}
           {toggle}
-          <CompactPageLoader />
+          <Skeleton className="h-64 w-full rounded-md" />
         </div>
       );
     }

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-custom-ai-assistant-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-custom-ai-assistant-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CompactPageLoader, EntityImage } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { EntityImage, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { AiSettingsPreviews } from '@/app/(app)/settings/ai-settings/components/previews/ai-settings-previews';
 import { useClientView } from '@/app/(app)/settings/ai-settings/hooks/use-client-view';
@@ -24,7 +24,12 @@ export function CustomerCustomAiAssistantTab({ organizationId }: CustomerCustomA
   const { view, isLoading } = useClientView(organizationId);
 
   if (isLoading) {
-    return <CompactPageLoader />;
+    return (
+      <div className="flex flex-col gap-[var(--spacing-system-l)]">
+        <Skeleton className="h-40 w-full rounded-md" />
+        <Skeleton className="h-64 w-full rounded-md" />
+      </div>
+    );
   }
 
   // The tab is only mounted when an override exists, but guard defensively.

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/ai-settings/components/ai-settings-view.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useSearchParams } from 'next/navigation';
 import { useCallback, useState } from 'react';
 import {
   useAdminAiConfig,
@@ -34,13 +35,19 @@ const FORM_ID_BY_TAB: Record<AiSettingsTabId, string> = {
 
 export function AiSettings() {
   const { toast } = useToast();
+  const searchParams = useSearchParams();
 
   // Tabs are feature-flag gated; default to the first one that's visible.
   const visibleTabs = getVisibleAiSettingsTabs();
   const firstTabId = (visibleTabs[0]?.id as AiSettingsTabId | undefined) ?? 'guardrails';
 
-  const [activeTab, setActiveTab] = useState<AiSettingsTabId>(firstTabId);
-  const [isEditMode, setIsEditMode] = useState(false);
+  // Deep-link support: `?tab=<id>&edit=true` opens a tab in edit mode
+  // (e.g. "Edit Default Appearance" on the customer edit page).
+  const tabParam = searchParams.get('tab') as AiSettingsTabId | null;
+  const initialTab = tabParam && visibleTabs.some(tab => tab.id === tabParam) ? tabParam : firstTabId;
+
+  const [activeTab, setActiveTab] = useState<AiSettingsTabId>(initialTab);
+  const [isEditMode, setIsEditMode] = useState(searchParams.get('edit') === 'true');
 
   // Fall back to a visible tab if the active one is hidden by a flag.
   const effectiveTab: AiSettingsTabId = visibleTabs.some(tab => tab.id === activeTab) ? activeTab : firstTabId;


### PR DESCRIPTION
## Description
- Replace the full-page loader (icon + "Loading" text) with skeletons in the "AI-Assistant Appearance" block on "/customers/edit" and in the "Custom AI Assistant" tab on customer details.
- Make "Edit Default Appearance" open "/settings/ai-settings" with the Customer AI Assistant tab already in edit mode (no extra modal).
- When the user confirms "Use default appearance?", delete the custom appearance immediately with pending state and toast feedback "Save Customer".
