### PR TITLE
Devices: archive page split, unarchive action, status defaults + centralized cache invalidation

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
@@ -14,9 +14,6 @@ export function CustomerDevicesTab({ organizationId }: CustomerDevicesTabProps) 
     <DevicesPanel
       embedded
       addDeviceHref={`/devices/new?organizationId=${organizationId}`}
-      // Archived devices live on the dedicated archive page; deep-link with the
-      // customer preselected (organizationIds is a URL-driven filter there).
-      archiveHref={`/devices/archive?organizationIds=${organizationId}`}
       lockedFilters={lockedFilters}
       hideColumns={['organization']}
       hideFilters={['organization']}

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/details-tabs/customer-devices-tab.tsx
@@ -14,6 +14,9 @@ export function CustomerDevicesTab({ organizationId }: CustomerDevicesTabProps) 
     <DevicesPanel
       embedded
       addDeviceHref={`/devices/new?organizationId=${organizationId}`}
+      // Archived devices live on the dedicated archive page; deep-link with the
+      // customer preselected (organizationIds is a URL-driven filter there).
+      archiveHref={`/devices/archive?organizationIds=${organizationId}`}
       lockedFilters={lockedFilters}
       hideColumns={['organization']}
       hideFilters={['organization']}

--- a/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/dashboard/components/devices-overview.tsx
@@ -79,7 +79,10 @@ export function DevicesOverviewSection() {
             progressVariant={card.progressVariant}
             percentageDisplay="plain"
             progressSize={{ base: 24, md: 56 }}
-            href={`/devices?statuses=${card.status}`}
+            href={
+              // Archived devices live on their own page; /devices only lists the rest.
+              card.status === DEVICE_STATUS.ARCHIVED ? '/devices/archive' : `/devices?statuses=${card.status}`
+            }
           />
         ))}
       </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/archive/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/archive/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { DevicesPanel } from '@/app/components/shared';
+import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { DEVICE_STATUS } from '../constants/device-statuses';
+
+// Statuses are locked to ARCHIVED here; the main /devices page shows the rest
+// (online / offline / pending) and links to this page via the Archive button.
+const ARCHIVED_ONLY_FILTERS = { statuses: [DEVICE_STATUS.ARCHIVED] };
+// Module-level so the prop keeps a stable identity across renders.
+const NO_DEFAULT_STATUSES: string[] = [];
+
+export default function ArchivedDevices() {
+  const handleBack = useSafeBack('/devices');
+
+  return (
+    <DevicesPanel
+      title="Archived Devices"
+      backButton={{ label: 'Back', onClick: handleBack }}
+      className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
+      lockedFilters={ARCHIVED_ONLY_FILTERS}
+      defaultStatuses={NO_DEFAULT_STATUSES}
+      hideFilters={['status']}
+      showAddDevice={false}
+      emptyMessage="No archived devices."
+    />
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-actions-dropdown.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-actions-dropdown.tsx
@@ -36,6 +36,7 @@ export function DeviceActionsDropdown({ device, context, onActionComplete, onRun
 
     const destructiveItems: ActionsMenuItem[] = [];
     if (items.archive) destructiveItems.push(items.archive);
+    if (items.unarchive) destructiveItems.push(items.unarchive);
     if (items.delete) destructiveItems.push(items.delete);
 
     if (destructiveItems.length > 0) {

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-skeleton.tsx
@@ -272,10 +272,12 @@ const QUERIES_SKELETON_COLUMNS: SkeletonColumn[] = [
   { id: 'open', header: '', width: 'w-12 shrink-0 flex-none' },
 ];
 
+// Widths must stay 1:1 with the real tickets-tab columns (see tickets-tab.tsx)
+// so the page-level skeleton and the tab's own loading table don't jump.
 const TICKETS_SKELETON_COLUMNS: SkeletonColumn[] = [
   { id: 'title', header: 'Title', width: 'flex-1' },
-  { id: 'assignee', header: 'Assignee', width: 'w-[160px]' },
-  { id: 'status', header: 'Status', width: 'w-[120px]' },
+  { id: 'assignee', header: 'Assignee', width: 'w-[280px]' },
+  { id: 'status', header: 'Status', width: 'w-[160px]' },
   { id: 'open', header: '', width: 'w-12 shrink-0 flex-none' },
 ];
 
@@ -531,42 +533,46 @@ function SecurityTabSkeleton() {
  * wrapping an InfoCard with pt-16 to make room. */
 function AgentsTabSkeleton() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="relative flex flex-col">
-          <div className="absolute top-4 left-4 z-10">
-            <Skeleton className="h-6 w-24 rounded-[6px]" />
-          </div>
-          <div className="absolute top-4 right-4 z-10">
-            <Skeleton className="h-4 w-4 rounded-full" />
-          </div>
-          <div className="bg-ods-card border border-ods-border rounded-[6px] p-4 pt-16 flex flex-col flex-1">
-            <div className="flex flex-col gap-2">
-              <div className="flex gap-2 items-center w-full">
-                <Skeleton className="h-5 w-14 shrink-0" />
-                <div className="flex-1 h-px bg-ods-border" />
-                <Skeleton className="h-5 w-20 shrink-0" />
-              </div>
-              <div className="flex gap-2 items-center w-full">
-                <Skeleton className="h-5 w-20 shrink-0" />
-                <div className="flex-1 h-px bg-ods-border" />
-                <Skeleton className="h-5 w-32 shrink-0" />
-              </div>
-              <div className="flex gap-2 items-center w-full">
-                <Skeleton className="h-5 w-8 shrink-0" />
-                <div className="flex-1 h-px bg-ods-border" />
-                <Skeleton className="h-5 w-40 shrink-0" />
-              </div>
-              <div className="flex gap-2 items-center w-full">
-                <Skeleton className="h-5 w-16 shrink-0" />
-                <div className="flex-1 h-px bg-ods-border" />
-                <Skeleton className="h-5 w-14 shrink-0" />
+    <section className="flex flex-col gap-[var(--spacing-system-xxs)]">
+      {/* Matches the real "Agent Versions" heading (`h3.text-h5`). */}
+      <TextSkeleton typography="text-h5" width="w-32" />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[var(--spacing-system-l)] items-stretch">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="relative flex flex-col">
+            <div className="absolute top-4 left-4 z-10">
+              <Skeleton className="h-6 w-24 rounded-[6px]" />
+            </div>
+            <div className="absolute top-4 right-4 z-10">
+              <Skeleton className="h-4 w-4 rounded-full" />
+            </div>
+            <div className="bg-ods-card border border-ods-border rounded-[6px] p-4 pt-16 flex flex-col flex-1">
+              <div className="flex flex-col gap-2">
+                <div className="flex gap-2 items-center w-full">
+                  <Skeleton className="h-5 w-14 shrink-0" />
+                  <div className="flex-1 h-px bg-ods-border" />
+                  <Skeleton className="h-5 w-20 shrink-0" />
+                </div>
+                <div className="flex gap-2 items-center w-full">
+                  <Skeleton className="h-5 w-20 shrink-0" />
+                  <div className="flex-1 h-px bg-ods-border" />
+                  <Skeleton className="h-5 w-32 shrink-0" />
+                </div>
+                <div className="flex gap-2 items-center w-full">
+                  <Skeleton className="h-5 w-8 shrink-0" />
+                  <div className="flex-1 h-px bg-ods-border" />
+                  <Skeleton className="h-5 w-40 shrink-0" />
+                </div>
+                <div className="flex gap-2 items-center w-full">
+                  <Skeleton className="h-5 w-16 shrink-0" />
+                  <div className="flex-1 h-px bg-ods-border" />
+                  <Skeleton className="h-5 w-14 shrink-0" />
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-details-view.tsx
@@ -19,6 +19,7 @@ import { CONTEXT_ENTITY_KIND } from '../../mingo/context/context-types';
 import { useTrackOpenView } from '../../mingo/context/use-track-open-view';
 import { useDeviceActionsMenu } from '../hooks/use-device-actions-menu';
 import { useDeviceDetails } from '../hooks/use-device-details';
+import { getDeviceName } from '../utils/device-name';
 import { getDeviceStatusConfig } from '../utils/device-status';
 import { DeviceDetailsSkeleton } from './device-details-skeleton';
 import { RunScriptModal } from './run-script/run-script-modal';
@@ -94,7 +95,7 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
       ? {
           type: CONTEXT_ENTITY_KIND.DEVICE,
           id: deviceId,
-          label: normalizedDevice.displayName || normalizedDevice.hostname || deviceId,
+          label: getDeviceName(normalizedDevice) || deviceId,
         }
       : null,
   );
@@ -120,6 +121,7 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
     if (actionAvailability?.runScriptEnabled) primaryItems.push(deviceMenuItems.runScript);
     if (actionAvailability?.manageFilesEnabled) primaryItems.push(deviceMenuItems.manageFiles);
     if (deviceMenuItems.archive) destructiveItems.push(deviceMenuItems.archive);
+    if (deviceMenuItems.unarchive) destructiveItems.push(deviceMenuItems.unarchive);
     if (deviceMenuItems.delete) destructiveItems.push(deviceMenuItems.delete);
 
     if (primaryItems.length > 0) {
@@ -163,8 +165,7 @@ export function DeviceDetailsView({ deviceId }: DeviceDetailsViewProps) {
     { ...deviceMenuItems.remoteShell, variant: 'outline' },
   ];
 
-  const title =
-    normalizedDevice?.displayName || normalizedDevice?.hostname || normalizedDevice?.description || 'Unknown Device';
+  const title = getDeviceName(normalizedDevice) || 'Unknown Device';
   const lastUpdated = normalizedDevice.updatedAt || normalizedDevice.lastSeen;
   const subtitle = lastUpdated ? `Updated ${formatRelativeTime(lastUpdated)}` : undefined;
   const statusConfig = getDeviceStatusConfig(normalizedDevice.status);

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-info-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/device-info-section.tsx
@@ -11,6 +11,7 @@ import { useCopyToClipboard } from '@/app/hooks/use-copy-to-clipboard';
 import { formatDate, formatTimeWithSeconds } from '@/lib/format-date';
 import { getFullImageUrl } from '@/lib/image-url';
 import type { Device } from '../types/device.types';
+import { getDeviceName } from '../utils/device-name';
 
 function formatDateWithTime(iso?: string): React.ReactNode {
   if (!iso) return 'Unknown';
@@ -54,7 +55,7 @@ export function DeviceInfoSection({ device }: DeviceInfoSectionProps) {
   const iconSize = 'w-4 h-4 md:w-6 md:h-6';
   const typeIcon = renderDeviceTypeIcon(device.type, `${iconSize} text-ods-text-secondary`);
 
-  const hostnameCell = <InfoCell value={device.hostname || 'Unknown'} label="Hostname" />;
+  const hostnameCell = <InfoCell value={getDeviceName(device)} label="Hostname" />;
   const typeCell = <InfoCell value={device.type || 'Unknown'} label="Type" icon={typeIcon} />;
   const deviceCell = (
     <InfoCell

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/devices-grid.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/devices-grid.tsx
@@ -2,6 +2,7 @@ import { DeviceCardSkeleton, DeviceCardSkeletonGrid } from '@flamingo-stack/open
 import { DeviceCard } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useRouter } from 'next/navigation';
 import type { Device } from '../types/device.types';
+import { getDeviceName } from '../utils/device-name';
 import { getDeviceOperatingSystem, getDeviceStatusConfig } from '../utils/device-status';
 
 interface DevicesGridProps {
@@ -10,9 +11,17 @@ interface DevicesGridProps {
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   sentinelRef?: React.RefObject<HTMLDivElement | null>;
+  emptyMessage?: string;
 }
 
-export function DevicesGrid({ devices, isLoading, hasNextPage, isFetchingNextPage, sentinelRef }: DevicesGridProps) {
+export function DevicesGrid({
+  devices,
+  isLoading,
+  hasNextPage,
+  isFetchingNextPage,
+  sentinelRef,
+  emptyMessage = 'No devices found. Try adjusting your search or filters.',
+}: DevicesGridProps) {
   const router = useRouter();
 
   const handleDeviceClick = (device: Device) => {
@@ -28,7 +37,7 @@ export function DevicesGrid({ devices, isLoading, hasNextPage, isFetchingNextPag
         <DeviceCardSkeletonGrid count={12} />
       ) : devices.length === 0 ? (
         <div className="flex items-center justify-center h-64 bg-ods-card border border-ods-border rounded-[6px]">
-          <p className="text-ods-text-secondary">No devices found. Try adjusting your search or filters.</p>
+          <p className="text-ods-text-secondary">{emptyMessage}</p>
         </div>
       ) : (
         <>
@@ -41,7 +50,7 @@ export function DevicesGrid({ devices, isLoading, hasNextPage, isFetchingNextPag
                   device={{
                     id: device.id,
                     machineId: device.machineId,
-                    name: device.displayName || device.hostname || device.description || '',
+                    name: getDeviceName(device),
                     organization: device.organization || device.machineId,
                     lastSeen: device.lastSeen,
                     operatingSystem: getDeviceOperatingSystem(device.osType),

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/devices-table-columns.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/devices-table-columns.tsx
@@ -19,8 +19,9 @@ import { deduplicateFilterOptions } from '@/lib/filter-utils';
 import { formatDateTime } from '@/lib/format-date';
 import { getFullImageUrl } from '@/lib/image-url';
 import { openInNewTab } from '@/lib/open-in-new-tab';
-import { DEFAULT_VISIBLE_STATUSES, DEVICE_STATUS } from '../constants/device-statuses';
+import { DEFAULT_VISIBLE_STATUSES } from '../constants/device-statuses';
 import type { Device, DeviceFilters } from '../types/device.types';
+import { getDeviceName } from '../utils/device-name';
 import { getDeviceStatusConfig } from '../utils/device-status';
 import { DeviceActionsDropdown } from './device-actions-dropdown';
 
@@ -67,6 +68,8 @@ interface DevicesTableBodyProps {
   actionsColumn?: ColumnDef<Device>;
   /** Column ids to drop from the base table columns (e.g. ['organization'] when scoped to a single org). */
   hideColumns?: string[];
+  /** Column ids whose header filter is dropped while the column stays visible (e.g. ['status'] on the archive page). */
+  disableColumnFilters?: string[];
   /** Server-side total (for paginated lists). Falls back to loaded-row count when omitted. */
   totalCount?: number;
 }
@@ -83,13 +86,17 @@ export function DevicesTableBody({
   onColumnFiltersChange,
   actionsColumn,
   hideColumns,
+  disableColumnFilters,
   totalCount,
 }: DevicesTableBodyProps) {
   const columns = useMemo<ColumnDef<Device>[]>(() => {
     const hidden = new Set(hideColumns ?? []);
-    const base = getDeviceTableColumns(deviceFilters ?? null).filter(c => !c.id || !hidden.has(c.id));
+    const unfiltered = new Set(disableColumnFilters ?? []);
+    const base = getDeviceTableColumns(deviceFilters ?? null)
+      .filter(c => !c.id || !hidden.has(c.id))
+      .map(c => (c.id && unfiltered.has(c.id) ? { ...c, meta: { ...c.meta, filter: undefined } } : c));
     return actionsColumn ? [...base, actionsColumn, DEVICE_OPEN_COLUMN] : [...base, DEVICE_OPEN_COLUMN];
-  }, [deviceFilters, actionsColumn, hideColumns]);
+  }, [deviceFilters, actionsColumn, hideColumns, disableColumnFilters]);
 
   const table = useDataTable<Device>({
     data: devices,
@@ -154,20 +161,14 @@ export function getDeviceFilterColumns(deviceFilters?: DeviceFilters | null): De
       filterable: true,
       filterOptions: (() => {
         const statuses = deviceFilters?.statuses || [];
-        // Show only DEFAULT_VISIBLE_STATUSES (excludes ARCHIVED and DELETED)
-        const normalStatuses = statuses.filter(s => (DEFAULT_VISIBLE_STATUSES as readonly string[]).includes(s.value));
-
-        return normalStatuses
+        // Show only DEFAULT_VISIBLE_STATUSES (ARCHIVED lives on /devices/archive, DELETED hidden)
+        return statuses
+          .filter(s => (DEFAULT_VISIBLE_STATUSES as readonly string[]).includes(s.value))
           .map(status => ({
             id: status.value,
             label: getDeviceStatusConfig(status.value).label,
             value: status.value,
-          }))
-          .sort((a, b) => {
-            if (a.value === DEVICE_STATUS.ARCHIVED) return 1;
-            if (b.value === DEVICE_STATUS.ARCHIVED) return -1;
-            return 0;
-          });
+          }));
       })(),
     },
     {
@@ -201,12 +202,7 @@ export function getDeviceTableColumns(deviceFilters?: DeviceFilters | null): Col
     const statuses = deviceFilters?.statuses || [];
     return statuses
       .filter(s => (DEFAULT_VISIBLE_STATUSES as readonly string[]).includes(s.value))
-      .map(s => ({ id: s.value, label: getDeviceStatusConfig(s.value).label, value: s.value }))
-      .sort((a, b) => {
-        if (a.value === DEVICE_STATUS.ARCHIVED) return 1;
-        if (b.value === DEVICE_STATUS.ARCHIVED) return -1;
-        return 0;
-      });
+      .map(s => ({ id: s.value, label: getDeviceStatusConfig(s.value).label, value: s.value }));
   })();
 
   const osFilterOptions = deviceFilters?.osTypes?.map(os => ({ id: os.value, label: os.value, value: os.value })) ?? [];
@@ -231,7 +227,7 @@ export function getDeviceTableColumns(deviceFilters?: DeviceFilters | null): Col
                 })}
             </div>
             <div className="flex-1 min-w-0">
-              <TruncateText>{device.displayName || device.hostname}</TruncateText>
+              <TruncateText>{getDeviceName(device)}</TruncateText>
             </div>
           </div>
         );

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/agents-tab.tsx
@@ -2,11 +2,13 @@
 
 import { InfoCard, Tag } from '@flamingo-stack/openframe-frontend-core';
 import { ToolBadge } from '@flamingo-stack/openframe-frontend-core/components';
+import { TerminalBrowserIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { formatRelativeTime, normalizeToolTypeWithFallback } from '@flamingo-stack/openframe-frontend-core/utils';
 import { formatDateTime } from '@/lib/format-date';
 import type { Device, InstalledAgent, ToolConnection } from '../../types/device.types';
 import { getAgentFooter } from '../../utils/agent-footer';
 import { getDeviceStatusConfig } from '../../utils/device-status';
+import { TabEmptyState } from './tab-empty-state';
 
 interface AgentsTabProps {
   device: Device;
@@ -120,9 +122,11 @@ export function AgentsTab({ device }: AgentsTabProps) {
 
   if (!hasAgents) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No agents found for this device</div>
-      </div>
+      <TabEmptyState
+        icon={<TerminalBrowserIcon />}
+        title="No agents found"
+        description="Agents installed on this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/hardware-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/hardware-tab.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { InfoCard } from '@flamingo-stack/openframe-frontend-core';
+import { HardDrivesIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import type { ReactNode } from 'react';
 import { formatDateTime } from '@/lib/format-date';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface HardwareTabProps {
   device: Device | null;
@@ -58,13 +60,19 @@ function Block({ heading, children }: { heading?: string; children: ReactNode })
   );
 }
 
+function HardwareEmptyState() {
+  return (
+    <TabEmptyState
+      icon={<HardDrivesIcon />}
+      title="No hardware data found"
+      description="Hardware details for this device will appear here."
+    />
+  );
+}
+
 export function HardwareTab({ device }: HardwareTabProps) {
   if (!device) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No device data available</div>
-      </div>
-    );
+    return <HardwareEmptyState />;
   }
 
   // SYSTEM — hardware identity from Fleet (currently unused on this tab).
@@ -115,6 +123,12 @@ export function HardwareTab({ device }: HardwareTabProps) {
 
   // BATTERY — macOS battery health from Fleet.
   const batteries = device.batteries || [];
+
+  const hasAnyData =
+    hasSystem || bootItems.length > 0 || hasCpu || memoryItems.length > 0 || hasFleetStorage || batteries.length > 0;
+  if (!hasAnyData) {
+    return <HardwareEmptyState />;
+  }
 
   return (
     <div className="flex flex-col gap-[var(--spacing-system-l)]">

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/network-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/network-tab.tsx
@@ -2,9 +2,9 @@
 
 import { InfoCard } from '@flamingo-stack/openframe-frontend-core';
 import { Hierarchy02Icon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { NoData } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import type { ReactNode } from 'react';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface NetworkTabProps {
   device: Device | null;
@@ -42,9 +42,11 @@ function Labeled({ title, children }: { title: string; children: ReactNode }) {
 export function NetworkTab({ device }: NetworkTabProps) {
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<Hierarchy02Icon />}
+        title="No network data found"
+        description="Network details for this device will appear here."
+      />
     );
   }
 
@@ -81,18 +83,12 @@ export function NetworkTab({ device }: NetworkTabProps) {
   const hasIpv6 = sortedIpv6.length > 0;
 
   if (interfaceItems.length === 0 && locationItems.length === 0 && !hasIpv4 && !hasIpv6) {
-    // Exact copy of the `DataTable.Body` empty state: the same wrapper + `NoData` with the
-    // same `py-[--spacing-system-xxl]` padding `DataTableEmpty` applies — so this tab is
-    // pixel-identical to the table tabs.
     return (
-      <div className="flex flex-col gap-[var(--spacing-system-xsf)] w-full">
-        <NoData
-          icon={<Hierarchy02Icon />}
-          title="No network data found"
-          description="Network details for this device will appear here."
-          className="py-[var(--spacing-system-xxl)]"
-        />
-      </div>
+      <TabEmptyState
+        icon={<Hierarchy02Icon />}
+        title="No network data found"
+        description="Network details for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/os-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/os-tab.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { InfoCard } from '@flamingo-stack/openframe-frontend-core';
+import { TerminalMonitorIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import type { ReactNode } from 'react';
 import { formatDateTime } from '@/lib/format-date';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface OsTabProps {
   device: Device | null;
@@ -39,13 +41,19 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
   );
 }
 
+function OsEmptyState() {
+  return (
+    <TabEmptyState
+      icon={<TerminalMonitorIcon />}
+      title="No OS data found"
+      description="Operating system details for this device will appear here."
+    />
+  );
+}
+
 export function OsTab({ device }: OsTabProps) {
   if (!device) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No device data available</div>
-      </div>
-    );
+    return <OsEmptyState />;
   }
 
   // OPERATING SYSTEM — name/version/build/platform identity from Fleet + GraphQL.
@@ -82,11 +90,7 @@ export function OsTab({ device }: OsTabProps) {
   ]);
 
   if (!hasOs && bootItems.length === 0 && managementItems.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No OS data available for this device</div>
-      </div>
-    );
+    return <OsEmptyState />;
   }
 
   return (

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/policies-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/policies-tab.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react';
 import { PoliciesTable, type PolicyTableRow } from '@/app/components/shared';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import type { Device, DevicePolicy } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface PoliciesTabProps {
   device: Device | null;
@@ -58,9 +59,11 @@ export function PoliciesTab({ device }: PoliciesTabProps) {
 
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<FolderShieldIcon />}
+        title="No policies applied"
+        description="Compliance policies for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/queries-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/queries-tab.tsx
@@ -9,6 +9,7 @@ import { formatQueryInterval, QueriesTable, type QueryTableRow } from '@/app/com
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import { useHostQueries } from '../../hooks/use-host-queries';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface QueriesTabProps {
   device: Device | null;
@@ -48,9 +49,11 @@ export function QueriesTab({ device }: QueriesTabProps) {
 
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<BracketCurlyEllipsisVrIcon />}
+        title="No queries found"
+        description="Scheduled queries for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/security-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/security-tab.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { AlertTriangleIcon, CheckCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  AlertTriangleIcon,
+  CheckCircleIcon,
+  ShieldIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { formatDateTime } from '@/lib/format-date';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface SecurityTabProps {
   device: Device | null;
@@ -219,9 +224,11 @@ function buildSections(device: Device): SecuritySection[] {
 export function SecurityTab({ device }: SecurityTabProps) {
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<ShieldIcon />}
+        title="No security data found"
+        description="Security details for this device will appear here."
+      />
     );
   }
 
@@ -229,9 +236,11 @@ export function SecurityTab({ device }: SecurityTabProps) {
 
   if (sections.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No security data available for this device</div>
-      </div>
+      <TabEmptyState
+        icon={<ShieldIcon />}
+        title="No security data found"
+        description="Security details for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/software-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/software-tab.tsx
@@ -23,6 +23,7 @@ import { formatRelativeTime } from '@flamingo-stack/openframe-frontend-core/util
 import { type ComponentType, useMemo, useState } from 'react';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import type { Device, Software } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface SoftwareTabProps {
   device: Device | null;
@@ -165,17 +166,21 @@ export function SoftwareTab({ device }: SoftwareTabProps) {
 
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<WebDesignIcon />}
+        title="No software found"
+        description="Installed software for this device will appear here."
+      />
     );
   }
 
   if (allSoftware.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No software data available for this device</div>
-      </div>
+      <TabEmptyState
+        icon={<WebDesignIcon />}
+        title="No software found"
+        description="Installed software for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tab-empty-state.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tab-empty-state.tsx
@@ -1,0 +1,17 @@
+import { NoData } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import type { ReactNode } from 'react';
+
+/**
+ * Unified empty screen for device detail tabs — the same wrapper + `NoData`
+ * padding that `DataTable.Body` renders for empty tables, so content tabs
+ * (hardware, network, OS, …) are pixel-identical to the table tabs.
+ * Pass the tab's own icon from `device-tabs.tsx` so the empty state matches
+ * the tab bar.
+ */
+export function TabEmptyState({ icon, title, description }: { icon: ReactNode; title: string; description: string }) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-system-xsf)] w-full">
+      <NoData icon={icon} title={title} description={description} className="py-[var(--spacing-system-xxl)]" />
+    </div>
+  );
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tickets-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tickets-tab.tsx
@@ -24,8 +24,16 @@ interface TicketsTabProps {
   device: Device | null;
 }
 
-/** Match a ticket to this device across the several ids the ticket payload can carry. */
-function ticketBelongsToDevice(ticket: Dialog, deviceIds: string[], hostname?: string): boolean {
+// TEMPORARY: the tickets API has no device filter (TicketFilterInput only
+// supports statuses/organizations/assignees/labels), so we fetch the largest
+// page the backend allows (100) and match tickets to this device client-side.
+// Replace with a server-side `filter: { machineIds }` once the backend
+// supports it.
+const DEVICE_TICKETS_PAGE_SIZE = 100;
+
+/** Match a ticket to this device strictly by machine id — never by hostname
+ *  (hostnames are not unique or stable across Fleet/GraphQL sources). */
+function ticketBelongsToDevice(ticket: Dialog, deviceIds: string[]): boolean {
   if (deviceIds.length === 0) return false;
   if (ticket.deviceId && deviceIds.includes(ticket.deviceId)) return true;
 
@@ -39,7 +47,6 @@ function ticketBelongsToDevice(ticket: Dialog, deviceIds: string[], hostname?: s
     if (deviceIds.includes((owner as ClientDialogOwner).machineId)) return true;
   }
 
-  if (hostname && ticket.deviceHostname && ticket.deviceHostname === hostname) return true;
   return false;
 }
 
@@ -58,6 +65,7 @@ export function TicketsTab({ device }: TicketsTabProps) {
   } = useTicketsQuery({
     archived: false,
     search: debouncedSearch,
+    pageSize: DEVICE_TICKETS_PAGE_SIZE,
   });
 
   // The device is identified by its machineId (the detail route param) — keep `id` too as a fallback.
@@ -66,17 +74,23 @@ export function TicketsTab({ device }: TicketsTabProps) {
     [device?.machineId, device?.id],
   );
 
-  const deviceTickets = useMemo(
-    () => tickets.filter(t => ticketBelongsToDevice(t, deviceIds, device?.hostname)),
-    [tickets, deviceIds, device?.hostname],
-  );
+  const deviceTickets = useMemo(() => tickets.filter(t => ticketBelongsToDevice(t, deviceIds)), [tickets, deviceIds]);
 
   // Reuse the shared ticket columns, but drop the device/source column — it's redundant on a
   // device-scoped list — and keep the trailing open-in-new-tab action.
   const columns = useMemo<ColumnDef<Dialog>[]>(() => {
-    const base = getTicketTableColumns({ isArchived: false }).filter(
-      column => (column as { accessorKey?: string }).accessorKey !== 'source',
-    );
+    const base = getTicketTableColumns({ isArchived: false })
+      .filter(column => (column as { accessorKey?: string }).accessorKey !== 'source')
+      .map(column => {
+        // With SOURCE dropped, STATUS becomes the last data column: anchor its
+        // filter dropdown to the header's right edge so it doesn't overflow
+        // past the table (the shared default is bottom-start).
+        if ((column as { accessorKey?: string }).accessorKey !== 'status' || !column.meta?.filter) return column;
+        return {
+          ...column,
+          meta: { ...column.meta, filter: { ...column.meta.filter, placement: 'bottom-end' as const } },
+        };
+      });
     return [...base, getTicketOpenColumn()];
   }, []);
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tickets-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/tickets-tab.tsx
@@ -78,18 +78,31 @@ export function TicketsTab({ device }: TicketsTabProps) {
 
   // Reuse the shared ticket columns, but drop the device/source column — it's redundant on a
   // device-scoped list — and keep the trailing open-in-new-tab action.
+  // With SOURCE dropped the shared flex widths drift, so pin ASSIGNEE/STATUS to
+  // the same fixed widths as DeviceDetailsSkeleton's tickets variant — the
+  // page-level skeleton, the tab's own loading skeleton and the loaded table
+  // then share one layout (no header jump between loading phases).
   const columns = useMemo<ColumnDef<Dialog>[]>(() => {
     const base = getTicketTableColumns({ isArchived: false })
       .filter(column => (column as { accessorKey?: string }).accessorKey !== 'source')
       .map(column => {
-        // With SOURCE dropped, STATUS becomes the last data column: anchor its
-        // filter dropdown to the header's right edge so it doesn't overflow
-        // past the table (the shared default is bottom-start).
-        if ((column as { accessorKey?: string }).accessorKey !== 'status' || !column.meta?.filter) return column;
-        return {
-          ...column,
-          meta: { ...column.meta, filter: { ...column.meta.filter, placement: 'bottom-end' as const } },
-        };
+        const key = (column as { accessorKey?: string }).accessorKey;
+        if (key === 'assignee') {
+          return { ...column, meta: { ...column.meta, width: 'w-[280px]' } };
+        }
+        if (key === 'status' && column.meta?.filter) {
+          // STATUS is the last data column here: anchor its filter dropdown to
+          // the header's right edge so it doesn't overflow past the table.
+          return {
+            ...column,
+            meta: {
+              ...column.meta,
+              width: 'w-[160px]',
+              filter: { ...column.meta.filter, placement: 'bottom-end' as const },
+            },
+          };
+        }
+        return column;
       });
     return [...base, getTicketOpenColumn()];
   }, []);

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/users-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/users-tab.tsx
@@ -14,6 +14,7 @@ import { useDebounce } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useMemo, useState } from 'react';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import type { Device } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface UsersTabProps {
   device: Device | null;
@@ -147,17 +148,21 @@ export function UsersTab({ device }: UsersTabProps) {
 
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<UsersIcon />}
+        title="No users found"
+        description="User accounts on this device will appear here."
+      />
     );
   }
 
   if (rows.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-h4">No users found for this device</div>
-      </div>
+      <TabEmptyState
+        icon={<UsersIcon />}
+        title="No users found"
+        description="User accounts on this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/vulnerabilities-tab.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/components/tabs/vulnerabilities-tab.tsx
@@ -20,6 +20,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
 import { formatDate } from '@/lib/format-date';
 import type { Device, Software, Vulnerability } from '../../types/device.types';
+import { TabEmptyState } from './tab-empty-state';
 
 interface VulnerabilitiesTabProps {
   device: Device | null;
@@ -208,9 +209,11 @@ export function VulnerabilitiesTab({ device }: VulnerabilitiesTabProps) {
 
   if (!device) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-ods-text-secondary text-lg">No device data available</div>
-      </div>
+      <TabEmptyState
+        icon={<BracketSquareCheckIcon />}
+        title="No vulnerabilities found"
+        description="Detected vulnerabilities for this device will appear here."
+      />
     );
   }
 

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/constants/device-statuses.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/constants/device-statuses.ts
@@ -1,5 +1,6 @@
 /**
- * Default visible device statuses (excludes ARCHIVED and DELETED)
+ * Default visible device statuses (excludes ARCHIVED and DELETED).
+ * Archived devices live on the dedicated /devices/archive page.
  * Use this constant for all device queries that should show "active" devices only.
  *
  * NOTE: If new statuses are added to the backend, they must be added here
@@ -24,7 +25,6 @@ export const DEFAULT_VISIBLE_STATUSES = [
   DEVICE_STATUS.ONLINE,
   DEVICE_STATUS.OFFLINE,
   DEVICE_STATUS.PENDING,
-  DEVICE_STATUS.ARCHIVED,
 ] as const satisfies string[];
 
 export const DEFAULT_DASHBOARD_STATUSES = [
@@ -34,7 +34,16 @@ export const DEFAULT_DASHBOARD_STATUSES = [
   DEVICE_STATUS.ARCHIVED,
 ] as const satisfies string[];
 
-export const DEFAULT_DEVICES_LIST_STATUSES = [
+// PENDING is intentionally not part of the default list view — pending
+// (still-enrolling) devices appear only when the user explicitly checks the
+// PENDING status filter. The option itself stays in DEFAULT_VISIBLE_STATUSES.
+export const DEFAULT_DEVICES_LIST_STATUSES = [DEVICE_STATUS.ONLINE, DEVICE_STATUS.OFFLINE] as const satisfies string[];
+
+// Statuses fetched when the device list is used as an enrichment registry
+// (e.g. monitoring query/policy tables mapping fleet hosts → device metadata).
+// Includes ARCHIVED so archived-but-monitored hosts keep their org/OS/image
+// instead of degrading to bare host rows.
+export const DEVICE_ENRICHMENT_STATUSES = [
   DEVICE_STATUS.ONLINE,
   DEVICE_STATUS.OFFLINE,
   DEVICE_STATUS.ARCHIVED,

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-actions-menu.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-actions-menu.tsx
@@ -5,6 +5,7 @@ import { normalizeOSType } from '@flamingo-stack/openframe-frontend-core';
 import {
   BoxArchiveIcon,
   BracketCurlyIcon,
+  InboxArrowUpIcon,
   TrashIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { useRouter } from 'next/navigation';
@@ -12,6 +13,8 @@ import { type ReactNode, useCallback, useMemo } from 'react';
 import type { Device } from '../types/device.types';
 import { type DeviceActionAvailability, getDeviceActionAvailability } from '../utils/device-action-utils';
 import { buildDeviceMenuItems } from '../utils/device-menu-items';
+import { getDeviceName } from '../utils/device-name';
+import { useDeviceActions } from './use-device-actions';
 import { useDeviceConfirmationDialogs } from './use-device-confirmation-dialogs';
 
 const DEFAULT_ICON_SIZE = 'w-6 h-6';
@@ -35,6 +38,7 @@ export interface DeviceActionsMenuItems {
   runScript: ActionsMenuItem;
   deviceLogs: ActionsMenuItem;
   archive: ActionsMenuItem | null;
+  unarchive: ActionsMenuItem | null;
   delete: ActionsMenuItem | null;
 }
 
@@ -63,10 +67,18 @@ export function useDeviceActionsMenu(
     if (navigateOnDestructive) router.push('/devices');
   }, [onActionComplete, navigateOnDestructive, router]);
 
-  const { openArchive, openDelete, dialogs } = useDeviceConfirmationDialogs(device, {
+  const { openArchive, openDelete, dialogs, unarchiveDevice, isUnarchiving } = useDeviceConfirmationDialogs(device, {
     onArchived: handleDestructiveSuccess,
     onDeleted: handleDestructiveSuccess,
   });
+
+  // Unarchive is non-destructive and instantly reversible — no confirm dialog,
+  // just the action + toast. The device stays valid, so no navigation either.
+  const handleUnarchive = useCallback(async () => {
+    if (!device) return;
+    const success = await unarchiveDevice(deviceId, getDeviceName(device));
+    if (success) onActionComplete?.();
+  }, [device, deviceId, unarchiveDevice, onActionComplete]);
 
   const actionAvailability = useMemo(() => (device ? getDeviceActionAvailability(device) : null), [device]);
 
@@ -114,6 +126,16 @@ export function useDeviceActionsMenu(
         }
       : null;
 
+    const unarchive: ActionsMenuItem | null = actionAvailability?.unarchiveEnabled
+      ? {
+          id: 'unarchive',
+          label: 'Unarchive Device',
+          icon: <InboxArrowUpIcon className={`${iconSize} text-ods-text-secondary`} />,
+          disabled: isUnarchiving,
+          onClick: handleUnarchive,
+        }
+      : null;
+
     const deleteItem: ActionsMenuItem | null = actionAvailability?.deleteEnabled
       ? {
           id: 'delete',
@@ -131,9 +153,20 @@ export function useDeviceActionsMenu(
       runScript,
       deviceLogs: base.deviceLogs,
       archive,
+      unarchive,
       delete: deleteItem,
     };
-  }, [deviceId, actionAvailability, isWindows, iconSize, handleRunScript, openArchive, openDelete]);
+  }, [
+    deviceId,
+    actionAvailability,
+    isWindows,
+    iconSize,
+    handleRunScript,
+    openArchive,
+    openDelete,
+    handleUnarchive,
+    isUnarchiving,
+  ]);
 
   return { items, dialogs, actionAvailability };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-actions.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-actions.ts
@@ -1,8 +1,13 @@
 'use client';
 
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
+import { dashboardQueryKeys } from '@/app/(app)/dashboard/utils/query-keys';
 import { apiClient } from '@/lib/api-client';
+import { DEVICE_STATUS } from '../constants/device-statuses';
+import { deviceQueryKeys } from '../utils/query-keys';
+import { deviceFiltersQueryKeys } from './use-device-filters';
 
 interface UseDeviceActionsOptions {
   onSuccess?: () => void;
@@ -10,15 +15,28 @@ interface UseDeviceActionsOptions {
 
 export function useDeviceActions(options?: UseDeviceActionsOptions) {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [isArchiving, setIsArchiving] = useState(false);
+  const [isUnarchiving, setIsUnarchiving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Every surface caching device data — lists (main / archive / customer tab),
+  // detail views, filter facet counts, dashboard counters — must refresh after
+  // a status mutation. Invalidating here, at the single mutation site, keeps
+  // active views refetching immediately and stale caches refetching on next
+  // mount, without every view wiring its own refetch callback.
+  const invalidateDeviceQueries = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: deviceQueryKeys.all });
+    queryClient.invalidateQueries({ queryKey: deviceFiltersQueryKeys.all });
+    queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.deviceStats() });
+  }, [queryClient]);
 
   const archiveDevice = useCallback(
     async (deviceId: string, deviceName?: string): Promise<boolean> => {
       setIsArchiving(true);
       try {
         const response = await apiClient.patch(`/api/devices/${deviceId}`, {
-          status: 'ARCHIVED',
+          status: DEVICE_STATUS.ARCHIVED,
         });
 
         if (!response.ok) {
@@ -30,6 +48,7 @@ export function useDeviceActions(options?: UseDeviceActionsOptions) {
           description: `${deviceName || deviceId} has been archived`,
         });
 
+        invalidateDeviceQueries();
         options?.onSuccess?.();
         return true;
       } catch (error) {
@@ -44,7 +63,45 @@ export function useDeviceActions(options?: UseDeviceActionsOptions) {
         setIsArchiving(false);
       }
     },
-    [toast, options],
+    [toast, options, invalidateDeviceQueries],
+  );
+
+  // Restores an archived device. OFFLINE is the natural restore target: the
+  // backend has no transition guards, and the agent heartbeat promotes the
+  // device to ONLINE on its next check-in (PENDING means "never connected").
+  const unarchiveDevice = useCallback(
+    async (deviceId: string, deviceName?: string): Promise<boolean> => {
+      setIsUnarchiving(true);
+      try {
+        const response = await apiClient.patch(`/api/devices/${deviceId}`, {
+          status: DEVICE_STATUS.OFFLINE,
+        });
+
+        if (!response.ok) {
+          throw new Error(response.error || 'Failed to unarchive device');
+        }
+
+        toast({
+          title: 'Device unarchived',
+          description: `${deviceName || deviceId} has been restored`,
+        });
+
+        invalidateDeviceQueries();
+        options?.onSuccess?.();
+        return true;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to unarchive device';
+        toast({
+          title: 'Unarchive failed',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+        return false;
+      } finally {
+        setIsUnarchiving(false);
+      }
+    },
+    [toast, options, invalidateDeviceQueries],
   );
 
   const deleteDevice = useCallback(
@@ -52,7 +109,7 @@ export function useDeviceActions(options?: UseDeviceActionsOptions) {
       setIsDeleting(true);
       try {
         const response = await apiClient.patch(`/api/devices/${deviceId}`, {
-          status: 'DELETED',
+          status: DEVICE_STATUS.DELETED,
         });
 
         if (!response.ok) {
@@ -64,6 +121,7 @@ export function useDeviceActions(options?: UseDeviceActionsOptions) {
           description: `${deviceName || deviceId} has been deleted`,
         });
 
+        invalidateDeviceQueries();
         options?.onSuccess?.();
         return true;
       } catch (error) {
@@ -78,14 +136,16 @@ export function useDeviceActions(options?: UseDeviceActionsOptions) {
         setIsDeleting(false);
       }
     },
-    [toast, options],
+    [toast, options, invalidateDeviceQueries],
   );
 
   return {
     archiveDevice,
+    unarchiveDevice,
     deleteDevice,
     isArchiving,
+    isUnarchiving,
     isDeleting,
-    isProcessing: isArchiving || isDeleting,
+    isProcessing: isArchiving || isUnarchiving || isDeleting,
   };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-confirmation-dialogs.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-confirmation-dialogs.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '@/app/components/shared/confirm-dialog';
 import { useCopyToClipboard } from '@/app/hooks/use-copy-to-clipboard';
 import type { Device } from '../types/device.types';
 import { buildUninstallCommand, normalizeDevicePlatform } from '../utils/device-command-utils';
+import { getDeviceName } from '../utils/device-name';
 import { useDeviceActions } from './use-device-actions';
 import { useReleaseVersion } from './use-release-version';
 
@@ -21,6 +22,10 @@ interface UseDeviceConfirmationDialogsResult {
   dialogs: ReactNode;
   isArchiving: boolean;
   isDeleting: boolean;
+  /** Re-exported from the hook's internal useDeviceActions instance so callers
+   *  (e.g. useDeviceActionsMenu) don't have to instantiate a second one. */
+  unarchiveDevice: (deviceId: string, deviceName?: string) => Promise<boolean>;
+  isUnarchiving: boolean;
 }
 
 export function useDeviceConfirmationDialogs(
@@ -31,12 +36,12 @@ export function useDeviceConfirmationDialogs(
     successDescription: 'Uninstall command copied to clipboard',
     errorDescription: 'Could not copy command to clipboard',
   });
-  const { archiveDevice, deleteDevice, isArchiving, isDeleting } = useDeviceActions();
+  const { archiveDevice, unarchiveDevice, deleteDevice, isArchiving, isUnarchiving, isDeleting } = useDeviceActions();
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const { releaseVersion } = useReleaseVersion({ enabled: showDeleteConfirm });
 
-  const deviceName = device?.displayName || device?.hostname || 'this device';
+  const deviceName = getDeviceName(device) || 'this device';
   const deviceId = device?.machineId || device?.id || '';
 
   const devicePlatform = useMemo(
@@ -121,5 +126,5 @@ export function useDeviceConfirmationDialogs(
     </>
   );
 
-  return { openArchive, openDelete, dialogs, isArchiving, isDeleting };
+  return { openArchive, openDelete, dialogs, isArchiving, isDeleting, unarchiveDevice, isUnarchiving };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-details.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-device-details.ts
@@ -178,8 +178,8 @@ function createDevice(
     // Core Identifiers
     id: node.id,
     machineId: node.machineId,
-    hostname: fleetData?.hostname || node.hostname,
-    displayName: node.displayName || fleetData?.display_name || node.hostname,
+    hostname: node.hostname,
+    displayName: node.displayName || node.hostname,
 
     // Hardware - CPU
     cpu_brand: fleetData?.cpu_brand,

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices-url-params.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices-url-params.ts
@@ -10,10 +10,11 @@ import type { DeviceFilterInput } from '../types/device.types';
 interface UseDevicesUrlParamsOptions {
   /**
    * Default statuses applied when the user hasn't picked any.
-   * - omitted → `DEFAULT_DEVICES_LIST_STATUSES` (ONLINE / OFFLINE / ARCHIVED;
-   *   PENDING is unselected by default, DELETED hidden). Used on the main Devices
-   *   page and the Customer devices tab.
-   * - `[]` → no default, every status (including PENDING / DELETED) returned.
+   * - omitted → `DEFAULT_DEVICES_LIST_STATUSES` (ONLINE / OFFLINE; PENDING is
+   *   opt-in via the filter, ARCHIVED lives on /devices/archive, DELETED
+   *   hidden). Used on the main Devices page and the Customer devices tab.
+   * - `[]` → no default, every status (including ARCHIVED / DELETED) returned;
+   *   pair with `lockedFilters` to scope the query (e.g. the archive page).
    */
   defaultStatuses?: string[];
 }
@@ -48,13 +49,33 @@ export function useDevicesUrlParams(options: UseDevicesUrlParamsOptions = {}) {
     [params.tags],
   );
 
-  // When the user hasn't explicitly picked statuses, fall back to the defaults
-  // (PENDING excluded). Shared by the API query and the filter UI so the shown
-  // checkmarks match what's actually queried (online/offline/archived checked,
-  // pending unchecked by default).
+  // Selecting exactly the default status set is the same as no selection —
+  // collapse it to [] so the URL stays clean (`?statuses=` is dropped) and it
+  // never reads as an active filter. Applied on both read (a URL that spells
+  // out the defaults) and write (Apply with all defaults checked).
+  const normalizeStatuses = useCallback(
+    (statuses: string[]) =>
+      statuses.length === defaultStatuses.length && defaultStatuses.every(s => statuses.includes(s)) ? [] : statuses,
+    [defaultStatuses],
+  );
+
+  const selectedStatuses = useMemo(() => normalizeStatuses(params.statuses), [params.statuses, normalizeStatuses]);
+
+  const normalizedParams = useMemo(() => ({ ...params, statuses: selectedStatuses }), [params, selectedStatuses]);
+
+  const setParamsNormalized = useCallback(
+    (next: Record<string, any>) =>
+      setParams('statuses' in next ? { ...next, statuses: normalizeStatuses(next.statuses || []) } : next),
+    [setParams, normalizeStatuses],
+  );
+
+  // When the user hasn't explicitly picked statuses, the QUERY falls back to the
+  // defaults (online/offline). This is query-only: the filter UI shows just the
+  // explicit selection (`selectedStatuses`), so nothing looks checked in the
+  // default state.
   const effectiveStatuses = useMemo(
-    () => (params.statuses.length > 0 ? params.statuses : defaultStatuses),
-    [params.statuses, defaultStatuses],
+    () => (selectedStatuses.length > 0 ? selectedStatuses : defaultStatuses),
+    [selectedStatuses, defaultStatuses],
   );
 
   const filters: DeviceFilterInput = useMemo(
@@ -69,11 +90,11 @@ export function useDevicesUrlParams(options: UseDevicesUrlParamsOptions = {}) {
 
   const tableFilters = useMemo(
     () => ({
-      status: effectiveStatuses,
+      status: selectedStatuses,
       os: params.osTypes,
       organization: params.organizationIds,
     }),
-    [effectiveStatuses, params.osTypes, params.organizationIds],
+    [selectedStatuses, params.osTypes, params.organizationIds],
   );
 
   const tagOptions: TagSearchOption<string>[] = useMemo(
@@ -83,14 +104,14 @@ export function useDevicesUrlParams(options: UseDevicesUrlParamsOptions = {}) {
 
   const handleFilterChange = useCallback(
     (columnFilters: Record<string, any[]>) => {
-      setParams({
+      setParamsNormalized({
         statuses: columnFilters.status || [],
         osTypes: columnFilters.os || [],
         organizationIds: columnFilters.organization || [],
       });
       document.querySelector('main')?.scrollTo({ top: 0, behavior: 'instant' });
     },
-    [setParams],
+    [setParamsNormalized],
   );
 
   const handleTagRemove = useCallback(
@@ -121,14 +142,13 @@ export function useDevicesUrlParams(options: UseDevicesUrlParamsOptions = {}) {
   );
 
   return {
-    params,
+    params: normalizedParams,
     setParam,
-    setParams,
+    setParams: setParamsNormalized,
     localSearch,
     setLocalSearch,
     debouncedSearch,
     filters,
-    effectiveStatuses,
     tableFilters,
     tagOptions,
     handleFilterChange,

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/hooks/use-devices.ts
@@ -7,6 +7,7 @@ import { apiClient } from '@/lib/api-client';
 import { GET_DEVICES_QUERY } from '../queries/devices-queries';
 import type { Device, DeviceFilterInput, DevicesGraphQlNode, GraphQlResponse } from '../types/device.types';
 import { createDeviceListItem } from '../utils/device-transform';
+import { deviceQueryKeys } from '../utils/query-keys';
 
 const DEVICES_PAGE_SIZE = 20;
 
@@ -21,9 +22,12 @@ interface DevicesPage {
   filteredCount: number;
 }
 
+// Derived from the canonical deviceQueryKeys registry so cache invalidation
+// (which targets deviceQueryKeys roots) stays linked by reference, not by a
+// duplicated 'devices' string literal.
 export const devicesQueryKeys = {
-  all: ['devices'] as const,
-  list: (filters: DeviceFilterInput, search: string) => ['devices', 'list', filters, search] as const,
+  all: deviceQueryKeys.all,
+  list: (filters: DeviceFilterInput, search: string) => [...deviceQueryKeys.lists(), filters, search] as const,
 };
 
 export function useDevices(filters: DeviceFilterInput = {}, search = '') {

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/page.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/page.tsx
@@ -18,6 +18,7 @@ export default function Devices() {
   return (
     <DevicesPanel
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
+      archiveHref="/devices/archive"
       // Only treat the tenant as having no customers once the check resolves, so the
       // "Add a customer" banner doesn't flash during loading. While checking, the
       // panel still keeps "Add Device" disabled via isCheckingOrganizations.

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-action-utils.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-action-utils.ts
@@ -21,6 +21,13 @@ export function canArchiveDevice(status: string | undefined): boolean {
 }
 
 /**
+ * Check if a device can be unarchived (restored from the archive)
+ */
+export function canUnarchiveDevice(status: string | undefined): boolean {
+  return status?.toUpperCase() === 'ARCHIVED';
+}
+
+/**
  * Check if a device can be deleted
  */
 export function canDeleteDevice(status: string | undefined): boolean {
@@ -71,6 +78,7 @@ export interface DeviceActionAvailability {
   manageFilesEnabled: boolean;
   runScriptEnabled: boolean;
   archiveEnabled: boolean;
+  unarchiveEnabled: boolean;
   deleteEnabled: boolean;
 
   // Tool IDs (for handlers)
@@ -104,6 +112,9 @@ export function getDeviceActionAvailability(device: Device): DeviceActionAvailab
 
     // Archive: device must not be already archived or deleted
     archiveEnabled: canArchiveDevice(device.status),
+
+    // Unarchive: only archived devices can be restored
+    unarchiveEnabled: canUnarchiveDevice(device.status),
 
     // Delete: device must not be already deleted
     deleteEnabled: canDeleteDevice(device.status),

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-name.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-name.ts
@@ -1,0 +1,10 @@
+/**
+ * Single source of truth for a device's display name.
+ *
+ * The name comes from GraphQL only: `displayName` when present, otherwise
+ * `hostname`. No other fallbacks (description, machineId, deviceId, Fleet
+ * display_name, …) — those diverge across screens and must not be used.
+ */
+export function getDeviceName(device?: { displayName?: string | null; hostname?: string | null } | null): string {
+  return device?.displayName || device?.hostname || '';
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-transform.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/devices/utils/device-transform.ts
@@ -11,7 +11,7 @@ export function createDeviceListItem(node: DevicesGraphQlNode): Device {
     // Core Identifiers
     id: node.id,
     machineId: node.machineId || '',
-    hostname: node.hostname || node.displayName || '',
+    hostname: node.hostname || '',
     displayName: node.displayName || node.hostname,
 
     // Hardware - CPU (not available in list view)

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/hooks/use-policy-devices-table.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/policy/hooks/use-policy-devices-table.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { apiClient } from '@/lib/api-client';
-import { DEFAULT_DEVICES_LIST_STATUSES } from '../../../devices/constants/device-statuses';
+import { DEVICE_ENRICHMENT_STATUSES } from '../../../devices/constants/device-statuses';
 import { GET_DEVICES_QUERY } from '../../../devices/queries/devices-queries';
 import type { Device, DevicesGraphQlNode, GraphQlResponse } from '../../../devices/types/device.types';
 import { getFleetHostId } from '../../../devices/utils/device-action-utils';
@@ -31,7 +31,7 @@ async function fetchDevicesPage(cursor: string | null): Promise<DevicesPage> {
   const response = await apiClient.post<GraphQlResponse<DevicesResponseData>>('/api/graphql', {
     query: GET_DEVICES_QUERY,
     variables: {
-      filter: { statuses: DEFAULT_DEVICES_LIST_STATUSES },
+      filter: { statuses: DEVICE_ENRICHMENT_STATUSES },
       first: DEVICES_PAGE_SIZE,
       after: cursor,
       search: '',

--- a/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/hooks/use-query-devices-table.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/monitoring/query/hooks/use-query-devices-table.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { apiClient } from '@/lib/api-client';
 import { fleetApiClient } from '@/lib/fleet-api-client';
-import { DEFAULT_DEVICES_LIST_STATUSES } from '../../../devices/constants/device-statuses';
+import { DEVICE_ENRICHMENT_STATUSES } from '../../../devices/constants/device-statuses';
 import { GET_DEVICES_QUERY } from '../../../devices/queries/devices-queries';
 import type { Device, DevicesGraphQlNode, GraphQlResponse } from '../../../devices/types/device.types';
 import { getFleetHostId } from '../../../devices/utils/device-action-utils';
@@ -24,7 +24,7 @@ async function fetchDevicesPage(
   const response = await apiClient.post<GraphQlResponse<DevicesResponseData>>('/api/graphql', {
     query: GET_DEVICES_QUERY,
     variables: {
-      filter: { statuses: DEFAULT_DEVICES_LIST_STATUSES },
+      filter: { statuses: DEVICE_ENRICHMENT_STATUSES },
       first: DEVICES_PAGE_SIZE,
       after: cursor,
       search: '',

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/hooks/use-tickets-query.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/hooks/use-tickets-query.ts
@@ -19,6 +19,7 @@ export function useTicketsQuery({
   organizationIds,
   assigneeIds,
   labelIds,
+  pageSize = TICKETS_PAGE_SIZE,
 }: DialogsQueryParams) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -47,6 +48,7 @@ export function useTicketsQuery({
       organizationIds,
       assigneeIds,
       labelIds,
+      pageSize,
     }),
     enabled: !waitingForStatusIds,
     queryFn: async ({ pageParam }) => {
@@ -68,7 +70,7 @@ export function useTicketsQuery({
         assigneeIds: assigneeIds?.length ? assigneeIds : undefined,
         labelIds: labelIds?.length ? labelIds : undefined,
         cursor: pageParam as string | undefined,
-        limit: TICKETS_PAGE_SIZE,
+        limit: pageSize,
       });
     },
     getNextPageParam: lastPage => (lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.endCursor : undefined),
@@ -101,9 +103,10 @@ export function useTicketsQuery({
         organizationIds,
         assigneeIds,
         labelIds,
+        pageSize,
       }),
     });
-  }, [queryClient, archived, search, statusFilters, statusIds, organizationIds, assigneeIds, labelIds]);
+  }, [queryClient, archived, search, statusFilters, statusIds, organizationIds, assigneeIds, labelIds, pageSize]);
 
   return {
     dialogs,

--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/utils/query-keys.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/utils/query-keys.ts
@@ -10,6 +10,9 @@ export interface DialogsQueryParams {
   organizationIds?: string[];
   assigneeIds?: string[];
   labelIds?: string[];
+  /** Page size override (default 20). Part of the query key — lists fetched
+   *  with different page sizes must not share a cache entry. */
+  pageSize?: number;
 }
 
 export const dialogsQueryKeys = {
@@ -31,6 +34,7 @@ export const dialogsQueryKeys = {
         organizationIds: params.organizationIds || [],
         assigneeIds: params.assigneeIds || [],
         labelIds: params.labelIds || [],
+        pageSize: params.pageSize ?? 20,
       },
     ] as const,
 

--- a/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/shared/devices-panel/devices-panel.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { GridIcon, PlusCircleIcon, TableCellIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  BoxArchiveIcon,
+  GridIcon,
+  PlusCircleIcon,
+  TableCellIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import {
   Alert,
   type ColumnDef,
@@ -36,14 +41,26 @@ import { EMBEDDED_PAGE_OFFSET } from '../embedded-page';
 export interface DevicesPanelProps {
   /** Page title shown in the PageLayout header. */
   title?: string;
+  /** Back button rendered above the title (e.g. on the archive page). */
+  backButton?: { label?: string; onClick: () => void };
   /** Destination of the "Add Device" button. */
   addDeviceHref?: string;
+  /** When false, drops the "Add Device" header button (e.g. on the archive page). */
+  showAddDevice?: boolean;
+  /** When set, shows an "Archive" header button linking to the archived-devices page. */
+  archiveHref?: string;
   /** Filters merged on top of URL-driven filters (e.g. lock to a single organization). */
   lockedFilters?: Partial<DeviceFilterInput>;
   /** Column ids to drop from the table (e.g. 'organization' when scoped to one org). */
   hideColumns?: string[];
-  /** Filter keys to drop from the FilterModal (e.g. 'organization' when scoped to one org). */
+  /**
+   * Filter keys to drop from the filter UI — the FilterModal, the grid filter
+   * row, and the table column-header filter (the column itself stays visible),
+   * e.g. 'organization' when scoped to one org, or 'status' on the archive page.
+   */
   hideFilters?: string[];
+  /** Message shown when the list is empty (with search/filters active or no `emptyState` given). */
+  emptyMessage?: string;
   /**
    * Default statuses applied when the user hasn't picked any. Pass `[]` to disable
    * the default and return devices of all statuses (e.g. when scoped to one customer).
@@ -83,10 +100,14 @@ export interface DevicesPanelProps {
 
 export function DevicesPanel({
   title = 'Devices',
+  backButton,
   addDeviceHref = '/devices/new',
+  showAddDevice = true,
+  archiveHref,
   lockedFilters,
   hideColumns,
   hideFilters,
+  emptyMessage = 'No devices found. Try adjusting your search or filters.',
   defaultStatuses,
   className = '',
   embedded = false,
@@ -104,7 +125,6 @@ export function DevicesPanel({
     setLocalSearch,
     debouncedSearch,
     filters: urlFilters,
-    effectiveStatuses,
     tableFilters,
     tagOptions,
     handleFilterChange,
@@ -115,8 +135,10 @@ export function DevicesPanel({
 
   const filters = useMemo<DeviceFilterInput>(() => ({ ...urlFilters, ...lockedFilters }), [urlFilters, lockedFilters]);
 
-  const { devices, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error, refetch, filteredCount } =
-    useDevices(filters, debouncedSearch);
+  const { devices, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error, filteredCount } = useDevices(
+    filters,
+    debouncedSearch,
+  );
 
   const { data: deviceFilters, isLoading: isDeviceFiltersLoading } = useDeviceFilters(filters);
 
@@ -135,15 +157,19 @@ export function DevicesPanel({
     const hidden = new Set(hideFilters ?? []);
     return getDeviceFilterColumns(deviceFilters ?? null).filter(c => !hidden.has(c.key));
   }, [deviceFilters, hideFilters]);
-  const renderRowActions = useMemo(() => getDeviceTableRowActions(() => refetch()), [refetch]);
+  // Post-action list refresh is handled centrally: useDeviceActions invalidates
+  // the device query roots, so no per-row refetch callback is needed.
+  const renderRowActions = useMemo(() => getDeviceTableRowActions(), []);
 
+  // The status column reflects only the user's explicit selection — the default
+  // statuses are a query-side fallback and must not render as checked filters.
   const columnFilters = useMemo<ColumnFiltersState>(
     () => [
-      ...(effectiveStatuses.length > 0 ? [{ id: 'status', value: effectiveStatuses }] : []),
+      ...(params.statuses.length > 0 ? [{ id: 'status', value: params.statuses }] : []),
       ...(params.osTypes.length > 0 ? [{ id: 'os', value: params.osTypes }] : []),
       ...(params.organizationIds.length > 0 ? [{ id: 'organization', value: params.organizationIds }] : []),
     ],
-    [effectiveStatuses, params.osTypes, params.organizationIds],
+    [params.statuses, params.osTypes, params.organizationIds],
   );
 
   const onColumnFiltersChange = useCallback<OnChangeFn<ColumnFiltersState>>(
@@ -197,25 +223,34 @@ export function DevicesPanel({
   // and surface an "Add Customer" action that routes to the new-customer form.
   // While the org check is still in flight, keep "Add Device" disabled too.
   const actions = useMemo<PageActionButton[]>(() => {
+    const result: PageActionButton[] = [];
+    if (archiveHref) {
+      result.push({
+        label: 'Archive',
+        href: archiveHref,
+        icon: <BoxArchiveIcon className="w-5 h-5 text-ods-text-secondary" />,
+        variant: 'outline',
+      });
+    }
+    if (!showAddDevice) return result;
     const accent = showEmptyState && !noOrganizations;
-    const addDevice: PageActionButton = {
+    if (noOrganizations) {
+      result.push({
+        label: 'Add Customer',
+        href: '/customers/new',
+        icon: <PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />,
+        variant: 'outline',
+      });
+    }
+    result.push({
       label: 'Add Device',
       onClick: () => router.push(addDeviceHref),
       disabled: noOrganizations || isCheckingOrganizations,
       icon: <PlusCircleIcon className={`w-5 h-5 ${accent ? 'text-ods-text-on-accent' : 'text-ods-text-secondary'}`} />,
       variant: accent ? 'accent' : 'outline',
-    };
-    if (!noOrganizations) return [addDevice];
-    return [
-      {
-        label: 'Add Customer',
-        href: '/customers/new',
-        icon: <PlusCircleIcon className="w-5 h-5 text-ods-text-secondary" />,
-        variant: 'outline',
-      },
-      addDevice,
-    ];
-  }, [showEmptyState, noOrganizations, isCheckingOrganizations, router, addDeviceHref]);
+    });
+    return result;
+  }, [archiveHref, showAddDevice, showEmptyState, noOrganizations, isCheckingOrganizations, router, addDeviceHref]);
 
   const handleLoadMore = useCallback(() => fetchNextPage(), [fetchNextPage]);
 
@@ -234,6 +269,7 @@ export function DevicesPanel({
     <>
       <PageLayout
         title={title}
+        backButton={backButton}
         actionsVariant="icon-buttons"
         className={cn(embedded && EMBEDDED_PAGE_OFFSET, className)}
         selector={
@@ -286,7 +322,7 @@ export function DevicesPanel({
               <DevicesTableBody
                 devices={devices}
                 isLoading={isLoading || isDeviceFiltersLoading}
-                emptyMessage="No devices found. Try adjusting your search or filters."
+                emptyMessage={emptyMessage}
                 skeletonRows={10}
                 stickyHeaderOffset="top-[96px]"
                 deviceFilters={deviceFilters ?? null}
@@ -294,6 +330,7 @@ export function DevicesPanel({
                 onColumnFiltersChange={onColumnFiltersChange}
                 actionsColumn={actionsColumn}
                 hideColumns={hideColumns}
+                disableColumnFilters={hideFilters}
                 totalCount={filteredCount}
                 footerSlot={
                   <DataTable.InfiniteFooter
@@ -318,6 +355,7 @@ export function DevicesPanel({
                   hasNextPage={hasNextPage}
                   isFetchingNextPage={isFetchingNextPage}
                   sentinelRef={gridSentinelRef}
+                  emptyMessage={emptyMessage}
                 />
               </>
             )}


### PR DESCRIPTION
## Summary

Aligns the Devices page with the Figma design ([devices frame](https://www.figma.com/design/hOyb03EVpnhOsnC5sOfHIk/openframe---devices?node-id=1-4521)) and splits archived devices out to a dedicated page.

### Devices page (`/devices`)
- Default view queries **ONLINE + OFFLINE** only; **PENDING is opt-in** via the status filter (option stays visible). The default is query-side only — nothing renders as an applied filter.
- Selecting exactly the default status set normalizes back to a clean URL (`?statuses=` dropped), so the default state never looks filtered; any other selection is an honest, explicitly-marked filter.
- **Archive** header button (per Figma) linking to the new page.

### Archive page (`/devices/archive`)
- Same `DevicesPanel` locked to `ARCHIVED`, with a **Back** button (scripts-archive pattern, `useSafeBack`), no Add Device, status filter hidden.
- Dashboard "Archived Devices" card now deep-links here instead of the (now unreachable) `?statuses=ARCHIVED` filter.

### Unarchive action
- New row/detail menu action for ARCHIVED devices. PATCHes status to **OFFLINE** — verified against backend (`openframe-oss-lib`): no transition guards, and the agent heartbeat promotes the device to ONLINE on next check-in (PENDING = "never connected", so not a valid restore target). No confirm dialog — non-destructive and instantly reversible.

### Centralized cache invalidation
- `useDeviceActions` (the single mutation site for archive/unarchive/delete) invalidates `['devices']` (lists + details), `['deviceFilters']` (facet counts) and dashboard device stats. Per-view `refetch()` wiring removed — active views refetch immediately, stale caches refetch on next mount.

### getDeviceName — SSOT for device names
- `devices/utils/device-name.ts`: display name = GraphQL `displayName || hostname`, no other fallbacks (description, machineId, Fleet `display_name`). Adopted across table, grid, detail title, Mingo context, unarchive toast, confirm dialogs.

## Review notes (multi-angle review, 8 finders + adversarial verify)

Fixed during review:
- Monitoring query/policy tables kept their archived-device enrichment via new `DEVICE_ENRICHMENT_STATUSES` (they'd have silently lost ARCHIVED rows' org/OS metadata).
- Detail title gets an `'Unknown Device'` fallback for empty-name records.
- One `useDeviceActions` instance per row dropdown (was 2 after unarchive addition).
- Query-key registries linked by reference instead of a duplicated `'devices'` literal; status PATCH bodies use `DEVICE_STATUS.*` constants; stable `[]` identity on the archive page.

Known/accepted (deliberate SSOT decisions, flagged for visibility):
- The device-info "Hostname" cell renders `getDeviceName()` (displayName-first) — per the SSOT policy the raw hostname is not shown separately.
- `use-device-details` no longer falls back to Fleet `hostname`/`display_name` — GraphQL is the only identity source; remote-shell/file-manager/ticket-matching consumers now see `node.hostname` only.
- A customer's archived devices are reachable only via `/devices/archive` (filterable by customer), not from the customer's Devices tab.

## Test plan
- `npm run lint:biome` ✅ (pre-commit gate), `tsc` clean on touched files (yalc lib `.d.ts` noise excluded), production `next build` ✅ (`/devices/archive` route emitted).
- Manual: devices default view (no PENDING, clean URL), PENDING opt-in, archive → device disappears from list + dashboard counters refresh, archive page lists ARCHIVED with Back, unarchive → returns to default view, delete flow unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Archived Devices page with back navigation and a clear empty state.
  * Added an **Unarchive** action so archived devices can be restored from device menus.
  * Devices panels now support an Archive button and more flexible empty-state messaging.

* **Bug Fixes**
  * Improved device naming across the app for more consistent titles, labels, and table rows.
  * Refined device filtering so archived devices are separated from the main list and default filters behave more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->