### PR TITLE
fix(frontend): neutral subscription-updated toast (no invoice on downgrade)

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-update-subscription.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/billing-usage/subscription/hooks/use-update-subscription.ts
@@ -57,16 +57,13 @@ export function useUpdateSubscription() {
             return;
           }
 
-          // An upgrade generates a pending invoice; a downgrade doesn't. We no
-          // longer auto-open the invoice — point the user to the invoices list
-          // instead, and word the downgrade case (no invoice) accordingly.
-          const hasPendingInvoice = result.subscription.pendingInvoices.length > 0;
-
+          // An upgrade may generate a pending invoice; a downgrade doesn't. We no
+          // longer auto-open the invoice — use a neutral message that points the
+          // user to the invoices list without asserting an invoice was created.
           toast({
             title: 'Subscription Updated',
-            description: hasPendingInvoice
-              ? 'An invoice was generated for your changes — check the invoices list in Billing & Usage to complete payment.'
-              : "Your changes have been applied and take effect from your next billing cycle. No invoice is needed — you'll see it reflected in your invoices list.",
+            description:
+              'Your changes have been applied. Check the invoices list in Billing & Usage for any pending payments.',
             variant: 'success',
           });
 


### PR DESCRIPTION
## What
The "Subscription Updated" toast asserted that *an invoice was generated for your changes*. On a **downgrade** no invoice is created, so this copy was misleading.

## Change
Replaced the invoice-branching toast copy with a single neutral message that points the user to the invoices list without claiming an invoice was created:

> **Subscription Updated** — Your changes have been applied. Check the invoices list in Billing & Usage for any pending payments.

Same message now shown for both upgrades and downgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the subscription update confirmation message to provide consistent guidance about checking the invoices list for pending payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->