### PR TITLE
test: CLI bootstrap test matrix (CI e2e run)

### DIFF
--- a/manifests/app-of-apps/values.yaml
+++ b/manifests/app-of-apps/values.yaml
@@ -4,3 +4,4 @@ repository:
   appsDir: apps
   URL: https://github.com/flamingo-stack/openframe-oss-tenant.git
   branch: main
+# CI test run: verify bootstrap e2e path (cli test matrix, run 7)


### PR DESCRIPTION
CI run to verify the bootstrap --non-interactive e2e path (CLI test matrix). Do not merge — will close after the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a brief CI-related note in the app deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->