### PR TITLE
ci: align with oss-tenant-only CLI (drop --deployment-mode, rename values file)

### DIFF
--- a/.github/steps/helm-override/action.yml
+++ b/.github/steps/helm-override/action.yml
@@ -12,9 +12,9 @@ inputs:
     description: 'Changes output'
     required: true
   helm-values-file:
-    description: 'Path to helm-values.yaml file'
+    description: 'Path to the openframe helm values file'
     required: false
-    default: 'cli/helm-values.yaml'
+    default: 'cli/openframe-helm-values.yaml'
   github-token:
     description: 'GitHub token for repository access'
     required: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
           tar -xzf "/tmp/${OPENFRAME_CLI_ARCHIVE}" -C /tmp
           install -m 0755 /tmp/openframe /usr/local/bin/openframe
           openframe --version
-          openframe bootstrap --deployment-mode=oss-tenant --non-interactive --verbose
+          openframe bootstrap --non-interactive --verbose
 
       - name: Setup Telepresence
         uses: ./.github/steps/setup-telepresence


### PR DESCRIPTION
## Description
The openframe CLI removed the --deployment-mode flag and renamed the values file it reads to openframe-helm-values.yaml. Match both:
- bootstrap step: openframe bootstrap --non-interactive --verbose
- helm-override: write cli/openframe-helm-values.yaml (the file bootstrap reads in working-directory: cli under --non-interactive)

Requires the new CLI release to be live (CI pulls releases/latest).

## Task
https://app.clickup.com/t/9013925967/86adg0p1e