### PR TITLE
chore(frontend): bump openframe-frontend-core to 0.0.374 

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.372",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.374",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.372",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.372.tgz",
-      "integrity": "sha512-iGYV+VGql1msgsbo8MqQVaO2/KnC2R3Wdi/yD68MwkfYcwuejJOi+Nc/x6fSH5RzcE8iDLYvA4//ON8IQG8HWA==",
+      "version": "0.0.374",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.374.tgz",
+      "integrity": "sha512-7rk2ZmwED6pDrA8jpnuJ6ZoasmkpKSdHiM+5d/I2c8p9LyNsGR2SiTNWQfoaG0UFuu3KwyFLG01C3nJdG1FiFg==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.372",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.374",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a frontend package dependency to a newer version for the latest improvements and compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->