### PR TITLE
chore(renovate): track meshcentral helm chart, drop dead integrated-tools rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["maven", "npm", "helmv3", "regex", "cargo"],
-  "labels": ["dependencies", "openframe-libs"],
+  "enabledManagers": [
+    "maven",
+    "npm",
+    "helmv3",
+    "cargo"
+  ],
+  "labels": [
+    "dependencies",
+    "openframe-libs"
+  ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "prCreation": "immediate",
@@ -11,113 +19,96 @@
   "commitMessageAction": "",
   "commitMessageExtra": "to {{{newVersion}}}",
   "commitMessagePrefix": "chore(deps):",
-
   "packageRules": [
     {
       "description": "Updates for OpenFrame OSS libs property",
-      "matchManagers": ["maven"],
-      "matchPackagePatterns": ["^com\\.openframe\\.oss"],
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackagePatterns": [
+        "^com\\.openframe\\.oss"
+      ],
       "groupName": "openframe-libs",
       "groupSlug": "openframe-libs",
       "commitMessageTopic": "OpenFrame libs",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": ["dependencies", "openframe-libs"],
+      "labels": [
+        "dependencies",
+        "openframe-libs"
+      ],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true
     },
     {
       "description": "Ignore parent POM, prevent lookup errors",
-      "matchPackageNames": ["com.openframe:openframe-parent"],
+      "matchPackageNames": [
+        "com.openframe:openframe-parent"
+      ],
       "enabled": false
     },
     {
       "description": "Disable all other dependencies - only update openframe libs",
-      "matchManagers": ["maven"],
-      "matchPackageNames": ["!/^com\\.openframe\\.oss/"],
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "!/^com\\.openframe\\.oss/"
+      ],
       "enabled": false
     },
     {
       "description": "Updates for OpenFrame frontend core npm package",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@flamingo-stack/openframe-frontend-core"],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@flamingo-stack/openframe-frontend-core"
+      ],
       "groupName": "openframe-frontend-core",
       "groupSlug": "openframe-frontend-core",
       "commitMessageTopic": "OpenFrame frontend core",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": ["dependencies", "openframe-libs"],
+      "labels": [
+        "dependencies",
+        "openframe-libs"
+      ],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true
     },
     {
       "description": "Disable all other npm dependencies - only update openframe-frontend-core",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["!@flamingo-stack/openframe-frontend-core"],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "!@flamingo-stack/openframe-frontend-core"
+      ],
       "enabled": false
     },
     {
-      "description": "Updates for fleetm Docker image",
-      "matchManagers": ["regex"],
-      "matchPackageNames": ["ghcr.io/flamingo-stack/fleetmdm/fleet"],
-      "groupName": "FleetMDM",
-      "groupSlug": "fleetmdm-image",
-      "commitMessageTopic": "FleetMDM",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "labels": ["dependencies", "fleetmdm"],
-      "prPriority": 10,
-      "enabled": true,
-      "ignoreUnstable": true,
-      "allowedVersions": "!/^9\\.9\\.9$/",
-      "separateMajorMinor": false
-    },
-    {
-      "description": "Updates for meshcentral Docker image",
-      "matchManagers": ["regex"],
-      "matchPackageNames": ["ghcr.io/flamingo-stack/meshcentral/meshcentral"],
-      "groupName": "MeshCentral",
-      "groupSlug": "meshcentral-image",
-      "commitMessageTopic": "MeshCentral",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "labels": ["dependencies", "meshcentral"],
-      "prPriority": 10,
-      "enabled": true,
-      "ignoreUnstable": true,
-      "separateMajorMinor": false
-    },
-    {
-      "description": "Updates for tacticalrmm Docker images",
-      "matchManagers": ["regex"],
-      "matchPackageNames": [
-        "ghcr.io/flamingo-stack/tacticalrmm/tactical",
-        "ghcr.io/flamingo-stack/tactical-frontend/tactical-frontend"
-      ],
-      "groupName": "TacticalRMM",
-      "groupSlug": "tacticalrmm-image",
-      "commitMessageTopic": "TacticalRMM",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "labels": ["dependencies", "tacticalrmm"],
-      "prPriority": 10,
-      "enabled": true,
-      "ignoreUnstable": true,
-      "separateMajorMinor": false
-    },
-    {
       "description": "Updates for fleetm Helm chart",
-      "matchManagers": ["helmv3"],
-      "matchPackageNames": ["fleet"],
-      "matchSourceUrls": ["oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"],
+      "matchManagers": [
+        "helmv3"
+      ],
+      "matchPackageNames": [
+        "fleet"
+      ],
+      "matchSourceUrls": [
+        "oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"
+      ],
       "groupName": "FleetMDM Helm chart",
       "groupSlug": "fleetmdm-helm-chart",
       "commitMessageTopic": "FleetMDM Helm chart",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": ["dependencies", "fleetmdm"],
+      "labels": [
+        "dependencies",
+        "fleetmdm"
+      ],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true,
@@ -125,84 +116,77 @@
       "separateMajorMinor": false
     },
     {
+      "description": "Updates for meshcentral Helm chart",
+      "matchManagers": [
+        "helmv3"
+      ],
+      "matchPackageNames": [
+        "meshcentral"
+      ],
+      "matchSourceUrls": [
+        "oci://ghcr.io/flamingo-stack/meshcentral/helm-charts"
+      ],
+      "groupName": "MeshCentral Helm chart",
+      "groupSlug": "meshcentral-helm-chart",
+      "commitMessageTopic": "MeshCentral Helm chart",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "labels": [
+        "dependencies",
+        "meshcentral"
+      ],
+      "prPriority": 10,
+      "enabled": true,
+      "ignoreUnstable": true,
+      "separateMajorMinor": false
+    },
+    {
       "description": "Only update fleetmdm chart",
-      "matchManagers": ["helmv3"],
-      "matchPackageNames": ["!fleet"],
+      "matchManagers": [
+        "helmv3"
+      ],
+      "matchPackageNames": [
+        "!fleet",
+        "!meshcentral"
+      ],
       "enabled": false
     },
     {
-      "description": "Track ALL deps for openframe-client (Rust/cargo) — one grouped PR",
-      "matchFileNames": ["clients/openframe-client/**"],
+      "description": "Track ALL deps for openframe-client (Rust/cargo) \u2014 one grouped PR",
+      "matchFileNames": [
+        "clients/openframe-client/**"
+      ],
       "enabled": true,
       "groupName": "openframe-client deps",
       "groupSlug": "openframe-client-deps",
       "commitMessageTopic": "openframe-client deps",
-      "labels": ["dependencies", "clients", "openframe-client"],
+      "labels": [
+        "dependencies",
+        "clients",
+        "openframe-client"
+      ],
       "prPriority": 20
     },
     {
-      "description": "Track ALL deps for openframe-chat (npm + Tauri/cargo) — one grouped PR",
-      "matchFileNames": ["clients/openframe-chat/**"],
+      "description": "Track ALL deps for openframe-chat (npm + Tauri/cargo) \u2014 one grouped PR",
+      "matchFileNames": [
+        "clients/openframe-chat/**"
+      ],
       "enabled": true,
       "groupName": "openframe-chat deps",
       "groupSlug": "openframe-chat-deps",
       "commitMessageTopic": "openframe-chat deps",
-      "labels": ["dependencies", "clients", "openframe-chat"],
+      "labels": [
+        "dependencies",
+        "clients",
+        "openframe-chat"
+      ],
       "prPriority": 20
     }
   ],
-
-  "regexManagers": [
-    {
-      "description": "Track fleetmdm image tag in the fleet chart values.yaml",
-      "fileMatch": [
-        "^manifests/integrated-tools/fleet/values\\.yaml$"
-      ],
-      "matchStrings": [
-        "imageTag:\\s*[\"']?(?<currentValue>[^\\s\"']+)[\"']?"
-      ],
-      "depNameTemplate": "ghcr.io/flamingo-stack/fleetmdm/fleet",
-      "datasourceTemplate": "docker"
-    },
-    {
-      "description": "Track meshcentral image tag",
-      "fileMatch": [
-        "^manifests/integrated-tools/meshcentral/values\\.yaml$"
-      ],
-      "matchStrings": [
-        "repository: meshcentral\\s+tag:\\s*[\"']?(?<currentValue>[^\\s\"']+)[\"']?"
-      ],
-      "depNameTemplate": "ghcr.io/flamingo-stack/meshcentral/meshcentral",
-      "datasourceTemplate": "docker"
-    },
-    {
-      "description": "Track tactical-base image tag",
-      "fileMatch": [
-        "^manifests/integrated-tools/tactical-rmm/values\\.yaml$"
-      ],
-      "matchStrings": [
-        "repository: tactical\\s+tag:\\s*[\"']?(?<currentValue>[^\\s\"']+)[\"']?"
-      ],
-      "depNameTemplate": "ghcr.io/flamingo-stack/tacticalrmm/tactical",
-      "datasourceTemplate": "docker"
-    },
-    {
-      "description": "Track tactical-frontend image tag",
-      "fileMatch": [
-        "^manifests/integrated-tools/tactical-rmm/values\\.yaml$"
-      ],
-      "matchStrings": [
-        "repository: tactical-frontend\\s+tag:\\s*[\"']?(?<currentValue>[^\\s\"']+)[\"']?"
-      ],
-      "depNameTemplate": "ghcr.io/flamingo-stack/tactical-frontend/tactical-frontend",
-      "datasourceTemplate": "docker"
-    }
-  ],
-
   "maven": {
     "enabled": true
   },
-
   "hostRules": [
     {
       "hostType": "maven",
@@ -210,7 +194,6 @@
       "description": "GitHub Packages Maven registry"
     }
   ],
-
   "registryAliases": {
     "github-packages": "https://maven.pkg.github.com"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": [
-    "maven",
-    "npm",
-    "helmv3",
-    "cargo"
-  ],
-  "labels": [
-    "dependencies",
-    "openframe-libs"
-  ],
+  "enabledManagers": ["maven", "npm", "helmv3", "cargo"],
+  "labels": ["dependencies", "openframe-libs"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "prCreation": "immediate",
@@ -19,96 +11,64 @@
   "commitMessageAction": "",
   "commitMessageExtra": "to {{{newVersion}}}",
   "commitMessagePrefix": "chore(deps):",
+
   "packageRules": [
     {
       "description": "Updates for OpenFrame OSS libs property",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackagePatterns": [
-        "^com\\.openframe\\.oss"
-      ],
+      "matchManagers": ["maven"],
+      "matchPackagePatterns": ["^com\\.openframe\\.oss"],
       "groupName": "openframe-libs",
       "groupSlug": "openframe-libs",
       "commitMessageTopic": "OpenFrame libs",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": [
-        "dependencies",
-        "openframe-libs"
-      ],
+      "labels": ["dependencies", "openframe-libs"],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true
     },
     {
       "description": "Ignore parent POM, prevent lookup errors",
-      "matchPackageNames": [
-        "com.openframe:openframe-parent"
-      ],
+      "matchPackageNames": ["com.openframe:openframe-parent"],
       "enabled": false
     },
     {
       "description": "Disable all other dependencies - only update openframe libs",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "!/^com\\.openframe\\.oss/"
-      ],
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["!/^com\\.openframe\\.oss/"],
       "enabled": false
     },
     {
       "description": "Updates for OpenFrame frontend core npm package",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "@flamingo-stack/openframe-frontend-core"
-      ],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@flamingo-stack/openframe-frontend-core"],
       "groupName": "openframe-frontend-core",
       "groupSlug": "openframe-frontend-core",
       "commitMessageTopic": "OpenFrame frontend core",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": [
-        "dependencies",
-        "openframe-libs"
-      ],
+      "labels": ["dependencies", "openframe-libs"],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true
     },
     {
       "description": "Disable all other npm dependencies - only update openframe-frontend-core",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "!@flamingo-stack/openframe-frontend-core"
-      ],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["!@flamingo-stack/openframe-frontend-core"],
       "enabled": false
     },
     {
       "description": "Updates for fleetm Helm chart",
-      "matchManagers": [
-        "helmv3"
-      ],
-      "matchPackageNames": [
-        "fleet"
-      ],
-      "matchSourceUrls": [
-        "oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"
-      ],
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["fleet"],
+      "matchSourceUrls": ["oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"],
       "groupName": "FleetMDM Helm chart",
       "groupSlug": "fleetmdm-helm-chart",
       "commitMessageTopic": "FleetMDM Helm chart",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": [
-        "dependencies",
-        "fleetmdm"
-      ],
+      "labels": ["dependencies", "fleetmdm"],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true,
@@ -117,76 +77,52 @@
     },
     {
       "description": "Updates for meshcentral Helm chart",
-      "matchManagers": [
-        "helmv3"
-      ],
-      "matchPackageNames": [
-        "meshcentral"
-      ],
-      "matchSourceUrls": [
-        "oci://ghcr.io/flamingo-stack/meshcentral/helm-charts"
-      ],
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["meshcentral"],
+      "matchSourceUrls": ["oci://ghcr.io/flamingo-stack/meshcentral/helm-charts"],
       "groupName": "MeshCentral Helm chart",
       "groupSlug": "meshcentral-helm-chart",
       "commitMessageTopic": "MeshCentral Helm chart",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
-      "labels": [
-        "dependencies",
-        "meshcentral"
-      ],
+      "labels": ["dependencies", "meshcentral"],
       "prPriority": 10,
       "enabled": true,
       "ignoreUnstable": true,
       "separateMajorMinor": false
     },
     {
-      "description": "Only update fleetmdm chart",
-      "matchManagers": [
-        "helmv3"
-      ],
-      "matchPackageNames": [
-        "!fleet",
-        "!meshcentral"
-      ],
+      "description": "Only update whitelisted charts",
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["!fleet", "!meshcentral"],
       "enabled": false
     },
     {
-      "description": "Track ALL deps for openframe-client (Rust/cargo) \u2014 one grouped PR",
-      "matchFileNames": [
-        "clients/openframe-client/**"
-      ],
+      "description": "Track ALL deps for openframe-client (Rust/cargo) — one grouped PR",
+      "matchFileNames": ["clients/openframe-client/**"],
       "enabled": true,
       "groupName": "openframe-client deps",
       "groupSlug": "openframe-client-deps",
       "commitMessageTopic": "openframe-client deps",
-      "labels": [
-        "dependencies",
-        "clients",
-        "openframe-client"
-      ],
+      "labels": ["dependencies", "clients", "openframe-client"],
       "prPriority": 20
     },
     {
-      "description": "Track ALL deps for openframe-chat (npm + Tauri/cargo) \u2014 one grouped PR",
-      "matchFileNames": [
-        "clients/openframe-chat/**"
-      ],
+      "description": "Track ALL deps for openframe-chat (npm + Tauri/cargo) — one grouped PR",
+      "matchFileNames": ["clients/openframe-chat/**"],
       "enabled": true,
       "groupName": "openframe-chat deps",
       "groupSlug": "openframe-chat-deps",
       "commitMessageTopic": "openframe-chat deps",
-      "labels": [
-        "dependencies",
-        "clients",
-        "openframe-chat"
-      ],
+      "labels": ["dependencies", "clients", "openframe-chat"],
       "prPriority": 20
     }
   ],
+
   "maven": {
     "enabled": true
   },
+
   "hostRules": [
     {
       "hostType": "maven",
@@ -194,6 +130,7 @@
       "description": "GitHub Packages Maven registry"
     }
   ],
+
   "registryAliases": {
     "github-packages": "https://maven.pkg.github.com"
   }


### PR DESCRIPTION
meshcentral migrated to a helm-chart dependency (Chart.yaml) but Renovate still had a dead regexManager pointing at the removed integrated-tools path, and the helmv3 default-deny only allowed fleet. Adds a helmv3 rule for the meshcentral OCI chart and allows it past the deny, mirroring the fleet setup. Also drops the dead integrated-tools regexManagers and their orphaned packageRules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency tracking to better handle Helm chart updates.
  * Changed certain service update rules to follow chart-based releases instead of image-tag-based tracking.
  * Removed outdated update configuration for some previously tracked image values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->