### PR TITLE
FE: auth. send Sign in from unauthorized overlay to the Login tab

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.392",
+    "@flamingo-stack/openframe-frontend-core": "0.0.393",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.392",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.393",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.392",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.392.tgz",
-      "integrity": "sha512-Bcs33OsPcfZfIFgeVvc7IK8PjQKTOUKyfgY6II599KuhJsUiyL0qNYviksLFuDOmTl2ruCdQoprTjf6I534zMQ==",
+      "version": "0.0.393",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.393.tgz",
+      "integrity": "sha512-VaXfJQYmd0K7SuZXAgasRiWSYu7kjFTqO20o+XUNMEFL0CUnk/YJSKbM5BpGyOU4Ztzch080GItSo6piZTOcKw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.392",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.393",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/components/unauthorized-overlay.tsx
+++ b/openframe/services/openframe-frontend/src/app/components/unauthorized-overlay.tsx
@@ -54,7 +54,8 @@ export function UnauthorizedOverlay({ onRetry }: UnauthorizedOverlayProps) {
       return;
     }
     if (loginUrl) {
-      window.location.href = loginUrl;
+      // Land on the Login tab directly — the auth host's root defaults to Sign Up
+      window.location.href = `${loginUrl.replace(/\/+$/, '')}/auth/login/`;
     } else {
       // Fallback: reload or no-op
       if (onRetry) onRetry();


### PR DESCRIPTION
## Description

The shared auth host root lands on /auth with the Sign Up tab preselected; users coming from the "Sign in required" overlay already have an account, so point them at /auth/login/ instead.