### PR TITLE
Auth: real-time email validation on registration

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
@@ -55,8 +55,9 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
   const handleCreateOrganization = async () => {
     if (!orgName.trim() || !isOrgNameValid || !isOrgEmailValid) return;
 
-    // Real-time check already flagged the email as registered — block submit.
-    if (emailStatus === 'taken') return;
+    // Block submit while the email check is pending or if it flagged the email as
+    // registered — keeps the Enter-key paths aligned with the disabled Continue button.
+    if (emailStatus === 'checking' || emailStatus === 'taken') return;
 
     if (isSaasShared) {
       if (!accessCode.trim()) {

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/components/choice-section.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { isSaasSharedMode } from '@/lib/app-mode';
 import { authApiClient, SAAS_DOMAIN_SUFFIX } from '@/lib/auth-api-client';
 import { AUTH_ERROR_CODE } from '../constants/auth-error-codes';
-import { useDomainAvailability } from '../hooks/use-registration-availability';
+import { useDomainAvailability, useEmailAvailability } from '../hooks/use-registration-availability';
 import { ForgotPasswordModal } from './forgot-password-modal';
 
 interface AuthChoiceSectionProps {
@@ -41,8 +41,8 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
   const isOrgEmailValid = emailRegex.test(orgEmail.trim());
   const isSignInEmailValid = emailRegex.test(signInEmail.trim());
 
-  // Real-time domain availability check (debounced). Real-time email validation is
-  // temporarily disabled — pending a dedicated BE endpoint for email registration checks.
+  // Real-time availability checks (debounced).
+  const emailStatus = useEmailAvailability(orgEmail);
   const { status: domainStatus, suggestions: liveDomainSuggestions } = useDomainAvailability(
     domain,
     orgName,
@@ -54,6 +54,9 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
 
   const handleCreateOrganization = async () => {
     if (!orgName.trim() || !isOrgNameValid || !isOrgEmailValid) return;
+
+    // Real-time check already flagged the email as registered — block submit.
+    if (emailStatus === 'taken') return;
 
     if (isSaasShared) {
       if (!accessCode.trim()) {
@@ -215,6 +218,15 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
               {orgEmail.trim() && !isOrgEmailValid && (
                 <p className="text-xs text-ods-error mt-1">Enter a valid email address</p>
               )}
+              {isOrgEmailValid && emailStatus === 'checking' && (
+                <p className="text-xs text-ods-text-secondary mt-1">Checking availability…</p>
+              )}
+              {isOrgEmailValid && emailStatus === 'taken' && (
+                <p className="text-xs text-ods-error mt-1">This email is already registered. Sign in instead.</p>
+              )}
+              {isOrgEmailValid && emailStatus === 'available' && (
+                <p className="text-xs text-ods-success mt-1">Email is available</p>
+              )}
             </div>
             <div className="flex-1 flex flex-col gap-1">
               <Label>Organization Name</Label>
@@ -347,6 +359,8 @@ export function AuthChoiceSection({ onCreateOrganization, onSignIn, isLoading }:
                 disabled={
                   !orgName.trim() ||
                   !isOrgEmailValid ||
+                  emailStatus === 'taken' ||
+                  emailStatus === 'checking' ||
                   (isSaasShared && (!domain.trim() || !accessCode.trim())) ||
                   (isSaasShared && (domainStatus === 'taken' || domainStatus === 'checking')) ||
                   isLoading ||

--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-registration-availability.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/hooks/use-registration-availability.ts
@@ -6,10 +6,44 @@ import { authApiClient, SAAS_DOMAIN_SUFFIX } from '@/lib/auth-api-client';
 
 export type AvailabilityStatus = 'idle' | 'checking' | 'available' | 'taken' | 'error';
 
-// NOTE: real-time email availability is temporarily unimplemented. It previously used
-// `discoverTenants`, which flags any email that belongs to a tenant — too broad to gate
-// registration. A dedicated BE endpoint for "is this email registered" is pending; the
-// email hook will be reintroduced against it.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Debounced check of whether an email is already registered. Runs only on valid email format. */
+export function useEmailAvailability(email: string, delay = 400): AvailabilityStatus {
+  const debounced = useDebounce(email.trim(), delay);
+  const [status, setStatus] = useState<AvailabilityStatus>('idle');
+
+  useEffect(() => {
+    if (!debounced || !EMAIL_REGEX.test(debounced)) {
+      setStatus('idle');
+      return;
+    }
+
+    let cancelled = false;
+    setStatus('checking');
+
+    authApiClient
+      .checkEmailAvailability(debounced)
+      .then(res => {
+        if (cancelled) return;
+        if (!res.ok || !res.data) {
+          setStatus('error');
+          return;
+        }
+        const { available } = res.data as { available?: boolean };
+        setStatus(available ? 'available' : 'taken');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debounced]);
+
+  return status;
+}
 
 /** Debounced check of subdomain availability; returns status plus suggested alternatives when taken. */
 export function useDomainAvailability(

--- a/openframe/services/openframe-frontend/src/lib/auth-api-client.ts
+++ b/openframe/services/openframe-frontend/src/lib/auth-api-client.ts
@@ -123,6 +123,11 @@ class AuthApiClient {
     return requestPublic<T>(path, { method: 'GET' });
   }
 
+  checkEmailAvailability<T = any>(email: string) {
+    const path = `/sas/tenant/email-available?email=${encodeURIComponent(email)}`;
+    return requestPublic<T>(path, { method: 'GET' });
+  }
+
   validateAccessCode<T = any>(email: string, code: string) {
     const path = `/sas/oauth/access-code/validate?email=${encodeURIComponent(email)}&code=${encodeURIComponent(code)}`;
     return requestPublic<T>(path, { method: 'GET' });


### PR DESCRIPTION

Reintroduce the debounced email-already-registered check on the Create Organization form using the new dedicated BE endpoint GET /sas/tenant/email-available?email= ({ available }), instead of the previous discoverTenants call (which flagged any tenant-linked email).

- authApiClient.checkEmailAvailability wraps the new endpoint.
- useEmailAvailability maps available:false -> taken, true -> available.
- Inline checking/available/taken states under the email field; Continue is disabled while checking or when the email is taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time email availability checks now appear during organization sign-up.
  * Users see clear status messages while entering an email, including checking, available, and already registered states.

* **Bug Fixes**
  * The Continue button now stays disabled while email validation is in progress or when the email is already registered.
  * Organization creation is blocked if the entered email is already in use, helping prevent failed submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->