### PR TITLE
Tickets page: bump openframe-frontend-core to 0.0.372, drop modal width-cap workaround

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.371",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.372",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.371",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.371.tgz",
-      "integrity": "sha512-U763SuD7U6MuL0NPrAwwEuWE3NwlspRHnYkzSRs02Tby+eRhO1mhXwNQVeLZeLBeD8iT3/Sk7uV5mnwmrgRFdQ==",
+      "version": "0.0.372",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.372.tgz",
+      "integrity": "sha512-iGYV+VGql1msgsbo8MqQVaO2/KnC2R3Wdi/yD68MwkfYcwuejJOi+Nc/x6fSH5RzcE8iDLYvA4//ON8IQG8HWA==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.371",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.372",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-filter-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/tickets-filter-modal.tsx
@@ -51,8 +51,6 @@ export function TicketsFilterModal({
       isOpen={isOpen}
       onClose={onClose}
       title="Filter Tickets"
-      // Hard width cap: autocomplete content must never stretch the panel past the viewport.
-      className="min-w-0 max-w-[calc(100vw-2rem)] md:max-w-md"
       footer={
         <>
           <Button variant="outline" className="flex-1 h-11" onClick={handleReset}>


### PR DESCRIPTION
ModalV2 now caps its own width (min-w-0 max-w-[min(28rem,calc(100vw-2rem))]), so the local override on the tickets filter modal is redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the tickets filter modal layout so it no longer constrains the panel width unexpectedly, resulting in a more consistent display on larger screens.
* **Chores**
  * Updated a frontend package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->