### PR TITLE
fix(chat): don't block macOS logout/restart/shutdown

### DIFF
--- a/clients/openframe-chat/src-tauri/Cargo.lock
+++ b/clients/openframe-chat/src-tauri/Cargo.lock
@@ -2649,7 +2649,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
 dependencies = [
+ "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-security",
@@ -2826,6 +2829,7 @@ dependencies = [
  "notify-rust",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-services",
  "objc2-foundation",
  "percent-encoding",
  "rand 0.8.6",

--- a/clients/openframe-chat/src-tauri/Cargo.lock
+++ b/clients/openframe-chat/src-tauri/Cargo.lock
@@ -2644,6 +2644,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,6 +2706,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-services",
 ]
 
 [[package]]
@@ -2717,6 +2730,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/clients/openframe-chat/src-tauri/Cargo.toml
+++ b/clients/openframe-chat/src-tauri/Cargo.toml
@@ -47,4 +47,4 @@ mslnk = "0.1.8"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSImage"] }
-objc2-foundation = { version = "0.3.2", features = ["NSData"] }
+objc2-foundation = { version = "0.3.2", features = ["NSData", "NSAppleEventManager", "NSAppleEventDescriptor", "objc2-core-services"] }

--- a/clients/openframe-chat/src-tauri/Cargo.toml
+++ b/clients/openframe-chat/src-tauri/Cargo.toml
@@ -47,4 +47,5 @@ mslnk = "0.1.8"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSImage"] }
+objc2-core-services = { version = "0.3.2", features = ["AE", "AERegistry"] }
 objc2-foundation = { version = "0.3.2", features = ["NSData", "NSAppleEventManager", "NSAppleEventDescriptor", "objc2-core-services"] }

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -18,6 +18,21 @@ use tauri::ActivationPolicy;
 static DOCK_QUIT_ACTION: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> =
     std::sync::OnceLock::new();
 
+// True when AppKit is terminating us for a logout/restart/shutdown (the quit
+// Apple event carries kAEQuitReason), as opposed to a plain Dock "Quit".
+#[cfg(target_os = "macos")]
+fn is_system_quit() -> bool {
+    use objc2_foundation::NSAppleEventManager;
+    const K_AE_QUIT_REASON: u32 = 0x7768_793F; // 'why?'
+    match NSAppleEventManager::sharedAppleEventManager().currentAppleEvent() {
+        Some(event) => {
+            event.paramDescriptorForKeyword(K_AE_QUIT_REASON).is_some()
+                || event.attributeDescriptorForKeyword(K_AE_QUIT_REASON).is_some()
+        }
+        None => false,
+    }
+}
+
 #[cfg(target_os = "macos")]
 unsafe extern "C" fn on_application_should_terminate(
     _this: *mut objc2::runtime::AnyObject,
@@ -27,7 +42,12 @@ unsafe extern "C" fn on_application_should_terminate(
     if let Some(action) = DOCK_QUIT_ACTION.get() {
         action();
     }
-    0 // NSTerminateCancel
+    // A logout/restart/shutdown must proceed or macOS blocks it; a Dock "Quit" stays in the tray.
+    if is_system_quit() {
+        1 // NSTerminateNow
+    } else {
+        0 // NSTerminateCancel
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -22,12 +22,12 @@ static DOCK_QUIT_ACTION: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> =
 // Apple event carries kAEQuitReason), as opposed to a plain Dock "Quit".
 #[cfg(target_os = "macos")]
 fn is_system_quit() -> bool {
+    use objc2_core_services::kAEQuitReason;
     use objc2_foundation::NSAppleEventManager;
-    const K_AE_QUIT_REASON: u32 = 0x7768_793F; // 'why?'
     match NSAppleEventManager::sharedAppleEventManager().currentAppleEvent() {
         Some(event) => {
-            event.paramDescriptorForKeyword(K_AE_QUIT_REASON).is_some()
-                || event.attributeDescriptorForKeyword(K_AE_QUIT_REASON).is_some()
+            event.paramDescriptorForKeyword(kAEQuitReason).is_some()
+                || event.attributeDescriptorForKeyword(kAEQuitReason).is_some()
         }
         None => false,
     }


### PR DESCRIPTION
## Problem

On macOS, quitting/restarting/shutting down the machine while OpenFrame Chat was running produced the dialog:

> **"OpenFrame" interrupted shutdown.** To continue shutting down, quit "OpenFrame".

Root cause: the swizzled `applicationShouldTerminate:` (`on_application_should_terminate` in `clients/openframe-chat/src-tauri/src/lib.rs`) **unconditionally returned `NSTerminateCancel`** to implement quit-to-tray. macOS uses that same delegate callback for both a user Dock "Quit" *and* a system logout/restart/shutdown, so the app refused every termination — blocking shutdown. Users worked around it by closing the window (`x`) first.

## Fix

Distinguish a system-initiated quit from a Dock "Quit":

- Read the current Apple event via `NSAppleEventManager`. A logout/restart/shutdown carries the `kAEQuitReason` (`'why?'`, `0x7768793F`) parameter on the `kAEQuitApplication` event; a plain Dock "Quit" does not.
- On a **system quit** → return `NSTerminateNow` so shutdown proceeds.
- On a **Dock "Quit"** → return `NSTerminateCancel` and hide to the tray (unchanged behavior).
- Windows are hidden first in both cases so the tray state is clean.

Enables the `NSAppleEventManager`, `NSAppleEventDescriptor`, and `objc2-core-services` features on `objc2-foundation`.

## Trade-off (accepted)

If the user cancels a shutdown *after* we've agreed to terminate, the chat process (and its tray icon) is gone until relaunch/next login — standard tray-app behavior. `applicationShouldTerminate:` forces a decision before the OS reveals whether the overall shutdown will complete, so surviving an aborted shutdown isn't possible here.

## Testing

- `cargo check --lib` passes; `objc2-core-services 0.3.2` resolves.
- Constants verified against the macOS SDK (`AERegistry.h`: `kAEQuitReason = 'why?'`).
- Reviewed the objc2 FFI (method names/signatures, feature gating, FourCC byte order, main-thread correctness) — sound.
- Not yet exercised via a real logout on a build+install; that needs a `tauri build` on the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS termination handling during logout, restart, or shutdown.
  * The app now exits correctly for system-initiated termination while preserving tray-only behavior when quitting from the Dock.
* **Maintenance**
  * Updated macOS-specific dependencies to support improved Apple event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->