### PR TITLE
chore(deps): bump openframe-frontend-core to 0.0.400 in frontend and chat

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.399",
+    "@flamingo-stack/openframe-frontend-core": "0.0.400",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.399",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.400",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.399",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.399.tgz",
-      "integrity": "sha512-gC2SU37CVt+9t80z45BiRJTrmiJDBiuX+4l6lKstSRP/w4dsnExDWRwFvMB70o/4R4zjGGbWb9CTa2Aljs5zDg==",
+      "version": "0.0.400",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.400.tgz",
+      "integrity": "sha512-AU7MHoIbYJEH3DiZZM9MLf9lfEASmN/6CoIPfLCIiVwPGuR+NkR4RinZFqp6QC0+nCvKFN0VsyCKvsGNntesFw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.399",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.400",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the application’s frontend foundation to the latest available release.
  - No visible feature changes or updates to application behavior are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->