### PR TITLE
fix(): notification navigation

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/tickets/components/ticket-details-view.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/tickets/components/ticket-details-view.tsx
@@ -43,7 +43,7 @@ import {
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-relay';
 import type { startTimerMutation as StartTimerMutationType } from '@/__generated__/startTimerMutation.graphql';
@@ -122,6 +122,8 @@ function withActivityTracking(item: ActionsMenuItem, subtype: EventSubtype): Act
 
 export function TicketDetailsView({ ticketId }: TicketDetailsViewProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const handleBackToTickets = useSafeBack('/tickets');
   const { toast } = useToast();
   // When the Mingo sidebar carries per-ticket context, the embedded technician
@@ -278,7 +280,15 @@ export function TicketDetailsView({ ticketId }: TicketDetailsViewProps) {
     dialog?.creationSource === CREATION_SOURCE.FAE_FORM || dialog?.creationSource === CREATION_SOURCE.ADMIN_DASHBOARD;
   const ticketInfoExpanded = isTicketInfoExpanded ?? defaultTicketInfoExpanded;
   const [activeChatTab, setActiveChatTab] = useState('client');
-  const [mainTab, setMainTab] = useState<'details' | 'chat'>('details');
+  const mainTab = searchParams.get('tab') === 'chat' ? 'chat' : 'details';
+  const handleMainTabChange = useCallback(
+    (tabId: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('tab', tabId);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   const clientDisplayName =
     dialog?.deviceHostname ||
@@ -881,11 +891,7 @@ export function TicketDetailsView({ ticketId }: TicketDetailsViewProps) {
             {/* Desktop (lg+): main pane (tabs / chat / details) beside a persistent details sidebar */}
             <div className="hidden lg:flex flex-1 min-w-0 flex-col gap-[var(--spacing-system-xxs)] min-h-0">
               {showDetailsTabs ? (
-                <TabNavigation
-                  tabs={mainTabs}
-                  activeTab={mainTab}
-                  onTabChange={id => setMainTab(id as 'details' | 'chat')}
-                >
+                <TabNavigation tabs={mainTabs} activeTab={mainTab} onTabChange={handleMainTabChange}>
                   {active =>
                     active === 'chat' ? (
                       <div className="flex-1 min-h-0 flex flex-col pt-[var(--spacing-system-mf)]">{clientChatBody}</div>
@@ -912,11 +918,7 @@ export function TicketDetailsView({ ticketId }: TicketDetailsViewProps) {
                 Ticket Details tab; the client chat (when present) gets its own tab without them. */}
             <div className="flex lg:hidden flex-1 min-w-0 flex-col gap-[var(--spacing-system-xxs)] min-h-0">
               {hasClientChat ? (
-                <TabNavigation
-                  tabs={mainTabs}
-                  activeTab={mainTab}
-                  onTabChange={id => setMainTab(id as 'details' | 'chat')}
-                >
+                <TabNavigation tabs={mainTabs} activeTab={mainTab} onTabChange={handleMainTabChange}>
                   {active =>
                     active === 'chat' ? (
                       <div className="flex-1 min-h-0 flex flex-col pt-[var(--spacing-system-mf)]">{clientChatBody}</div>

--- a/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
+++ b/openframe/services/openframe-frontend/src/app/components/notifications/notification-navigation.ts
@@ -34,6 +34,17 @@ const TICKET_CONTEXT_TYPES = new Set<string>([
 ]);
 
 /**
+ * Ticket contexts announcing a new message in the ticket's client chat; they land on the
+ * Chat tab instead of Details. Mingo ticket messages (`ADMIN_AI_TICKET_MESSAGE`) are
+ * excluded — with `mingo-sidebar-context` on, that conversation lives in the sidebar
+ * drawer, not the page's Client Chat tab.
+ */
+const TICKET_CHAT_CONTEXT_TYPES = new Set<string>([
+  CUSTOMER_MESSAGE_PUBLISHED_CONTEXT_TYPE,
+  ADMIN_MESSAGE_PUBLISHED_CONTEXT_TYPE,
+]);
+
+/**
  * A notification's primary action. Either a plain `route` the host pushes onto
  * the router, or — for a Mingo dialog once the standalone `/mingo` page is
  * retired behind `mingo-sidebar` — a `mingoDialogId` the host opens in the
@@ -42,7 +53,8 @@ const TICKET_CONTEXT_TYPES = new Set<string>([
 export type NotificationAction = { label: string; route: string } | { label: string; mingoDialogId: string };
 
 const mingoDialogRoute = (dialogId: string) => `/mingo?dialogId=${encodeURIComponent(dialogId)}`;
-const ticketRoute = (ticketId: string) => `/tickets/dialog?id=${encodeURIComponent(ticketId)}`;
+const ticketRoute = (ticketId: string, tab?: 'chat') =>
+  `/tickets/dialog?id=${encodeURIComponent(ticketId)}${tab ? `&tab=${tab}` : ''}`;
 
 /**
  * Action for a Mingo dialog. With `mingo-sidebar` ON the `/mingo` page is gone
@@ -73,7 +85,8 @@ export function resolveNotificationAction(notification: Notification): Notificat
   }
 
   if (contextType && TICKET_CONTEXT_TYPES.has(contextType) && ticketId) {
-    return { label: 'Ticket Details', route: ticketRoute(ticketId) };
+    const tab = TICKET_CHAT_CONTEXT_TYPES.has(contextType) ? 'chat' : undefined;
+    return { label: 'Ticket Details', route: ticketRoute(ticketId, tab) };
   }
 
   if (contextType === ADMIN_AI_MESSAGE_CONTEXT_TYPE && dialogId) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket detail tabs now stay synchronized with the URL, allowing the selected tab to be preserved and shared.
  * Ticket-related notifications involving new customer or admin messages now open directly to the ticket’s Chat tab.

* **Bug Fixes**
  * Improved navigation consistency when switching between ticket details and chat views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->