### PR TITLE
fix(client): restore 0o644 on atomic_write so chat can read shared_token.enc

### DIFF
--- a/clients/openframe-client/src/utils/fs.rs
+++ b/clients/openframe-client/src/utils/fs.rs
@@ -13,8 +13,42 @@ pub fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> Result<()> {
     let mut tmp = NamedTempFile::new_in(parent)
         .with_context(|| format!("failed to create temp file in {}", parent.display()))?;
     tmp.write_all(contents.as_ref())?;
+    // NamedTempFile defaults to 0o600; restore fs::write's 0o644 so user processes can read.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o644))?;
+    }
     // persist() atomically replaces any existing file at `path` (MoveFileEx on Windows).
     tmp.persist(path)
         .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn atomic_write_sets_644_and_self_heals() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token.enc");
+
+        atomic_write(&path, b"first").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+
+        // A pre-existing owner-only file must be corrected on the next write, not preserved.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        atomic_write(&path, b"second").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+    }
 }


### PR DESCRIPTION
## Problem

`token_refresh_run_manager` (#2016) switched `SharedTokenService::update` from `std::fs::write` to the new `atomic_write` helper (`tempfile::NamedTempFile` + `persist()`). `NamedTempFile` creates its temp file at **0o600**, and `persist()` is a rename that replaces the destination inode — so `shared_token.enc` (and `agent_config.json`, the other caller) started coming out **owner-only**.

This breaks **openframe-chat**: it's a Tauri GUI app running as the **logged-in user**, reading the token via `fs::read_to_string`, while openframe-client writes it as the **root daemon**. On macOS the secured dir is intentionally user-traversable so the GUI can read it, and `PERMISSIONS.md` documents data files at **644**. Old `fs::write` produced 0o644 → chat could read; new 0o600 → permission denied.

## Fix

`atomic_write` now explicitly sets **0o644** on the temp file before `persist` (Unix only; Windows uses ACLs, so it's `#[cfg(unix)]`-gated). Setting the mode *before* the rename means the live file is never observed at 0o600.

A fixed 0o644 (rather than "preserve existing mode") is deliberate: machines that already ran the buggy build have a 0o600 file on disk, so preserving would keep them broken. 0o644 on every write **self-heals** those on the next token/config refresh.

## Notes

- Both `atomic_write` callers (`shared_token.enc`, `agent_config.json`) now write 0o644 — matches pre-#2016 `fs::write` behavior and the documented 644 model.
- Recovery on already-affected machines happens on the next proactive refresh/restart; an immediate unblock is `sudo chmod 644 "/Library/Application Support/OpenFrame/secured/shared_token.enc"`.

## Test

Added a Unix-only unit test covering fresh-write → 0o644 and the 0o600 self-heal case. Passes; crate builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files created through atomic writes now use more permissive read permissions on Unix, making them readable by user processes.
  * Existing files with overly restrictive permissions are corrected on the next atomic write, while preserving the updated content.

* **Tests**
  * Added coverage to verify the resulting file permissions and ensure previously owner-only files are updated properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->