### PR TITLE
ci(version): unify base fetch with saas repos

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,7 +39,7 @@ jobs:
 
           latest=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases \
             --json tagName --jq '.[].tagName' \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v '^9\.9\.' | sort -V | tail -1)
           [[ -n "$latest" ]] || { echo "No x.y.z releases found"; exit 1; }
           IFS='.' read -r cur_major cur_minor cur_patch <<< "$latest"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,11 +33,14 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          latest=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
-          [[ "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Latest release tag '${latest}' is not x.y.z"; exit 1; }
+          latest=$(gh release list --limit 100 --exclude-drafts --exclude-pre-releases \
+            --json tagName --jq '.[].tagName' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          [[ -n "$latest" ]] || { echo "No x.y.z releases found"; exit 1; }
           IFS='.' read -r cur_major cur_minor cur_patch <<< "$latest"
 
           if [ -z "$INPUT_VERSION" ]; then


### PR DESCRIPTION
Uniform version base across all org repos, same block as flamingo-stack/openframe-saas-shared#1366: newest non-prerelease release via `gh release list | sort -V` instead of the `releases/latest` endpoint. No behavior change here (no promote flow, Latest badge == newest release), pure consistency so the dispatch block is byte-identical in all 7 repos.

Also adds `GH_REPO` to the step env: `gh release list` needs repo context (this job has no checkout), unlike the full-path `gh api` call it replaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version detection to use the latest valid `x.y.z` tag, avoiding incorrect version selection.
  * Added a safeguard so the versioning process now fails clearly when no matching release tags are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->