### PR TITLE
fix(release): move latest tag on dispatch releases too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.ORGANISATION }}/${{ env.REPOSITORY }}/${{ matrix.name }}
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
             type=raw,value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.version != '' }}
           labels: |
             org.opencontainers.image.vendor=${{ env.ORGANISATION }}


### PR DESCRIPTION
latest was gated to is_default_branch so workflow_dispatch versioned releases only pushed the version tag and latest froze. Same class of issue as fleetmdm #69, fixed on the metadata-action side: latest now moves on push and dispatch, excluded only on pull_request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation so the `latest` Docker image tag is published for non-pull-request runs.
  * This makes the most recent build consistently available after release-related workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->