### PR TITLE
ci(release): guard helm chart tag against non-semver mutable tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
         if: steps.should_run.outputs.run == 'true'
         with:
           name: app-of-apps
-          tag: ${{ needs.version.outputs.version }}
+          tag: ${{ needs.version.outputs.version == 'latest' && '9.9.9' || needs.version.outputs.version }}
           path: ./manifests/app-of-apps
           registry: ${{ env.REGISTRY }}
           repository: ${{ env.ORGANISATION }}/${{ env.REPOSITORY }}


### PR DESCRIPTION
On push, version resolves to a mutable tag (latest/dev) which is not valid OCI semver for the helm chart releaser. Same guard as fleetmdm #71: use 9.9.9 placeholder when version is the mutable tag, otherwise the real version. build_helm only stays green today because it's skipped when the chart is unchanged; a push that changes the chart would otherwise fail the helm release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release packaging so chart versions are tagged correctly, including a fallback tag for “latest” releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->