### PR TITLE
fix(frontend): mark approval notification read when decided in Mingo chat

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-dialog-selection.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/mingo/hooks/use-mingo-dialog-selection.ts
@@ -11,6 +11,7 @@ import {
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useApprovalNotificationReader } from '@/app/components/notifications/use-approval-notification-reader';
 import { EVENT_SUBTYPE, trackDashboardActivity } from '@/lib/analytics';
 import { apiClient } from '@/lib/api-client';
 import { foldPendingApprovalsEnvelope } from '@/lib/chat-history';
@@ -43,6 +44,9 @@ export function useMingoDialogSelection() {
 
   const approveRequestMutation = useApproveRequestMutation();
   const rejectRequestMutation = useRejectRequestMutation();
+  // Clears the approval-request notification when the user decides it in the chat (drawer has no URL,
+  // so the location auto-reader can't). Same effect as resolving it from Notifications › Approvals.
+  const markApprovalNotificationRead = useApprovalNotificationReader();
 
   const handleApprove = useCallback(
     async (requestId?: string) => {
@@ -62,6 +66,7 @@ export function useMingoDialogSelection() {
 
       try {
         await approveRequestMutation.mutateAsync(requestId);
+        markApprovalNotificationRead(requestId);
         trackDashboardActivity(EVENT_SUBTYPE.APPROVE_MINGO_COMMAND);
       } catch (error) {
         toast({
@@ -72,7 +77,7 @@ export function useMingoDialogSelection() {
         });
       }
     },
-    [approveRequestMutation, toast, activeDialogId, updateApprovalStatusInMessages],
+    [approveRequestMutation, toast, activeDialogId, updateApprovalStatusInMessages, markApprovalNotificationRead],
   );
 
   const handleReject = useCallback(
@@ -87,6 +92,7 @@ export function useMingoDialogSelection() {
 
       try {
         await rejectRequestMutation.mutateAsync(requestId);
+        markApprovalNotificationRead(requestId);
         trackDashboardActivity(EVENT_SUBTYPE.REJECT_MINGO_COMMAND);
       } catch (error) {
         toast({
@@ -97,7 +103,7 @@ export function useMingoDialogSelection() {
         });
       }
     },
-    [rejectRequestMutation, toast, activeDialogId, updateApprovalStatusInMessages],
+    [rejectRequestMutation, toast, activeDialogId, updateApprovalStatusInMessages, markApprovalNotificationRead],
   );
 
   const handleApproveRef = useRef(handleApprove);

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notifications-data-provider.tsx
@@ -433,7 +433,7 @@ function NotificationsDataInner({
  * every entity type a notification can carry, and routes through the context's `markRead` so
  * the drawer list, the unread connection and the sidebar bucket all update together. Pending
  * approval requests are left unread — opening the entity isn't acting on them; they clear only
- * once approved/rejected.
+ * once approved/rejected (handled imperatively at the decision site — see useApprovalNotificationReader).
  */
 function EntityViewAutoReader() {
   const pathname = usePathname();

--- a/openframe/services/openframe-frontend/src/app/components/notifications/use-approval-notification-reader.ts
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/use-approval-notification-reader.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { getApprovalMeta, useNotifications } from '@flamingo-stack/openframe-frontend-core';
+import { useCallback, useRef } from 'react';
+
+/**
+ * Imperatively marks the approval-request notification read once the user decides it (approve/reject)
+ * somewhere other than the Notifications › Approvals list — e.g. inside the Mingo chat drawer, which
+ * has no URL for `EntityViewAutoReader` to key off. Mirrors what the Approvals sub-row does on a
+ * successful decision (`onResolved` → `markRead`), matching the pending notification to the resolved
+ * request by `approvalRequestId`. `markRead` routes through the provider so the drawer list, the
+ * unread connection and the sidebar bucket all update together, and persists the read server-side.
+ */
+export function useApprovalNotificationReader(): (approvalRequestId: string) => void {
+  const { notifications, markRead } = useNotifications();
+  // Ref so the returned callback stays stable and always reads the latest list without resubscribing.
+  const notificationsRef = useRef(notifications);
+  notificationsRef.current = notifications;
+
+  return useCallback(
+    (approvalRequestId: string) => {
+      const match = notificationsRef.current.find(
+        n => !n.read && getApprovalMeta(n)?.approvalRequestId === approvalRequestId,
+      );
+      if (match) markRead(match.id);
+    },
+    [markRead],
+  );
+}


### PR DESCRIPTION
## Problem

When a user approves (or rejects) an action **directly inside the Mingo chat**, the corresponding approval notification stays **unread**. It only clears if the user goes through **Notifications › Approvals** manually.

## Root cause

The auto-read for approval notifications fired only via **URL matching** in `EntityViewAutoReader`:

- On the standalone `/mingo` page, viewing a dialog put the dialog id in the URL (`/mingo?dialogId=X`), so once the approval resolved the location match cleared it.
- The in-layout **chat drawer has no URL**, so `notificationTargetsLocation` never matches → the notification is never marked read.

The chat approve/reject handlers themselves never touched notifications — the only path that cleared them was the manual Approvals sub-row, which imperatively calls `markRead` on a successful decision.

## Fix

Mirror the proven Approvals-list path for the chat, independent of any NATS timing:

- **`useApprovalNotificationReader`** — new hook that finds the unread notification by `approvalRequestId` and calls `markRead` (updates the drawer list, unread connection, sidebar bucket, and persists server-side).
- Called from the shared Mingo approve/reject handlers (`use-mingo-dialog-selection.ts`) right after the mutation succeeds — so it works for both the drawer and the legacy `/mingo` page, on both approve and reject.

## Testing

- `npm run lint:biome` — clean on touched files
- `npm run type-check` — no new errors in touched files
- Manual: approve/reject inside the Mingo chat → related notification immediately leaves the unread list.