### PR TITLE
ci(release): fix latest release not updating on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
     uses: ./.github/workflows/version.yml
     with:
       version: ${{ inputs.version }}
-      is-release: ${{ github.event_name == 'workflow_dispatch' }}
 
   changes:
     name: Detect Changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ env:
 jobs:
   version:
     name: Resolve Version
-    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/version.yml
     with:
       version: ${{ inputs.version }}
+      is-release: ${{ github.event_name == 'workflow_dispatch' }}
 
   changes:
     name: Detect Changes
@@ -198,7 +198,7 @@ jobs:
         working-directory: ${{ matrix.path }}
         if: steps.should_run.outputs.run == 'true'
         env:
-          VERSION: ${{ needs.version.outputs.version || 'latest' }}
+          VERSION: ${{ needs.version.outputs.version }}
         run: |
           if [[ "${{ matrix.name }}" == "openframe-client" && "${{ matrix.os }}" == "macos" ]]; then
             IFS=',' read -ra ARCHITECTURES <<< "${{ matrix.target }}"
@@ -297,7 +297,7 @@ jobs:
         if: steps.should_run.outputs.run == 'true'
         with:
           name: app-of-apps
-          tag: ${{ inputs.version || '9.9.9' }}
+          tag: ${{ needs.version.outputs.version }}
           path: ./manifests/app-of-apps
           registry: ${{ env.REGISTRY }}
           repository: ${{ env.ORGANISATION }}/${{ env.REPOSITORY }}
@@ -346,7 +346,7 @@ jobs:
 
       - name: Generate release header
         run: |
-          VERSION="${{ needs.version.outputs.version || 'latest' }}"
+          VERSION="${{ needs.version.outputs.version }}"
           IMAGES=$(echo '${{ needs.matrix.outputs.images_matrix }}' | jq -r '.[] | "- `${{ env.REGISTRY }}/${{ env.ORGANISATION }}/${{ env.REPOSITORY }}/\(.name):'"${VERSION}"'`"')
 
           cat > RELEASE_HEADER.md <<EOF
@@ -375,8 +375,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.version.outputs.version || 'latest' }}
-          name: "🦩 ${{ needs.version.outputs.version || 'latest' }}"
+          tag_name: ${{ needs.version.outputs.version }}
+          name: "🦩 ${{ needs.version.outputs.version }}"
           draft: false
           prerelease: ${{ github.event_name == 'push' }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,7 +33,6 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,11 +8,6 @@ on:
         required: false
         type: string
         default: ''
-      is-release:
-        description: "true on workflow_dispatch (resolve/bump); false on push (returns latest)"
-        required: false
-        type: string
-        default: 'true'
     outputs:
       version:
         description: "Resolved release version"
@@ -33,11 +28,11 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          IS_RELEASE: ${{ inputs.is-release }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          if [ "$IS_RELEASE" != "true" ]; then
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
             echo "push event: version resolves to latest"
             echo "version=latest" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ''
+      is-release:
+        description: "true on workflow_dispatch (resolve/bump); false on push (returns latest)"
+        required: false
+        type: string
+        default: 'true'
     outputs:
       version:
         description: "Resolved release version"
@@ -28,8 +33,15 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          IS_RELEASE: ${{ inputs.is-release }}
         run: |
           set -euo pipefail
+
+          if [ "$IS_RELEASE" != "true" ]; then
+            echo "push event: version resolves to latest"
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           latest=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           latest=${latest:-0.0.0}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,27 +18,28 @@ jobs:
     name: Resolve version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.version_push.outputs.version || steps.version_dispatch.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Resolve version (push)
+        id: version_push
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          echo "push event: version resolves to latest"
+          echo "version=latest" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve version
-        id: version
+      - name: Resolve version (dispatch)
+        id: version_dispatch
+        if: github.event_name == 'workflow_dispatch'
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
-            echo "push event: version resolves to latest"
-            echo "version=latest" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          latest=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          latest=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases \
+            --json tagName --jq '.[].tagName' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '^9\.9\.' | sort -V | tail -1 || true)
           latest=${latest:-0.0.0}
           IFS='.' read -r cur_major cur_minor cur_patch <<< "$latest"
 
@@ -48,6 +49,13 @@ jobs:
           else
             if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Invalid version format: ${INPUT_VERSION} (expected x.y.z)"
+              exit 1
+            fi
+            IFS='.' read -r new_major new_minor new_patch <<< "$INPUT_VERSION"
+            if ! ([ "$new_major" -eq $((cur_major + 1)) ] && [ "$new_minor" -eq 0 ] && [ "$new_patch" -eq 0 ]) &&
+               ! ([ "$new_major" -eq "$cur_major" ] && [ "$new_minor" -eq $((cur_minor + 1)) ] && [ "$new_patch" -eq 0 ]) &&
+               ! ([ "$new_major" -eq "$cur_major" ] && [ "$new_minor" -eq "$cur_minor" ] && [ "$new_patch" -eq $((cur_patch + 1)) ]); then
+              echo "Invalid version bump: ${latest} -> ${INPUT_VERSION}"
               exit 1
             fi
             version="$INPUT_VERSION"


### PR DESCRIPTION
The version job is gated to workflow_dispatch, so on push it is skipped. Jobs that need version (build_images, build_clients, build_helm, release) were skipped too, so latest stopped updating on push. Guard them with if not failure and not cancelled so they run on push and on dispatch alike.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The release process now consistently resolves a version for all release steps.
  * Non-release runs now use `latest` automatically, while release runs continue to use the resolved version.

* **Bug Fixes**
  * Removed several version fallbacks so build artifacts, charts, and GitHub releases all use the same version value.
  * Release tags and names now match the resolved version more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->