### PR TITLE
fix(frontend): billing & subscription fixes + Relay id-collision + skeletons

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-section.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-section.tsx
@@ -1,4 +1,18 @@
+import { AlertTriangleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
+
+// Static "Test mode" banner. Shared by the live view and its loading skeleton so
+// the copy/chrome are defined once.
+export function TestModeBanner() {
+  return (
+    <div className="flex items-start gap-[var(--spacing-system-s)] rounded-md bg-[var(--ods-open-yellow-base)] p-[var(--spacing-system-s)] text-ods-text-on-accent">
+      <AlertTriangleIcon className="size-6 shrink-0" />
+      <p className="flex-1 text-h3 font-bold">
+        Test mode — invoices and usage shown here are samples. No real charges are being made.
+      </p>
+    </div>
+  );
+}
 
 export function SectionBlock({ title, children }: { title: string; children: React.ReactNode }) {
   return (

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-skeleton.tsx
@@ -1,64 +1,61 @@
 'use client';
 
-import { PageLayout, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { ExternalLinkIcon, SearchIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Input, PageLayout, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
+import { BillingRow, SectionBlock, TestModeBanner } from './billing-section';
 
-// Mirrors a DashboardInfoCard (~94px tall): text column (title + big value)
-// with a circular progress on the right, inside the same card chrome.
-function InfoCardSkeleton() {
+// A value placeholder sized to sit on the right of a BillingRow.
+function Value({ width }: { width: string }) {
+  return <Skeleton className={`h-4 ${width}`} />;
+}
+
+// Mirrors a DashboardInfoCard: real uppercase title, skeleton value, and an
+// optional progress ring (shown for committed packages, hidden for PAYG).
+function InfoCardSkeleton({ title, withProgress = true }: { title: string; withProgress?: boolean }) {
   return (
     <div className="h-[94px] bg-ods-card border border-ods-border rounded-sm p-[var(--spacing-system-m)] flex gap-[var(--spacing-system-s)] items-center">
       <div className="flex-1 flex flex-col gap-2">
-        <Skeleton className="h-3 w-28" />
+        <p className="text-h5 text-ods-text-secondary">{title}</p>
         <Skeleton className="h-7 w-24" />
       </div>
-      <Skeleton className="size-12 rounded-full shrink-0" />
+      {withProgress && <Skeleton className="size-12 rounded-full shrink-0" />}
     </div>
   );
 }
 
-// Mirrors a BillingRow: label on the left, divider, value on the right.
-function BillingRowSkeleton({ labelWidth, valueWidth }: { labelWidth: string; valueWidth: string }) {
-  return (
-    <div className="flex gap-2 items-center w-full">
-      <Skeleton className={`h-4 ${labelWidth}`} />
-      <div className="flex-1 h-px bg-ods-border min-w-4" />
-      <Skeleton className={`h-4 ${valueWidth}`} />
-    </div>
-  );
-}
+const INVOICE_COLUMNS = ['INVOICE', 'DUE DATE', 'AMOUNT', 'STATUS'] as const;
+const INVOICE_ROW_KEYS = ['a', 'b', 'c'] as const;
 
-// Mirrors a SectionBlock (~166px card): uppercase title above a fixed-height card.
-function SectionBlockSkeleton({
-  title,
-  rows,
-}: {
-  title: string;
-  rows: ReadonlyArray<{ labelWidth: string; valueWidth: string }>;
-}) {
+// Mirrors the Invoices History table: real column headers, skeleton cells, and
+// the real (static) external-link action chrome.
+function InvoicesTableSkeleton() {
   return (
-    <div className="flex flex-col gap-1 h-full">
-      <p className="text-h5 text-ods-text-secondary uppercase tracking-[-0.02em]">{title}</p>
-      <div className="h-[166px] bg-ods-card border border-ods-border rounded-md p-4 flex flex-col gap-3">
-        {rows.map((row, i) => (
-          <BillingRowSkeleton key={i} labelWidth={row.labelWidth} valueWidth={row.valueWidth} />
+    <div className="flex flex-col">
+      <div className="flex items-center gap-4 px-3 py-3 border-b border-ods-border">
+        {INVOICE_COLUMNS.map(col => (
+          <p key={col} className="text-h5 text-ods-text-secondary flex-1">
+            {col}
+          </p>
         ))}
+        <Skeleton className="h-3 w-16 shrink-0" />
       </div>
+      {INVOICE_ROW_KEYS.map(key => (
+        <div key={key} className="flex items-center gap-4 px-3 py-3 border-b border-ods-border last:border-b-0">
+          <Skeleton className="h-4 w-24 flex-1" />
+          <Skeleton className="h-4 w-20 flex-1" />
+          <Skeleton className="h-4 w-16 flex-1" />
+          <div className="flex-1">
+            <Skeleton className="h-6 w-20 rounded-md" />
+          </div>
+          <div className="flex items-center justify-center p-3 bg-ods-card border border-ods-border rounded-md text-ods-text-secondary shrink-0">
+            <ExternalLinkIcon className="size-6" />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
-
-const CURRENT_PLAN_ROWS = [
-  { labelWidth: 'w-28', valueWidth: 'w-16' },
-  { labelWidth: 'w-20', valueWidth: 'w-24' },
-  { labelWidth: 'w-24', valueWidth: 'w-20' },
-  { labelWidth: 'w-24', valueWidth: 'w-16' },
-];
-
-const USAGE_OVERVIEW_ROWS = [
-  { labelWidth: 'w-28', valueWidth: 'w-10' },
-  { labelWidth: 'w-32', valueWidth: 'w-10' },
-];
 
 export function BillingUsageSkeleton() {
   const handleBack = useSafeBack('/settings');
@@ -69,14 +66,29 @@ export function BillingUsageSkeleton() {
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
       backButton={{ label: 'Back', onClick: handleBack }}
     >
+      <TestModeBanner />
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-[var(--spacing-system-m)]">
-        <InfoCardSkeleton />
-        <InfoCardSkeleton />
+        <InfoCardSkeleton title="Device Usage" />
+        <InfoCardSkeleton title="AI Usage" withProgress={false} />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-[var(--spacing-system-l)] items-stretch">
-        <SectionBlockSkeleton title="Current Plan" rows={CURRENT_PLAN_ROWS} />
-        <SectionBlockSkeleton title="Usage Overview" rows={USAGE_OVERVIEW_ROWS} />
+        <SectionBlock title="Current Plan">
+          <BillingRow label="Device Package" value={<Value width="w-16" />} />
+          <BillingRow label="AI Package" value={<Value width="w-28" />} />
+          <BillingRow label="Next Payment" value={<Value width="w-16" />} />
+        </SectionBlock>
+        <SectionBlock title="Usage Overview">
+          <BillingRow label="Active devices" value={<Value width="w-8" />} />
+          <BillingRow label="Inactive devices" value={<Value width="w-8" />} />
+        </SectionBlock>
+      </div>
+
+      <div className="flex flex-col gap-[var(--spacing-system-l)]">
+        <h2 className="text-h2 text-ods-text-primary">Invoices History</h2>
+        <Input startAdornment={<SearchIcon />} placeholder="Search for Invoice" className="w-full" readOnly />
+        <InvoicesTableSkeleton />
       </div>
     </PageLayout>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/billing-usage-view.tsx
@@ -17,8 +17,9 @@ import { featureFlags } from '@/lib/feature-flags';
 import { useBillingSummary } from '../hooks/use-billing-summary';
 import { useCancelSubscription } from '../hooks/use-cancel-subscription';
 import { useCancellationImpact } from '../hooks/use-cancellation-impact';
+import { useResumeSubscription } from '../hooks/use-resume-subscription';
 import { formatCount, formatCurrency, formatDateOrDash } from '../lib/format';
-import { BillingRow, SectionBlock } from './billing-section';
+import { BillingRow, SectionBlock, TestModeBanner } from './billing-section';
 import { BillingUsageSkeleton } from './billing-usage-skeleton';
 import { CancelOfferModal } from './cancel-offer-modal';
 import { type CancelReason, CancelSubscriptionModal } from './cancel-subscription-modal';
@@ -36,12 +37,17 @@ export function BillingUsageView() {
 function BillingUsageContent() {
   const router = useRouter();
   const handleBack = useSafeBack('/settings');
+  // Bumped after a resume so the billing query refetches from the network — the
+  // resumeSubscription mutation returns a bare Boolean, so the Relay store can't
+  // reflect the new status on its own.
+  const [refreshKey, setRefreshKey] = useState(0);
   const data = useLazyLoadQuery<BillingUsageViewQueryType>(
     billingUsageViewQuery,
     {},
-    { fetchPolicy: 'store-and-network' },
+    { fetchPolicy: 'store-and-network', fetchKey: refreshKey },
   );
   const cancelSubscription = useCancelSubscription();
+  const resumeSubscription = useResumeSubscription();
   const [cancelStep, setCancelStep] = useState<'idle' | 'reason' | 'offer' | 'cancelled'>('idle');
   const [cancelReason, setCancelReason] = useState<CancelReason | null>(null);
   const [cancelComment, setCancelComment] = useState<string>('');
@@ -78,8 +84,12 @@ function BillingUsageContent() {
   const primaryAction = flags.isPendingCancellation
     ? {
         label: 'Renew Subscription',
-        onClick: () => router.push('/settings/billing-usage/subscription'),
+        // Still inside the paid period → clear the scheduled cancellation in
+        // place via resumeSubscription (no checkout needed), then refetch.
+        onClick: () => resumeSubscription.mutate({ onSuccess: () => setRefreshKey(k => k + 1) }),
         variant: 'accent' as const,
+        loading: resumeSubscription.isPending,
+        disabled: resumeSubscription.isPending,
       }
     : flags.isOverdue
       ? {
@@ -114,12 +124,7 @@ function BillingUsageContent() {
       actions={[primaryAction]}
       menuActions={menuActions}
     >
-      <div className="flex items-start gap-[var(--spacing-system-s)] rounded-md bg-[var(--ods-open-yellow-base)] p-[var(--spacing-system-s)] text-ods-text-on-accent">
-        <AlertTriangleIcon className="size-6 shrink-0" />
-        <p className="flex-1 text-h3 font-bold">
-          Test mode — invoices and usage shown here are samples. No real charges are being made.
-        </p>
-      </div>
+      <TestModeBanner />
 
       <div
         className={cn('grid gap-[var(--spacing-system-m)]', flags.hasAi ? 'grid-cols-1 md:grid-cols-2' : 'grid-cols-1')}
@@ -213,9 +218,7 @@ function BillingUsageContent() {
                 </>
               }
             />
-          ) : (
-            <BillingRow label="Next Billing" value={formatDateOrDash(billing.nextBilling)} />
-          )}
+          ) : null}
         </SectionBlock>
         <SectionBlock title="Usage Overview">
           <BillingRow label="Active devices" value={formatCount(device.active)} />
@@ -256,6 +259,7 @@ function BillingUsageContent() {
                 activeDevices: device.active,
                 tickets: impact.tickets,
                 kbArticles: impact.kbArticles,
+                scripts: impact.scripts,
                 monitoringPolicies: impact.monitoringPolicies,
                 savedQueries: impact.savedQueries,
               }
@@ -278,14 +282,22 @@ function BillingUsageContent() {
           cancelSubscription.mutate({
             reason: cancelReason ?? undefined,
             description: cancelComment || undefined,
-            onSuccess: () => setCancelStep('cancelled'),
+            onSuccess: () => {
+              setCancelStep('cancelled');
+              // Force the mounted billing query to re-request now that the store
+              // was invalidated, so the page reflects the pending-cancellation state.
+              setRefreshKey(k => k + 1);
+            },
           });
         }}
       />
 
       <SubscriptionCancelledModal
         isOpen={cancelStep === 'cancelled'}
-        endDate={billing.nextBilling}
+        // After the successful cancel invalidates the store and the query
+        // refetches, cancellationEffectiveAt is populated; fall back to the
+        // period end until that lands.
+        endDate={billing.cancellationEffectiveAt ?? billing.nextBilling}
         onClose={() => setCancelStep('idle')}
       />
     </PageLayout>
@@ -318,6 +330,8 @@ const billingUsageViewQuery = graphql`
       }
       pendingInvoices {
         id
+        invoiceNumber
+        status
         hostedInvoiceUrl
         amountDue
         currency

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/cancel-subscription-modal.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/cancel-subscription-modal.tsx
@@ -11,9 +11,20 @@ import {
   Skeleton,
   Textarea,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
-import { useEffect, useId, useState } from 'react';
+import { Suspense, useEffect, useId, useState } from 'react';
+import { graphql, type PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
+import type { cancelSubscriptionModalPreviewQuery as CancelSubscriptionModalPreviewQueryType } from '@/__generated__/cancelSubscriptionModalPreviewQuery.graphql';
 import { SimpleModal } from '@/app/components/shared/simple-modal';
 import { formatDate } from '@/lib/format-date';
+
+// Live-from-Stripe preview of the effective cancellation date, fetched lazily
+// only when the modal opens (subscription.cancellationEffectiveAt is null while
+// still ACTIVE, so this dedicated preview field is the correct source).
+const cancelSubscriptionModalPreviewQuery = graphql`
+  query cancelSubscriptionModalPreviewQuery {
+    subscriptionCancellationPreview
+  }
+`;
 
 export type CancelReason = 'TOO_EXPENSIVE' | 'NOT_USING_ENOUGH' | 'MISSING_FEATURE' | 'TECHNICAL_ISSUES' | 'OTHER';
 
@@ -29,6 +40,7 @@ export interface DataLossStats {
   activeDevices: number;
   tickets: number;
   kbArticles: number;
+  scripts: number;
   monitoringPolicies: number;
   savedQueries: number;
 }
@@ -74,12 +86,23 @@ export function CancelSubscriptionModal({
   const reasonId = useId();
   const commentId = useId();
 
+  const [previewRef, loadPreview] = useQueryLoader<CancelSubscriptionModalPreviewQueryType>(
+    cancelSubscriptionModalPreviewQuery,
+  );
+
   useEffect(() => {
     if (!isOpen) {
       setReason('');
       setComment('');
+      return;
     }
-  }, [isOpen]);
+    // Load lazily on first open and reuse the cached result on subsequent opens
+    // (store-or-network + a retained queryRef = no refetch each time), matching
+    // how the data-loss metrics are cached rather than refetched every open.
+    if (!previewRef) {
+      loadPreview({}, { fetchPolicy: 'store-or-network' });
+    }
+  }, [isOpen, loadPreview, previewRef]);
 
   const handleConfirm = () => {
     if (!reason || isPending) return;
@@ -112,7 +135,13 @@ export function CancelSubscriptionModal({
     >
       <div className="text-h4 text-ods-text-primary gap-[var(--spacing-system-xs)] flex">
         <span>Your subscription will remain active until:</span>
-        <span className="text-ods-warning">{formatEndDate(endDate)}</span>
+        {previewRef ? (
+          <Suspense fallback={<Skeleton className="h-5 w-20" />}>
+            <CancellationEffectiveDate queryRef={previewRef} fallback={endDate} />
+          </Suspense>
+        ) : (
+          <span className="text-ods-warning">{formatEndDate(endDate)}</span>
+        )}
       </div>
       <p className="text-h4 text-ods-text-primary">
         Pay-as-you-go top-ups are disabled immediately. Any usage already accrued will be charged at the end of the
@@ -157,6 +186,19 @@ export function CancelSubscriptionModal({
   );
 }
 
+// Reads the preloaded preview and renders the effective cancellation date,
+// falling back to the caller-provided date when Stripe exposes no period end.
+function CancellationEffectiveDate({
+  queryRef,
+  fallback,
+}: {
+  queryRef: PreloadedQuery<CancelSubscriptionModalPreviewQueryType>;
+  fallback: string | null;
+}) {
+  const data = usePreloadedQuery(cancelSubscriptionModalPreviewQuery, queryRef);
+  return <span className="text-ods-warning">{formatEndDate(data.subscriptionCancellationPreview ?? fallback)}</span>;
+}
+
 function DataLossItem({ children }: { children: React.ReactNode }) {
   return (
     <li className="flex items-start text-h3 text-ods-text-primary">
@@ -195,6 +237,12 @@ function DataLossBox({ stats }: { stats: DataLossStats }) {
         {` knowledge base articles`}
       </DataLossItem>
     ),
+    stats.scripts > 0 && (
+      <DataLossItem key="scripts">
+        <Stat value={stats.scripts} />
+        {` scripts`}
+      </DataLossItem>
+    ),
     (showPolicies || showQueries) && (
       <DataLossItem key="fleet">
         {showPolicies && (
@@ -229,9 +277,9 @@ function DataLossBox({ stats }: { stats: DataLossStats }) {
   );
 }
 
-// Mirrors the data-loss box structure (header chrome + 4 bulleted rows) so the
+// Mirrors the data-loss box structure (header chrome + 5 bulleted rows) so the
 // loading state keeps the same shape instead of a flat rectangle.
-const SKELETON_ROW_WIDTHS = ['w-1/2', 'w-3/4', 'w-2/5', 'w-3/4'] as const;
+const SKELETON_ROW_WIDTHS = ['w-1/2', 'w-3/4', 'w-2/5', 'w-1/3', 'w-3/4'] as const;
 
 function DataLossSkeleton() {
   return (

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/invoices-history.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/components/invoices-history.tsx
@@ -11,15 +11,49 @@ import {
   useDataTable,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useCallback, useMemo, useState } from 'react';
+import { InvoiceStatus } from '@/generated/schema-enums';
 import { formatCurrency, formatDateOrDash } from '../lib/format';
 
 interface InvoiceItem {
   id: string;
-  amountDue: number; // smallest currency unit (cents)
+  /** Human-readable Stripe invoice number (e.g. "ABCD-0001"). Null for legacy entries. */
+  invoiceNumber?: string | null;
+  /**
+   * Lifecycle status mirrored from Stripe. Typed loosely (not `InvoiceStatus`) so
+   * the relay-generated shape — which widens with `"%future added value"` — assigns
+   * cleanly; `statusTag` narrows it against the `InvoiceStatus` values.
+   */
+  status?: string | null;
+  amountDue: number; // major currency units (e.g. 11.92 USD)
   currency: string;
   createdAt: string;
-  dueDate: string | null;
+  dueDate?: string | null;
   hostedInvoiceUrl: string;
+}
+
+/** Amount in major units (dollars) — the backend already returns `amountDue` in major units. */
+function invoiceAmount(invoice: InvoiceItem): number {
+  return invoice.amountDue;
+}
+
+/** Tag styling + label for each lifecycle status; null (legacy) reads as unpaid. */
+function statusTag(status: string | null | undefined): {
+  variant: 'success' | 'warning' | 'error' | 'grey';
+  label: string;
+} {
+  switch (status) {
+    case InvoiceStatus.PAID:
+      return { variant: 'success', label: 'Paid' };
+    case InvoiceStatus.DRAFT:
+      return { variant: 'grey', label: 'Draft' };
+    case InvoiceStatus.VOID:
+      return { variant: 'error', label: 'Void' };
+    case InvoiceStatus.UNCOLLECTIBLE:
+      return { variant: 'error', label: 'Uncollectible' };
+    default:
+      // OPEN and legacy (null) both mean "still owed".
+      return { variant: 'warning', label: 'Unpaid' };
+  }
 }
 
 export function InvoicesHistory({ invoices }: { invoices: readonly InvoiceItem[] }) {
@@ -27,19 +61,26 @@ export function InvoicesHistory({ invoices }: { invoices: readonly InvoiceItem[]
 
   const data = useMemo(() => {
     const query = search.trim().toLowerCase();
-    const list = query ? invoices.filter(invoice => invoice.id.toLowerCase().includes(query)) : invoices;
-    return list as InvoiceItem[];
+    if (!query) return invoices as InvoiceItem[];
+    // Client-side match on invoice number and amount. The amount haystack holds
+    // both the bare "11.92" and the formatted "$11.92" so "11.9", "11.92" and
+    // "$11.92" all match.
+    return invoices.filter(invoice => {
+      const amount = invoiceAmount(invoice);
+      const haystack = [invoice.invoiceNumber ?? '', amount.toFixed(2), formatCurrency(amount)].join(' ').toLowerCase();
+      return haystack.includes(query);
+    }) as InvoiceItem[];
   }, [invoices, search]);
 
   const columns = useMemo<ColumnDef<InvoiceItem>[]>(
     () => [
       {
-        // The Stripe invoice id is an opaque base64 string with no user value, so the
-        // issue date stands in as the invoice identifier here.
-        accessorKey: 'createdAt',
+        // Human-readable Stripe invoice number; legacy entries have none, so the
+        // issue date stands in as the identifier.
+        accessorKey: 'invoiceNumber',
         header: 'INVOICE',
         cell: ({ row }: { row: Row<InvoiceItem> }) => (
-          <TruncateText>{formatDateOrDash(row.original.createdAt)}</TruncateText>
+          <TruncateText>{row.original.invoiceNumber ?? formatDateOrDash(row.original.createdAt)}</TruncateText>
         ),
         meta: { width: 'flex-1 min-w-0' },
       },
@@ -55,15 +96,17 @@ export function InvoicesHistory({ invoices }: { invoices: readonly InvoiceItem[]
         accessorKey: 'amountDue',
         header: 'AMOUNT',
         cell: ({ row }: { row: Row<InvoiceItem> }) => (
-          <TruncateText>{formatCurrency(row.original.amountDue / 100)}</TruncateText>
+          <TruncateText>{formatCurrency(invoiceAmount(row.original))}</TruncateText>
         ),
         meta: { width: 'flex-1 min-w-0' },
       },
       {
         accessorKey: 'status',
         header: 'STATUS',
-        // Status is mocked: pendingInvoices are unpaid, and the schema exposes no status field yet.
-        cell: () => <Tag variant="warning" label="Unpaid" />,
+        cell: ({ row }: { row: Row<InvoiceItem> }) => {
+          const { variant, label } = statusTag(row.original.status);
+          return <Tag variant={variant} label={label} />;
+        },
         enableSorting: false,
         // The body cell is a `flex-col` (default `align-items: stretch`), which stretches the
         // tag full-width. `items-start` keeps it at its natural width, left-aligned.

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-billing-summary.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-billing-summary.ts
@@ -155,6 +155,15 @@ export function useBillingSummary(subscription: SubscriptionData) {
       showProgress: !aiIsPayg,
     },
     ui: { warnings, showOverageBlock, accentClass, accentBorderClass },
-    billing: { nextPayment, nextBilling, latestPendingInvoice, trialExpirationDate },
+    billing: {
+      nextPayment,
+      nextBilling,
+      latestPendingInvoice,
+      trialExpirationDate,
+      // Non-null only once cancellation is scheduled (PENDING_CANCELLATION /
+      // CANCELED) — used by the "Subscription Cancelled" modal after the store
+      // is invalidated and the query refetches.
+      cancellationEffectiveAt: subscription?.cancellationEffectiveAt ?? null,
+    },
   };
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-cancel-subscription.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-cancel-subscription.ts
@@ -2,7 +2,7 @@
 
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useCallback } from 'react';
-import { graphql, useMutation } from 'react-relay';
+import { commitLocalUpdate, graphql, useMutation, useRelayEnvironment } from 'react-relay';
 import type { useCancelSubscriptionMutation as UseCancelSubscriptionMutationType } from '@/__generated__/useCancelSubscriptionMutation.graphql';
 
 const cancelSubscriptionMutation = graphql`
@@ -19,6 +19,7 @@ interface CancelSubscriptionOptions {
 
 export function useCancelSubscription() {
   const { toast } = useToast();
+  const environment = useRelayEnvironment();
   const [commit, isInFlight] = useMutation<UseCancelSubscriptionMutationType>(cancelSubscriptionMutation);
 
   const mutate = useCallback(
@@ -28,6 +29,11 @@ export function useCancelSubscription() {
       commit({
         variables: { input },
         onCompleted: () => {
+          // The mutation returns a bare Boolean, so Relay can't reconcile the new
+          // PENDING_CANCELLATION state on its own. Invalidate the store so every
+          // subscription-derived query (billing view, subscription-lock, …)
+          // refetches from the server on its next read instead of serving stale data.
+          commitLocalUpdate(environment, store => store.invalidateStore());
           onSuccess?.();
         },
         onError: err => {
@@ -39,7 +45,7 @@ export function useCancelSubscription() {
         },
       });
     },
-    [commit, toast],
+    [commit, toast, environment],
   );
 
   return { mutate, isPending: isInFlight };

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-cancellation-impact.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-cancellation-impact.ts
@@ -27,6 +27,16 @@ const KB_ARTICLES_QUERY = `
   }
 `;
 
+// ACTIVE only — the default (null statuses) also counts ARCHIVED scripts, which
+// aren't "data you'll lose" in the same sense.
+const SCRIPTS_QUERY = `
+  query CancellationScripts {
+    scripts(filter: { statuses: [ACTIVE] }, first: 1) {
+      filteredCount
+    }
+  }
+`;
+
 interface GraphQlEnvelope<T> {
   data?: T;
   errors?: Array<{ message: string }>;
@@ -36,6 +46,7 @@ export interface CancellationImpact {
   /** Total tickets across every status (active, on-hold, resolved, …). */
   tickets: number;
   kbArticles: number;
+  scripts: number;
   monitoringPolicies: number;
   savedQueries: number;
 }
@@ -62,6 +73,16 @@ async function fetchKbArticles(): Promise<number> {
   return res.data?.data?.articles?.filteredCount ?? 0;
 }
 
+async function fetchScriptsCount(): Promise<number> {
+  const res = await apiClient.post<GraphQlEnvelope<{ scripts?: { filteredCount: number } }>>(MAIN_GRAPHQL_ENDPOINT, {
+    query: SCRIPTS_QUERY,
+  });
+  if (!res.ok || res.data?.errors?.length) {
+    throw new Error(res.error || res.data?.errors?.[0]?.message || 'Failed to load scripts count');
+  }
+  return res.data?.data?.scripts?.filteredCount ?? 0;
+}
+
 /**
  * Best-effort "what you'll lose" counts for the cancellation modal. Sourced from three
  * transports (ai-agent GraphQL, main GraphQL, Fleet REST); each is settled independently so
@@ -74,9 +95,10 @@ export function useCancellationImpact({ enabled }: { enabled: boolean }) {
     enabled,
     staleTime: 60_000,
     queryFn: async () => {
-      const [tickets, kbArticles, policies, queries] = await Promise.allSettled([
+      const [tickets, kbArticles, scripts, policies, queries] = await Promise.allSettled([
         fetchTicketsTotal(),
         fetchKbArticles(),
+        fetchScriptsCount(),
         fleetApiClient.getPoliciesCount(),
         fleetApiClient.getQueriesCount(),
       ]);
@@ -84,6 +106,7 @@ export function useCancellationImpact({ enabled }: { enabled: boolean }) {
       return {
         tickets: tickets.status === 'fulfilled' ? tickets.value : 0,
         kbArticles: kbArticles.status === 'fulfilled' ? kbArticles.value : 0,
+        scripts: scripts.status === 'fulfilled' ? scripts.value : 0,
         monitoringPolicies:
           policies.status === 'fulfilled' && policies.value.ok ? (policies.value.data?.count ?? 0) : 0,
         savedQueries: queries.status === 'fulfilled' && queries.value.ok ? (queries.value.data?.count ?? 0) : 0,

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-resume-subscription.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/hooks/use-resume-subscription.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useCallback } from 'react';
+import { graphql, useMutation } from 'react-relay';
+import type { useResumeSubscriptionMutation as UseResumeSubscriptionMutationType } from '@/__generated__/useResumeSubscriptionMutation.graphql';
+
+// Clears a scheduled cancellation (status PENDING_CANCELLATION) in Stripe so the
+// subscription renews again. Only valid while still inside the paid period — a
+// fully canceled subscription must go through checkout instead. Takes no input
+// and returns a Boolean, so the Relay store can't auto-update; callers refetch
+// the billing query via `onSuccess`.
+const resumeSubscriptionMutation = graphql`
+  mutation useResumeSubscriptionMutation {
+    resumeSubscription
+  }
+`;
+
+interface ResumeSubscriptionOptions {
+  onSuccess?: () => void;
+}
+
+export function useResumeSubscription() {
+  const { toast } = useToast();
+  const [commit, isInFlight] = useMutation<UseResumeSubscriptionMutationType>(resumeSubscriptionMutation);
+
+  const mutate = useCallback(
+    (options?: ResumeSubscriptionOptions) => {
+      const { onSuccess } = options ?? {};
+      commit({
+        variables: {},
+        onCompleted: (response, errors) => {
+          if (errors?.length || !response.resumeSubscription) {
+            toast({
+              title: 'Renew Failed',
+              description: errors?.map(e => e.message).join('. ') || 'Failed to renew subscription',
+              variant: 'destructive',
+            });
+            return;
+          }
+          toast({
+            title: 'Subscription Renewed',
+            description: 'Your subscription will continue and the scheduled cancellation was removed.',
+            variant: 'success',
+          });
+          onSuccess?.();
+        },
+        onError: err => {
+          toast({
+            title: 'Renew Failed',
+            description: err instanceof Error ? err.message : 'Failed to renew subscription',
+            variant: 'destructive',
+          });
+        },
+      });
+    },
+    [commit, toast],
+  );
+
+  return { mutate, isPending: isInFlight };
+}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/product-subscription-card.tsx
@@ -73,6 +73,8 @@ interface ProductSubscriptionCardProps {
   customSubtitle: string;
   helpText?: ReactNode;
   disabled?: boolean;
+  /** Whether the card offers a Custom Amount option. Defaults to true. */
+  allowCustom?: boolean;
   /**
    * Reserve vertical space for the billing-period toggle even when this card
    * has none, so cards stay aligned when a sibling card shows the toggle.
@@ -121,6 +123,7 @@ export function ProductSubscriptionCard({
   customSubtitle,
   helpText,
   disabled = false,
+  allowCustom = true,
   reserveBillingPeriodSpace = false,
   onUpdatesChange,
 }: ProductSubscriptionCardProps) {
@@ -163,6 +166,7 @@ export function ProductSubscriptionCard({
     customLabel,
     customSubtitle,
     payAsYouGoOption: product.payAsYouGoOption ?? null,
+    allowCustom,
   });
 
   // "MONTHLY" → "monthly" / "YEARLY" → "yearly", so period-aware copy matches
@@ -210,43 +214,45 @@ export function ProductSubscriptionCard({
             options={radioOptions}
             className="[&>div]:!rounded-none [&>div]:!border-0"
           />
-          <div
-            aria-hidden={disabled || selection.selectedPackageId !== CUSTOM_OPTION_ID}
-            className={cn(
-              'grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none',
-              !disabled && selection.selectedPackageId === CUSTOM_OPTION_ID
-                ? 'grid-rows-[1fr] opacity-100'
-                : 'grid-rows-[0fr] opacity-0 pointer-events-none',
-            )}
-          >
-            <div className="overflow-hidden">
-              <div className="flex flex-col gap-1 pl-12 pr-3 pb-2">
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  aria-label={`Number of ${packageUnitLabel}`}
-                  value={selection.customQuantity ?? ''}
-                  onChange={event => setCustomQuantity(event.target.value.replace(/\D/g, ''))}
-                  endAdornment={packageUnitLabel}
-                  tabIndex={!disabled && selection.selectedPackageId === CUSTOM_OPTION_ID ? undefined : -1}
-                />
-                {customNotDivisible ? (
-                  <p className="text-h6 text-ods-error">
-                    {`Must be a multiple of ${formatCompact(unitSize)} ${packageUnitLabel}`}
-                  </p>
-                ) : (
-                  customPrice && (
-                    <p className="text-h6 text-ods-text-secondary">
-                      {`$${formatMoney(customPrice.total)}${periodSuffix}`}
-                      {customPrice.discountPercent > 0 && (
-                        <span className="text-ods-success"> (-{customPrice.discountPercent}%)</span>
-                      )}
+          {allowCustom && (
+            <div
+              aria-hidden={disabled || selection.selectedPackageId !== CUSTOM_OPTION_ID}
+              className={cn(
+                'grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none',
+                !disabled && selection.selectedPackageId === CUSTOM_OPTION_ID
+                  ? 'grid-rows-[1fr] opacity-100'
+                  : 'grid-rows-[0fr] opacity-0 pointer-events-none',
+              )}
+            >
+              <div className="overflow-hidden">
+                <div className="flex flex-col gap-1 pl-12 pr-3 pb-2">
+                  <Input
+                    type="text"
+                    inputMode="numeric"
+                    aria-label={`Number of ${packageUnitLabel}`}
+                    value={selection.customQuantity ?? ''}
+                    onChange={event => setCustomQuantity(event.target.value.replace(/\D/g, ''))}
+                    endAdornment={packageUnitLabel}
+                    tabIndex={!disabled && selection.selectedPackageId === CUSTOM_OPTION_ID ? undefined : -1}
+                  />
+                  {customNotDivisible ? (
+                    <p className="text-h6 text-ods-error">
+                      {`Must be a multiple of ${formatCompact(unitSize)} ${packageUnitLabel}`}
                     </p>
-                  )
-                )}
+                  ) : (
+                    customPrice && (
+                      <p className="text-h6 text-ods-text-secondary">
+                        {`$${formatMoney(customPrice.total)}${periodSuffix}`}
+                        {customPrice.discountPercent > 0 && (
+                          <span className="text-ods-success"> (-{customPrice.discountPercent}%)</span>
+                        )}
+                      </p>
+                    )
+                  )}
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </Card>

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-skeleton.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-skeleton.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { PageLayout, Skeleton, SkeletonButton } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { QuestionCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import { Button, PageLayout, Skeleton } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
 
-const RADIO_ROW_KEYS = ['payg', 'tier-1', 'tier-2', 'tier-3', 'custom'] as const;
+// Static copy that never depends on the server response, so we render it for
+// real and skeleton only the server-derived option rows/prices.
+const ADDITIONAL_DEVICES_HELPER_TEXT =
+  'You can add more devices anytime. Additional devices beyond your package are charged at pay-as-you-go rates and added to your next invoice.';
 
 export function SubscriptionSettingsSkeleton() {
   const handleBack = useSafeBack('/settings/billing-usage');
@@ -14,59 +18,104 @@ export function SubscriptionSettingsSkeleton() {
       className="px-[var(--spacing-system-l)] pb-[var(--spacing-system-l)]"
       backButton={{ label: 'Back', onClick: handleBack }}
     >
-      <EnableCheckboxSkeleton />
-
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
-        <ProductCardSkeleton />
-        <ProductCardSkeleton />
+        <ProductCardSkeleton
+          title="Device Management Plan"
+          description="Select the number of devices you'd like to include in your yearly subscription plan:"
+          customLabel="Custom Amount"
+          customSubtitle="Choose your number of devices"
+          tierRows={1}
+        />
+        <ProductCardSkeleton
+          title="AI Assistant Add-on"
+          description="Buy OpenFrame tokens to power your AI assistants across all supported models. One unified balance."
+          withHelp
+        />
       </div>
 
       <div className="flex flex-col-reverse justify-between lg:flex-row gap-6 lg:items-center">
-        <Skeleton className="h-4 flex-1 max-w-xl" />
-        <SkeletonButton size="lg" />
+        <p className="hidden lg:block text-h6 text-ods-text-secondary flex-1 max-w-[500px]">
+          {ADDITIONAL_DEVICES_HELPER_TEXT}
+        </p>
+        <div className="flex flex-1 justify-end">
+          <Button variant="accent" disabled>
+            Update Subscription
+          </Button>
+        </div>
       </div>
     </PageLayout>
   );
 }
 
-function EnableCheckboxSkeleton() {
+// A grouped radio row: real circle placeholder, real label (when known),
+// skeleton the server-derived subtitle/price.
+function RadioRow({
+  label,
+  subtitle,
+  trailing,
+  children,
+}: {
+  label?: string;
+  subtitle?: string;
+  trailing?: boolean;
+  children?: React.ReactNode;
+}) {
   return (
-    <div className="flex items-center gap-3 rounded-md border border-ods-border bg-ods-card p-4">
-      <Skeleton className="h-6 w-6 rounded shrink-0" />
-      <div className="flex flex-col gap-1 flex-1">
-        <Skeleton className="h-5 w-40" />
-        <Skeleton className="h-4 w-64" />
+    <div className="border-b border-ods-border last:border-b-0">
+      <div className="flex items-center gap-3 px-3 py-3">
+        <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+        <div className="flex flex-col gap-1 flex-1">
+          {label ? <span className="text-h4 text-ods-text-primary">{label}</span> : <Skeleton className="h-5 w-32" />}
+          {subtitle ? (
+            <span className="text-h6 text-ods-text-secondary">{subtitle}</span>
+          ) : (
+            <Skeleton className="h-4 w-44" />
+          )}
+        </div>
+        {trailing && <Skeleton className="h-8 w-14 rounded-md shrink-0" />}
       </div>
+      {children}
     </div>
   );
 }
 
-function ProductCardSkeleton() {
+// Mirrors a ProductSubscriptionCard: real title/description/"Packages" label and
+// the static PAYG + Custom option labels; the tier rows and every price/subtitle
+// come from the server, so those stay skeletons.
+function ProductCardSkeleton({
+  title,
+  description,
+  customLabel,
+  customSubtitle,
+  tierRows = 0,
+  withHelp = false,
+}: {
+  title: string;
+  description: string;
+  customLabel?: string;
+  customSubtitle?: string;
+  tierRows?: number;
+  withHelp?: boolean;
+}) {
   return (
     <div className="flex flex-1 flex-col gap-6 p-6 bg-ods-bg border border-ods-border rounded-lg">
-      {/* Title (h2) */}
-      <Skeleton className="h-10 w-3/4" />
-      {/* Description (~2 lines) */}
-      <div className="flex flex-col gap-1">
-        <Skeleton className="h-5 w-full" />
-        <Skeleton className="h-5 w-4/5" />
+      <div className="flex items-start justify-between gap-4">
+        <h2 className="text-h2 text-ods-text-primary">{title}</h2>
+        {withHelp && <QuestionCircleIcon className="size-6 text-ods-text-secondary shrink-0" />}
       </div>
-      {/* TabSelector (Monthly/Annual) — rendered as placeholder; hidden in single-period products */}
-      <Skeleton className="h-11 w-full rounded-md" />
-      {/* Packages section */}
+      <p className="text-h4 text-ods-text-primary">{description}</p>
+
       <div className="flex flex-col gap-2">
-        <Skeleton className="h-4 w-20" />
+        <p className="text-h5 text-ods-text-secondary">Packages</p>
         <div className="flex flex-col rounded-md border border-ods-border bg-ods-card overflow-hidden">
-          {RADIO_ROW_KEYS.map((key, idx) => (
-            <div key={key} className="flex items-center gap-3 px-3 py-3 border-b border-ods-border last:border-b-0">
-              <Skeleton className="h-6 w-6 rounded-full shrink-0" />
-              <div className="flex flex-col gap-1 flex-1">
-                <Skeleton className="h-5 w-32" />
-                <Skeleton className="h-4 w-48" />
-              </div>
-              {idx > 0 && idx < RADIO_ROW_KEYS.length - 1 && <Skeleton className="h-8 w-14 rounded-md shrink-0" />}
-            </div>
+          {/* Pay as you go — static label, server-provided subtitle. */}
+          <RadioRow label="Pay as you go" />
+          {/* Committed tiers — fully server-derived. */}
+          {Array.from({ length: tierRows }, (_, idx) => (
+            <RadioRow key={idx} trailing />
           ))}
+          {/* Custom Amount — static label/subtitle from product display config. */}
+          {customLabel && <RadioRow label={customLabel} subtitle={customSubtitle} />}
         </div>
       </div>
     </div>

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/components/subscription-settings-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckboxBlock, PageLayout } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { PageLayout } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { Fragment, type ReactNode, Suspense, useCallback, useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import type { subscriptionSettingsViewQuery as SubscriptionSettingsViewQueryType } from '@/__generated__/subscriptionSettingsViewQuery.graphql';
@@ -8,8 +8,8 @@ import { useSubscriptionLock } from '@/app/components/subscription-lock/subscrip
 import { SubscriptionStatus } from '@/app/components/subscription-lock/subscription-status';
 import { TrialEndedBanner } from '@/app/components/subscription-lock/trial-ended-banner';
 import { useSafeBack } from '@/app/hooks/use-safe-back';
-import type { OpenframeProduct, PlanLine, ProductUpdates } from '../types/subscription.types';
-import { buildProductCancelUpdates, isPlanChanged } from '../utils/subscription.utils';
+import type { OpenframeProduct, ProductUpdates } from '../types/subscription.types';
+import { isPlanChanged } from '../utils/subscription.utils';
 import { ModelTokenRates } from './model-token-rates';
 import { PlanChangeSummary, type PlanChangeSummaryItem } from './plan-change-summary';
 import { ProductSubscriptionCard } from './product-subscription-card';
@@ -26,10 +26,9 @@ interface ProductDisplay {
   customLabel: string;
   customSubtitle: string;
   helpText?: ReactNode;
+  /** Whether the card offers a Custom Amount option. AI tokens are PAYG-only. */
+  allowCustom?: boolean;
 }
-
-/** Disabling a product cancels its committed package, falling back to always-on PAYG. */
-const PAYG_PLAN_LINE: PlanLine = { payg: true, quantity: null, billingPeriod: null, annualTotal: null };
 
 const ADDITIONAL_DEVICES_HELPER_TEXT =
   'You can add more devices anytime. Additional devices beyond your package are charged at pay-as-you-go rates and added to your next invoice.';
@@ -52,6 +51,8 @@ const PRODUCT_DISPLAY: Partial<Record<OpenframeProduct, ProductDisplay>> = {
     customLabel: 'Custom Amount',
     customSubtitle: 'Choose your number of tokens',
     helpText: <ModelTokenRates />,
+    // AI tokens are pay-as-you-go only — no committed Custom Amount.
+    allowCustom: false,
   },
 };
 
@@ -113,36 +114,27 @@ function SubscriptionSettingsContent() {
       new Set(p.packageOptions.map(opt => opt.billingPeriod).filter(Boolean)).size > 1,
   );
 
-  const [aiEnabled, setAiEnabled] = useState(true);
-
   const [updatesMap, setUpdatesMap] = useState<Partial<Record<OpenframeProduct, ProductUpdates>>>({});
 
   const handleUpdatesChange = useCallback((productName: OpenframeProduct, updates: ProductUpdates) => {
     setUpdatesMap(prev => ({ ...prev, [productName]: updates }));
   }, []);
 
-  const considered = products.filter(p => !(p.name === 'AI_ASSISTANCE' && !aiEnabled));
-  const aiCancelUpdates = aiEnabled
-    ? []
-    : buildProductCancelUpdates('AI_ASSISTANCE', subscriptionProducts.find(sp => sp.name === 'AI_ASSISTANCE') ?? null);
-  const packageUpdates = [...considered.flatMap(p => updatesMap[p.name]?.packageUpdates ?? []), ...aiCancelUpdates];
-  const checkoutProducts = considered.map(p => updatesMap[p.name]?.checkout).filter(c => c != null);
-  const hasInvalidCustom = considered.some(p => {
+  const packageUpdates = products.flatMap(p => updatesMap[p.name]?.packageUpdates ?? []);
+  const checkoutProducts = products.map(p => updatesMap[p.name]?.checkout).filter(c => c != null);
+  const hasInvalidCustom = products.some(p => {
     const updates = updatesMap[p.name];
     return updates != null && !updates.valid;
   });
 
-  // Current vs selected plan, one row per product. AI being turned off cancels
-  // its committed package, so its "next" line falls back to always-on PAYG.
+  // Current vs selected plan, one row per product.
   const summaryItems: PlanChangeSummaryItem[] = products.flatMap(product => {
     const display = PRODUCT_DISPLAY[product.name];
     const comparison = updatesMap[product.name]?.comparison;
     if (!display || !comparison) return [];
-    const isAiOff = product.name === 'AI_ASSISTANCE' && !aiEnabled;
-    const effective = isAiOff ? { current: comparison.current, next: PAYG_PLAN_LINE } : comparison;
     // Skip products that are neither active today nor being committed to.
-    if (!effective.current && effective.next.payg) return [];
-    return [{ label: display.rowLabel, comparison: effective }];
+    if (!comparison.current && comparison.next.payg) return [];
+    return [{ label: display.rowLabel, comparison }];
   });
 
   // Only meaningful for the update flow (active subscription). Driven by the
@@ -160,13 +152,6 @@ function SubscriptionSettingsContent() {
     >
       {isLocked && lockCopy && <TrialEndedBanner lockCopy={lockCopy} />}
 
-      <CheckboxBlock
-        checked={aiEnabled}
-        onCheckedChange={setAiEnabled}
-        label="Enable AI Assistants"
-        description="Enhance your workflow with AI assistants."
-      />
-
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
         {products.map(product => {
           const display = PRODUCT_DISPLAY[product.name];
@@ -177,7 +162,6 @@ function SubscriptionSettingsContent() {
               <ProductSubscriptionCard
                 productRef={product}
                 subscriptionProductRef={subProduct}
-                disabled={product.name === 'AI_ASSISTANCE' && !aiEnabled}
                 reserveBillingPeriodSpace={anyHasBillingToggle}
                 onUpdatesChange={updates => handleUpdatesChange(product.name, updates)}
                 {...display}

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-update-subscription.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-update-subscription.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
+import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { graphql, useMutation } from 'react-relay';
 import type {
@@ -37,6 +38,7 @@ const updateSubscriptionMutation = graphql`
 
 export function useUpdateSubscription() {
   const { toast } = useToast();
+  const router = useRouter();
   const [commit, isInFlight] = useMutation<UseUpdateSubscriptionMutationType>(updateSubscriptionMutation);
 
   const mutate = useCallback(
@@ -55,25 +57,20 @@ export function useUpdateSubscription() {
             return;
           }
 
-          const latestPending = [...result.subscription.pendingInvoices].sort(
-            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-          )[0];
-
-          if (latestPending) {
-            toast({
-              title: 'Redirecting to Payment',
-              description: 'Complete your payment to activate changes.',
-              variant: 'success',
-            });
-            window.location.href = latestPending.hostedInvoiceUrl;
-            return;
-          }
+          // An upgrade generates a pending invoice; a downgrade doesn't. We no
+          // longer auto-open the invoice — point the user to the invoices list
+          // instead, and word the downgrade case (no invoice) accordingly.
+          const hasPendingInvoice = result.subscription.pendingInvoices.length > 0;
 
           toast({
             title: 'Subscription Updated',
-            description: 'Your subscription changes have been applied.',
+            description: hasPendingInvoice
+              ? 'An invoice was generated for your changes — check the invoices list in Billing & Usage to complete payment.'
+              : "Your changes have been applied and take effect from your next billing cycle. No invoice is needed — you'll see it reflected in your invoices list.",
             variant: 'success',
           });
+
+          router.push('/settings/billing-usage');
         },
         onError: err => {
           toast({
@@ -84,7 +81,7 @@ export function useUpdateSubscription() {
         },
       });
     },
-    [commit, toast],
+    [commit, toast, router],
   );
 
   return { mutate, isPending: isInFlight };

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/build-package-radio-options.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/build-package-radio-options.tsx
@@ -21,6 +21,8 @@ interface BuildPackageRadioOptionsArgs {
   customLabel: string;
   customSubtitle: string;
   payAsYouGoOption: PayAsYouGoOption | null;
+  /** Whether to offer a Custom Amount option (false for PAYG-only products). */
+  allowCustom: boolean;
 }
 
 export function buildPackageRadioOptions({
@@ -32,6 +34,7 @@ export function buildPackageRadioOptions({
   customLabel,
   customSubtitle,
   payAsYouGoOption,
+  allowCustom,
 }: BuildPackageRadioOptionsArgs) {
   const paygOption = payAsYouGoOption
     ? [{ value: PAYG_OPTION_ID, label: 'Pay as you go', description: formatPaygSubtitle(payAsYouGoOption) }]
@@ -51,5 +54,9 @@ export function buildPackageRadioOptions({
     };
   });
 
-  return [...paygOption, ...tierOptions, { value: CUSTOM_OPTION_ID, label: customLabel, description: customSubtitle }];
+  const customOption = allowCustom
+    ? [{ value: CUSTOM_OPTION_ID, label: customLabel, description: customSubtitle }]
+    : [];
+
+  return [...paygOption, ...tierOptions, ...customOption];
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/utils/subscription.utils.ts
@@ -116,6 +116,26 @@ function toCatalogOptionId(globalId: string): string {
 }
 
 /**
+ * Catalog `packageOptionId` to attach a committed quantity to for `period`.
+ * Prefer the period-matched package option, then the first package option; then
+ * fall back to the product's pay-as-you-go option. The fallback matters for
+ * products that expose *no* committed `packageOptions` (e.g. AI Assistant, which
+ * is catalog-PAYG-only) — without it a valid Custom Amount there resolves to a
+ * null id, so the diff/checkout came out empty and the submit button stayed
+ * disabled even though the plan-change preview showed a change. With the
+ * fallback, Custom Amount behaves like it does for a product that has package
+ * options (Devices). Returns null only when the product has neither.
+ */
+function committedOptionId(product: ProductData, period: BillingPeriod): string | null {
+  const option =
+    product.packageOptions.find(opt => opt.billingPeriod === period) ??
+    product.packageOptions[0] ??
+    product.payAsYouGoOption ??
+    null;
+  return option ? toCatalogOptionId(option.id) : null;
+}
+
+/**
  * Backend `quantity`, catalog `priceTier.from`/`upTo`, and the Custom Amount
  * input all speak the same real product count (devices, tokens) — no unit
  * conversion. `unitSize` (devices: 1, AI tokens: 100_000) is only a granularity
@@ -156,11 +176,7 @@ export function diffPackageUpdates(
     return activeCancelId ? [{ productName: product.name, packageOptionId: activeCancelId, action: 'CANCEL' }] : [];
   }
 
-  const nextPackageOption =
-    product.packageOptions.find(opt => opt.billingPeriod === currentSelection.billingPeriod) ??
-    product.packageOptions[0] ??
-    null;
-  const nextPackageId = nextPackageOption ? toCatalogOptionId(nextPackageOption.id) : null;
+  const nextPackageId = committedOptionId(product, currentSelection.billingPeriod);
 
   let nextQuantity: number | null = null;
   if (currentSelection.selectedPackageId === CUSTOM_OPTION_ID) {
@@ -199,30 +215,6 @@ export function isPlanChanged({ current, next }: PlanComparison): boolean {
   return (current.quantity ?? null) !== (next.quantity ?? null);
 }
 
-interface CancelablePackageOption {
-  readonly packageOptionId: string;
-  readonly status: SubscriptionProductData['packageOptions'][number]['status'];
-}
-
-interface CancelableSubscriptionProduct {
-  readonly packageOptions: ReadonlyArray<CancelablePackageOption>;
-}
-
-/**
- * When the user disables the AI Assistant checkbox while there is an active
- * AI subscription, we still need to CANCEL its active package — the view
- * filters AI out of the per-card diff, so this lives at the view level.
- */
-export function buildProductCancelUpdates(
-  productName: ProductData['name'],
-  subscriptionProduct: CancelableSubscriptionProduct | null,
-): PackageUpdateInput[] {
-  if (!subscriptionProduct) return [];
-  return subscriptionProduct.packageOptions
-    .filter(opt => opt.status === 'ACTIVE')
-    .map(opt => ({ productName, packageOptionId: opt.packageOptionId, action: 'CANCEL' }));
-}
-
 /**
  * Desired end-state for `createCheckoutSession` (used when there is no active
  * paid subscription: TRIAL / TRIAL_EXPIRED / CANCELED). Unlike `diffPackageUpdates`
@@ -236,11 +228,6 @@ export function buildCheckoutProduct(
     return { productName: product.name, payAsYouGoEnabled: true };
   }
 
-  const periodOption =
-    product.packageOptions.find(opt => opt.billingPeriod === currentSelection.billingPeriod) ??
-    product.packageOptions[0] ??
-    null;
-
   let quantity: number | null = null;
   if (currentSelection.selectedPackageId === CUSTOM_OPTION_ID) {
     quantity = validCustomQuantity(product, currentSelection.customQuantity);
@@ -251,7 +238,7 @@ export function buildCheckoutProduct(
 
   return {
     productName: product.name,
-    packageOptionId: periodOption ? toCatalogOptionId(periodOption.id) : null,
+    packageOptionId: committedOptionId(product, currentSelection.billingPeriod),
     quantity,
     payAsYouGoEnabled: true,
   };

--- a/openframe/services/openframe-frontend/src/lib/relay/environment.ts
+++ b/openframe/services/openframe-frontend/src/lib/relay/environment.ts
@@ -94,6 +94,28 @@ const fetchRelay: FetchFunction = async (request, variables) => {
   return json;
 };
 
+/**
+ * Custom record-id resolution for normalization.
+ *
+ * `SubscriptionOptionDetail.id` is documented as a "stable unique identifier for
+ * Relay normalization" but the backend can emit several options that share the
+ * same composite id (its slot disambiguation is buggy — e.g. an EXPIRED, an
+ * ACTIVE and a PENDING_ACTIVATION option all collapse to `...:<date>#1`). Relay
+ * would normalize those into a single record (last-write-wins), silently
+ * dropping the ACTIVE option so the current-plan view falls back to PAYG.
+ *
+ * Returning `undefined` for this type opts it out of global normalization: Relay
+ * stores each list entry under a parent-scoped client id (by field + index)
+ * instead, so colliding backend ids no longer merge. Safe because these options
+ * are never fetched via `node(id:)` and are only read inline through their
+ * parent subscription/product. Everything else keeps the default id-based
+ * normalization.
+ */
+function resolveDataId(value: { readonly id?: unknown }, typeName: string): string | undefined {
+  if (typeName === 'SubscriptionOptionDetail') return undefined;
+  return typeof value.id === 'string' ? value.id : undefined;
+}
+
 let relayEnvironment: IEnvironment | null = null;
 
 /**
@@ -105,6 +127,8 @@ export function getRelayEnvironment(): IEnvironment {
       network: Network.create(fetchRelay),
       store: new Store(new RecordSource()),
       isServer: true,
+      // biome-ignore lint/style/useNamingConvention: Relay's Environment option key is fixed.
+      getDataID: resolveDataId,
     });
   }
 
@@ -116,6 +140,8 @@ export function getRelayEnvironment(): IEnvironment {
     relayEnvironment = new Environment({
       network: Network.create(fetchRelay),
       store,
+      // biome-ignore lint/style/useNamingConvention: Relay's Environment option key is fixed.
+      getDataID: resolveDataId,
     });
   }
 


### PR DESCRIPTION
## Summary

Batch of billing & subscription fixes (frontend), plus a root-cause Relay store fix and refreshed loading skeletons. Scope: `openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/**` + `src/lib/relay/environment.ts`.

## Changes

### Relay id-collision (root cause of wrong active plan)
- The backend can emit multiple `SubscriptionOptionDetail` entries sharing the **same `id`** (its `#slot` disambiguation is buggy — EXPIRED/ACTIVE/PENDING_ACTIVATION collapse to `...:<date>#1`). Relay normalized them into one record (last-write-wins), dropping the ACTIVE package → Current Plan wrongly showed "Pay as you go".
- Fix: `getDataID` in `relay/environment.ts` de-normalizes `SubscriptionOptionDetail` (parent-scoped client ids) so colliding backend ids no longer merge. **This is a FE workaround; the backend duplicate-id bug should be fixed too.**

### Subscription settings
- Enabled a valid submit for a committed Custom Amount on PAYG-only products by falling back to `payAsYouGoOption` for the catalog option id.
- Then removed the AI **Custom Amount** option and the always-on **"Enable AI Assistants"** toggle (AI is PAYG-only / always enabled). Added `allowCustom` to the product card; removed dead `buildProductCancelUpdates`.

### Update flow
- No longer auto-opens the hosted invoice. Redirects to `/settings/billing-usage` and toasts an upgrade/downgrade-aware message (invoice generated vs. applies next cycle).

### Cancel / renew flow
- On successful cancel: invalidate the Relay store + refetch so the page reflects `PENDING_CANCELLATION`.
- Cancel modal lazy-loads `subscriptionCancellationPreview` (cached, not refetched each open) for the "remain active until" date.
- Cancelled modal shows `cancellationEffectiveAt` from the refetched data.
- Pending-cancellation **Renew Subscription** now calls `resumeSubscription` (new `use-resume-subscription` hook) instead of routing.

### Invoices & cancellation impact
- Invoices table pulls real `invoiceNumber` + `status`; amount treated as major units (no `/100`); client-side search by number/amount; `VOID` renders red.
- Cancellation data-loss modal now includes a **scripts** count.

### Billing view & skeletons
- Hid the **Next Billing** row; extracted a shared `TestModeBanner`.
- Rebuilt both loading skeletons to match the current screens — rendering real static labels/headings/copy and skeletoning only server-derived values (Updated Plan block excluded as it's conditional).

## Testing
- `biome check` clean across changed files; `tsc --noEmit` shows no errors in changed files (repo-wide TS7016 noise is pre-existing/environmental).
- Verified via static tracing + generated Relay artifacts; not driven against a live backend.

## Notes
- Generated Relay artifacts (`src/__generated__/*`) are gitignored and regenerated by `relay-compiler` during build (two new operations: `useResumeSubscriptionMutation`, `cancelSubscriptionModalPreviewQuery`).
- `.env.local` intentionally not included.
