### PR TITLE
chore: bump openframe-frontend-core to 0.0.392 in frontend and chat

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.391",
+    "@flamingo-stack/openframe-frontend-core": "0.0.392",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.391",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.392",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.391",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.391.tgz",
-      "integrity": "sha512-nVMQBRxB6dqHzhRp8yW8dZmkedTr4TJOenuMvEE7u1GyVi0EkKPN0oxAKv2IXLZJOiM3NDCGI4H6r+QYbpzBjA==",
+      "version": "0.0.392",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.392.tgz",
+      "integrity": "sha512-Bcs33OsPcfZfIFgeVvc7IK8PjQKTOUKyfgY6II599KuhJsUiyL0qNYviksLFuDOmTl2ruCdQoprTjf6I534zMQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.391",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.392",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared frontend package to a newer version in two app configurations.
  * This keeps the chat and frontend services aligned on the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->