### PR TITLE
ci(release): match helm tag guard to latest sentinel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
         if: steps.should_run.outputs.run == 'true'
         with:
           name: app-of-apps
-          tag: ${{ needs.version.outputs.version == 'dev' && '9.9.9' || needs.version.outputs.version }}
+          tag: ${{ needs.version.outputs.version == 'latest' && '9.9.9' || needs.version.outputs.version }}
           path: ./manifests/app-of-apps
           registry: ${{ env.REGISTRY }}
           repository: ${{ env.ORGANISATION }}/${{ env.REPOSITORY }}


### PR DESCRIPTION
Guard from #2097 compares to 'dev', but this repo's push sentinel is 'latest' (version.yml:28) — condition never fires, chart would go out with mutable non-semver tag and fail helm-oci-chart-releaser on the next manifests push. Same one-liner as fleetmdm #71 / meshcentral #50.