### PR TITLE
fix: nats consumer reconect

### DIFF
--- a/clients/openframe-client/src/config/update_config.rs
+++ b/clients/openframe-client/src/config/update_config.rs
@@ -18,5 +18,6 @@ pub const RECONNECTION_DELAY_MS: u64 = 5000; // 5 seconds
 
 // NATS message settings
 pub const CONSUMER_ACK_WAIT_SECS: u64 = 120;
+pub const CONSUMER_IDLE_HEARTBEAT_SECS: u64 = 30;
 pub const CONSUMER_MAX_DELIVER: i64 = 10; // Maximum delivery attempts
 pub const UNINSTALL_CONSUMER_MAX_DELIVER: i64 = 20; // Larger budget: uninstall may defer behind a long install holding the tool lock

--- a/clients/openframe-client/src/listener/openframe_client_update_listener.rs
+++ b/clients/openframe-client/src/listener/openframe_client_update_listener.rs
@@ -8,6 +8,7 @@ use crate::config::update_config::{
     CONSUMER_CYCLE_PAUSE_MS,
     RECONNECTION_DELAY_MS,
     CONSUMER_ACK_WAIT_SECS,
+    CONSUMER_IDLE_HEARTBEAT_SECS,
     CONSUMER_MAX_DELIVER,
 };
 use async_nats::jetstream::consumer::PushConsumer;
@@ -87,8 +88,8 @@ impl OpenFrameClientUpdateListener {
             let message = match msg_result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Failed to receive message: {:#}", e);
-                    continue;
+                    error!("Message stream error, recreating consumer: {:#}", e);
+                    return Err(anyhow::anyhow!("Message stream error: {}", e));
                 }
             };
 
@@ -200,6 +201,7 @@ impl OpenFrameClientUpdateListener {
             deliver_subject,
             durable_name: Some(durable_name),
             ack_wait: Duration::from_secs(CONSUMER_ACK_WAIT_SECS),
+            idle_heartbeat: Duration::from_secs(CONSUMER_IDLE_HEARTBEAT_SECS),
             deliver_policy: DeliverPolicy::New,
             max_deliver: CONSUMER_MAX_DELIVER,
             ..Default::default()

--- a/clients/openframe-client/src/listener/tool_agent_update_listener.rs
+++ b/clients/openframe-client/src/listener/tool_agent_update_listener.rs
@@ -8,6 +8,7 @@ use crate::config::update_config::{
     CONSUMER_CYCLE_PAUSE_MS,
     RECONNECTION_DELAY_MS,
     CONSUMER_ACK_WAIT_SECS,
+    CONSUMER_IDLE_HEARTBEAT_SECS,
     CONSUMER_MAX_DELIVER,
 };
 use async_nats::jetstream::consumer::PushConsumer;
@@ -87,8 +88,8 @@ impl ToolAgentUpdateListener {
             let message = match msg_result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Failed to receive message: {:#}", e);
-                    continue;
+                    error!("Message stream error, recreating consumer: {:#}", e);
+                    return Err(anyhow::anyhow!("Message stream error: {}", e));
                 }
             };
 
@@ -208,6 +209,7 @@ impl ToolAgentUpdateListener {
             deliver_subject,
             durable_name: Some(durable_name),
             ack_wait: Duration::from_secs(CONSUMER_ACK_WAIT_SECS),
+            idle_heartbeat: Duration::from_secs(CONSUMER_IDLE_HEARTBEAT_SECS),
             deliver_policy: DeliverPolicy::New,
             max_deliver: CONSUMER_MAX_DELIVER,
             ..Default::default()

--- a/clients/openframe-client/src/listener/tool_installation_message_listener.rs
+++ b/clients/openframe-client/src/listener/tool_installation_message_listener.rs
@@ -8,6 +8,7 @@ use crate::config::update_config::{
     CONSUMER_CYCLE_PAUSE_MS,
     RECONNECTION_DELAY_MS,
     CONSUMER_ACK_WAIT_SECS,
+    CONSUMER_IDLE_HEARTBEAT_SECS,
     CONSUMER_MAX_DELIVER,
 };
 use async_nats::jetstream::consumer::PushConsumer;
@@ -86,8 +87,8 @@ impl ToolInstallationMessageListener {
             let message = match msg_result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Failed to receive message: {:#}", e);
-                    continue;
+                    error!("Message stream error, recreating consumer: {:#}", e);
+                    return Err(anyhow::anyhow!("Message stream error: {}", e));
                 }
             };
 
@@ -200,6 +201,7 @@ impl ToolInstallationMessageListener {
             deliver_subject,
             durable_name: Some(durable_name),
             ack_wait: Duration::from_secs(CONSUMER_ACK_WAIT_SECS),
+            idle_heartbeat: Duration::from_secs(CONSUMER_IDLE_HEARTBEAT_SECS),
             max_deliver: CONSUMER_MAX_DELIVER,
             ..Default::default()
         }

--- a/clients/openframe-client/src/listener/tool_uninstall_message_listener.rs
+++ b/clients/openframe-client/src/listener/tool_uninstall_message_listener.rs
@@ -11,6 +11,7 @@ use crate::config::update_config::{
     CONSUMER_CYCLE_PAUSE_MS,
     RECONNECTION_DELAY_MS,
     CONSUMER_ACK_WAIT_SECS,
+    CONSUMER_IDLE_HEARTBEAT_SECS,
     UNINSTALL_CONSUMER_MAX_DELIVER,
 };
 use async_nats::jetstream::consumer::PushConsumer;
@@ -90,8 +91,8 @@ impl ToolUninstallMessageListener {
             let message = match msg_result {
                 Ok(msg) => msg,
                 Err(e) => {
-                    error!("Failed to receive message: {:#}", e);
-                    continue;
+                    error!("Message stream error, recreating consumer: {:#}", e);
+                    return Err(anyhow::anyhow!("Message stream error: {}", e));
                 }
             };
 
@@ -233,6 +234,7 @@ impl ToolUninstallMessageListener {
             deliver_subject,
             durable_name: Some(durable_name),
             ack_wait: Duration::from_secs(CONSUMER_ACK_WAIT_SECS),
+            idle_heartbeat: Duration::from_secs(CONSUMER_IDLE_HEARTBEAT_SECS),
             max_deliver: UNINSTALL_CONSUMER_MAX_DELIVER,
             ..Default::default()
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heartbeat-based consumer settings to improve listener responsiveness and stability.
* **Bug Fixes**
  * Listener streams now recover more reliably when message consumption fails.
  * On stream errors, consumers are recreated instead of continuing in a broken state.
  * Reconnect flow now triggers automatically after a consumer failure, helping restore updates faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->