### PR TITLE
ci(test): verify openframe CLI download before bootstrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,9 +197,20 @@ jobs:
         working-directory: cli
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENFRAME_CLI_URL: "https://github.com/${{ env.ORGANISATION }}/openframe-cli/releases/latest/download/openframe-cli_linux_amd64.tar.gz"
+          OPENFRAME_CLI_BASE: "https://github.com/${{ env.ORGANISATION }}/openframe-cli/releases/latest/download"
+          OPENFRAME_CLI_ARCHIVE: "openframe-cli_linux_amd64.tar.gz"
         run: |
-          curl -fL "$OPENFRAME_CLI_URL" | tar -xz -C /tmp && install -m 0755 /tmp/openframe /usr/local/bin/openframe
+          set -euo pipefail
+          # Download the release archive and verify it against the release
+          # checksums before installing — a truncated download or an HTML error
+          # page (e.g. a release with no assets) must fail here, not deep inside
+          # bootstrap. --ignore-missing checks only the archive we fetched.
+          curl -fLo "/tmp/${OPENFRAME_CLI_ARCHIVE}" "${OPENFRAME_CLI_BASE}/${OPENFRAME_CLI_ARCHIVE}"
+          curl -fLo /tmp/checksums.txt "${OPENFRAME_CLI_BASE}/checksums.txt"
+          ( cd /tmp && sha256sum --ignore-missing -c checksums.txt )
+          tar -xzf "/tmp/${OPENFRAME_CLI_ARCHIVE}" -C /tmp
+          install -m 0755 /tmp/openframe /usr/local/bin/openframe
+          openframe --version
           openframe bootstrap --deployment-mode=oss-tenant --non-interactive --verbose
 
       - name: Setup Telepresence

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,6 +207,10 @@ jobs:
           # bootstrap. --ignore-missing checks only the archive we fetched.
           curl -fLo "/tmp/${OPENFRAME_CLI_ARCHIVE}" "${OPENFRAME_CLI_BASE}/${OPENFRAME_CLI_ARCHIVE}"
           curl -fLo /tmp/checksums.txt "${OPENFRAME_CLI_BASE}/checksums.txt"
+          # Guard: assert the archive is actually listed. --ignore-missing skips
+          # unlisted entries, so a name drift would otherwise verify nothing
+          # (GNU exits 1 on "no file was verified", but BSD sha256sum passes 0).
+          grep -qF "${OPENFRAME_CLI_ARCHIVE}" /tmp/checksums.txt
           ( cd /tmp && sha256sum --ignore-missing -c checksums.txt )
           tar -xzf "/tmp/${OPENFRAME_CLI_ARCHIVE}" -C /tmp
           install -m 0755 /tmp/openframe /usr/local/bin/openframe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,15 +201,10 @@ jobs:
           OPENFRAME_CLI_ARCHIVE: "openframe-cli_linux_amd64.tar.gz"
         run: |
           set -euo pipefail
-          # Download the release archive and verify it against the release
-          # checksums before installing — a truncated download or an HTML error
-          # page (e.g. a release with no assets) must fail here, not deep inside
-          # bootstrap. --ignore-missing checks only the archive we fetched.
+          # Download the release archive and verify it against the release checksums before installing.
           curl -fLo "/tmp/${OPENFRAME_CLI_ARCHIVE}" "${OPENFRAME_CLI_BASE}/${OPENFRAME_CLI_ARCHIVE}"
           curl -fLo /tmp/checksums.txt "${OPENFRAME_CLI_BASE}/checksums.txt"
-          # Guard: assert the archive is actually listed. --ignore-missing skips
-          # unlisted entries, so a name drift would otherwise verify nothing
-          # (GNU exits 1 on "no file was verified", but BSD sha256sum passes 0).
+          # Guard: assert the archive is actually listed.
           grep -qF "${OPENFRAME_CLI_ARCHIVE}" /tmp/checksums.txt
           ( cd /tmp && sha256sum --ignore-missing -c checksums.txt )
           tar -xzf "/tmp/${OPENFRAME_CLI_ARCHIVE}" -C /tmp


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved the automated test workflow’s CLI installation by switching to a fixed archive download, validating it against a checksum list, and installing it more reliably.
  * Added stronger shell safety checks and an `--version` verification step to fail fast if setup is incorrect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->