### PR TITLE
OS chat notifications

### DIFF
--- a/clients/openframe-chat/src-tauri/Cargo.lock
+++ b/clients/openframe-chat/src-tauri/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
  "once_cell",
  "pin-project",
  "portable-atomic",
- "rand 0.8.6",
+ "rand",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -792,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -2324,20 +2324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
-dependencies = [
- "cc",
- "log",
- "objc2",
- "objc2-foundation",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,22 +2459,8 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.2.17",
  "log",
- "rand 0.8.6",
+ "rand",
  "signatory",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
-dependencies = [
- "futures-lite",
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -2497,7 +2469,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "rand 0.8.6",
+ "rand",
 ]
 
 [[package]]
@@ -2773,7 +2745,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
+ "bitflags 2.13.0",
+ "block2",
  "objc2",
+ "objc2-core-location",
  "objc2-foundation",
 ]
 
@@ -2822,17 +2797,18 @@ dependencies = [
  "aes-gcm",
  "async-nats",
  "base64 0.21.7",
+ "block2",
  "dirs 5.0.1",
  "futures",
  "log",
  "mslnk",
- "notify-rust",
  "objc2",
  "objc2-app-kit",
  "objc2-core-services",
  "objc2-foundation",
+ "objc2-user-notifications",
  "percent-encoding",
- "rand 0.8.6",
+ "rand",
  "serde",
  "serde_json",
  "tauri",
@@ -2840,12 +2816,12 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
- "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tokio",
  "tracing",
  "uuid",
+ "windows",
  "winreg 0.52.0",
 ]
 
@@ -3060,7 +3036,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3243,15 +3219,6 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -3293,18 +3260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3314,17 +3271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -3334,15 +3281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3551,7 +3489,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -3992,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
 dependencies = [
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
  "zeroize",
 ]
@@ -4004,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4471,25 +4409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-notification"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
-dependencies = [
- "log",
- "notify-rust",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "serde_repr",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
- "url",
-]
-
-[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,18 +4543,6 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
-]
-
-[[package]]
-name = "tauri-winrt-notification"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
-dependencies = [
- "quick-xml 0.37.5",
- "thiserror 2.0.18",
- "windows",
- "windows-version",
 ]
 
 [[package]]
@@ -4819,7 +4726,7 @@ dependencies = [
  "futures-sink",
  "http",
  "httparse",
- "rand 0.8.6",
+ "rand",
  "ring",
  "rustls-pki-types",
  "tokio",

--- a/clients/openframe-chat/src-tauri/Cargo.toml
+++ b/clients/openframe-chat/src-tauri/Cargo.toml
@@ -26,9 +26,7 @@ tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-single-instance = "2"
-tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
-notify-rust = "4"
 aes-gcm = "0.10"
 base64 = "0.21"
 async-nats = { git = "https://github.com/flamingo-stack/nats.rs.git", branch = "main", features = ["websockets"] }
@@ -43,9 +41,32 @@ rand = "0.8"
 dirs = "5"
 winreg = "0.52"
 mslnk = "0.1.8"
+windows = { version = "0.61", features = ["Data_Xml_Dom", "UI_Notifications"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6"
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSApplication", "NSImage"] }
 objc2-core-services = { version = "0.3.2", features = ["AE", "AERegistry"] }
-objc2-foundation = { version = "0.3.2", features = ["NSData", "NSAppleEventManager", "NSAppleEventDescriptor", "objc2-core-services"] }
+objc2-foundation = { version = "0.3.2", features = [
+    "NSAppleEventDescriptor",
+    "NSAppleEventManager",
+    "NSArray",
+    "NSBundle",
+    "NSData",
+    "NSDictionary",
+    "NSError",
+    "NSSet",
+    "NSString",
+    "objc2-core-services",
+] }
+objc2-user-notifications = { version = "0.3.2", features = [
+    "UNNotification",
+    "UNNotificationAction",
+    "UNNotificationCategory",
+    "UNNotificationContent",
+    "UNNotificationRequest",
+    "UNNotificationResponse",
+    "UNNotificationTrigger",
+    "UNUserNotificationCenter",
+] }

--- a/clients/openframe-chat/src-tauri/capabilities/default.json
+++ b/clients/openframe-chat/src-tauri/capabilities/default.json
@@ -9,7 +9,6 @@
     "core:event:allow-emit",
     "dialog:default",
     "fs:default",
-    "notification:default",
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "https://*" }, { "url": "http://*" }]

--- a/clients/openframe-chat/src-tauri/src/lib.rs
+++ b/clients/openframe-chat/src-tauri/src/lib.rs
@@ -83,6 +83,7 @@ pub(crate) fn activate_main_window(app: &tauri::AppHandle) {
         }
         if let Some(window) = handle.get_webview_window("main") {
             let _ = window.show();
+            let _ = window.unminimize();
             let _ = window.set_focus();
         }
     });
@@ -203,6 +204,29 @@ fn register_app_id() {
     }
 }
 
+/// Register the openframe-chat:// URI scheme (HKCU, no elevation). Toast
+/// clicks activate through it — see nats_bridge/windows_toast.rs. Re-written
+/// on every launch so the command always points at the current exe path.
+#[cfg(target_os = "windows")]
+fn register_url_scheme() {
+    use winreg::{enums::*, RegKey};
+
+    let Ok(exe) = std::env::current_exe() else {
+        log::warn!("url scheme: current_exe unavailable — skipping registration");
+        return;
+    };
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok((key, _)) = hkcu.create_subkey(r"Software\Classes\openframe-chat") else {
+        log::warn!("url scheme: failed to create registry key");
+        return;
+    };
+    let _ = key.set_value("", &"URL:OpenFrame Chat");
+    let _ = key.set_value("URL Protocol", &"");
+    if let Ok((command, _)) = key.create_subkey(r"shell\open\command") {
+        let _ = command.set_value("", &format!("\"{}\" \"%1\"", exe.display()));
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn register_start_menu_shortcut() {
     use mslnk::ShellLink;
@@ -255,9 +279,9 @@ fn register_start_menu_shortcut() {
 
 /// Materializes the embedded app icon to a user-writable path and points the
 /// AUMID's `IconUri` at it. The agent ships only the chat executable — no Tauri
-/// `resources/` on disk — so a bundled-resource path never exists; and
-/// notify-rust ignores per-notification icons on Windows, leaving this registry
-/// icon as the only logo source for toasts and the Action Center.
+/// `resources/` on disk — so a bundled-resource path never exists; our toast
+/// XML sets no per-notification image, leaving this registry icon as the only
+/// logo source for toasts and the Action Center.
 #[cfg(target_os = "windows")]
 fn register_notification_icon(app: &tauri::AppHandle) {
     use winreg::{enums::*, RegKey};
@@ -301,6 +325,14 @@ fn nats_set_notifications_enabled(bridge: State<'_, NatsBridge>, enabled: bool) 
     bridge.set_notifications_enabled(enabled);
 }
 
+/// Called once by the WebView when its notification:click listener mounts.
+/// Opens the click gate and returns a click that happened before the WebView
+/// was ready (a notification click that cold-started the app), if any.
+#[tauri::command]
+fn take_pending_notification_click(bridge: State<'_, NatsBridge>) -> Option<serde_json::Value> {
+    bridge.take_startup_click()
+}
+
 #[tauri::command]
 async fn nats_subscribe_dialog(
     bridge: State<'_, NatsBridge>,
@@ -335,6 +367,7 @@ pub fn run() {
     {
         register_app_id();
         register_start_menu_shortcut();
+        register_url_scheme();
     }
 
     println!("[startup] openframe-chat starting (version {})", env!("CARGO_PKG_VERSION"));
@@ -378,6 +411,13 @@ pub fn run() {
     builder = builder
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             log::info!("single-instance: second launch intercepted");
+            // Windows toast clicks arrive as a protocol launch of a second
+            // instance with the openframe-chat:// URI in argv.
+            if let Some(uri) = argv.iter().find(|arg| arg.starts_with("openframe-chat://")) {
+                if let Some(bridge) = app.try_state::<NatsBridge>() {
+                    bridge.handle_notification_uri(uri);
+                }
+            }
             let background_relaunch = argv.iter().any(|arg| arg == "--background");
             if !background_relaunch {
                 if let Some(window) = app.get_webview_window("main") {
@@ -400,7 +440,6 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {
             if std::env::var("OPENFRAME_DISABLE_LOG").is_err() {
@@ -484,6 +523,14 @@ pub fn run() {
             app.manage(bridge.clone());
             bridge.start();
             log::info!("NATS bridge initialized");
+
+            // Cold start from a Windows toast click: the protocol launch put
+            // the URI in our own argv. The payload is stashed until the
+            // WebView pulls take_pending_notification_click.
+            #[cfg(target_os = "windows")]
+            if let Some(uri) = std::env::args().find(|arg| arg.starts_with("openframe-chat://")) {
+                bridge.handle_notification_uri(&uri);
+            }
             
             let show_i = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
 
@@ -694,10 +741,7 @@ pub fn run() {
                     let _ = window.hide();
                 }
                 WindowEvent::Focused(true) => {
-                    // Click-on-notification heuristic: when the main window
-                    // gains focus shortly after a NATS-driven notification
-                    // fired, ask the bridge to emit notification:click so
-                    // the WebView can navigate to the source dialog.
+                    // The user is looking at the chat — clear the unread badge.
                     if window.label() == "main" {
                         if let Some(bridge) = window.app_handle().try_state::<NatsBridge>() {
                             bridge.on_main_window_focused();
@@ -715,6 +759,7 @@ pub fn run() {
             log_from_js,
             nats_status,
             nats_set_notifications_enabled,
+            take_pending_notification_click,
             nats_subscribe_dialog,
             nats_unsubscribe_dialog,
             nats_register_event_channel,

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/macos_un.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/macos_un.rs
@@ -1,0 +1,235 @@
+// `UNUserNotificationCenter` backend for bundled (production) macOS builds.
+//
+// Chosen over the deprecated `NSUserNotificationCenter` path (notify-rust)
+// because UN delivers `didReceiveNotificationResponse` for every click —
+// live banner, Notification Center hours later, or a click that launches the
+// app cold — while the legacy path only reports clicks on the live banner.
+//
+// The click target rides in the notification's `userInfo` (as the ready-made
+// `notification:click` JSON payload), so it survives process restarts and no
+// in-process id→target registry is needed.
+//
+// UN APIs abort in processes without a bundle identifier, so `init` refuses
+// to activate for dev builds (`tauri dev` runs a bare binary) — those have
+// no OS notifications.
+
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use block2::{DynBlock, RcBlock};
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Bool, ProtocolObject};
+use objc2::{define_class, msg_send, AnyThread};
+use objc2_foundation::{
+    NSArray, NSBundle, NSDictionary, NSError, NSObject, NSObjectProtocol, NSSet, NSString,
+};
+use objc2_user_notifications::{
+    UNAuthorizationOptions, UNMutableNotificationContent, UNNotification, UNNotificationAction,
+    UNNotificationActionOptions, UNNotificationCategory, UNNotificationCategoryOptions,
+    UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
+    UNUserNotificationCenter, UNUserNotificationCenterDelegate,
+};
+
+use super::notifications::{deliver_click_payload, NotificationTarget};
+use super::Inner;
+
+const CATEGORY_ID: &str = "openframe-chat-message";
+const OPEN_ACTION_ID: &str = "open";
+const PAYLOAD_KEY: &str = "of-click-payload";
+
+/// The delegate has no state of its own; clicks are routed to the bridge
+/// through this slot. Set once at `init`, before the delegate is installed.
+static ROUTER: OnceLock<Arc<Inner>> = OnceLock::new();
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+pub(super) fn active() -> bool {
+    ACTIVE.load(Ordering::Acquire)
+}
+
+/// Install the delegate and register the action category. Called from
+/// `NatsBridge::new` during Tauri setup — early enough that a cold-start
+/// click's response (delivered right after launch) finds the delegate.
+pub(super) fn init(inner: &Arc<Inner>) {
+    if tauri::is_dev() {
+        return;
+    }
+    if NSBundle::mainBundle().bundleIdentifier().is_none() {
+        tracing::warn!("[NATS] no bundle identifier — OS notifications disabled");
+        return;
+    }
+    if ROUTER.set(inner.clone()).is_err() {
+        return;
+    }
+
+    static DELEGATE: OnceLock<Retained<NotificationDelegate>> = OnceLock::new();
+    DELEGATE.get_or_init(|| {
+        let delegate = NotificationDelegate::new();
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        center.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+        register_category(&center);
+        delegate
+    });
+
+    ACTIVE.store(true, Ordering::Release);
+    tracing::info!("[NATS] UNUserNotificationCenter notification backend active");
+}
+
+/// Ask macOS for notification permission once, when the frontend enables the
+/// feature. Denial is not an error — notifications just won't display, which
+/// the user controls in System Settings.
+pub(super) fn ensure_authorized() {
+    if !active() {
+        return;
+    }
+    static REQUESTED: AtomicBool = AtomicBool::new(false);
+    if REQUESTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    UNUserNotificationCenter::currentNotificationCenter()
+        .requestAuthorizationWithOptions_completionHandler(
+            UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+            &RcBlock::new(|granted: Bool, error: *mut NSError| {
+                if let Some(error) = NonNull::new(error).map(|p| unsafe { p.as_ref() }) {
+                    tracing::warn!(
+                        "[NATS] notification authorization failed: {}",
+                        error.localizedDescription()
+                    );
+                } else {
+                    tracing::info!(
+                        "[NATS] notification authorization granted: {}",
+                        granted.as_bool()
+                    );
+                }
+            }),
+        );
+}
+
+pub(super) fn fire(title: String, body: String, target: Option<NotificationTarget>) {
+    if !active() {
+        tracing::debug!("[NATS] UN backend inactive (dev/unbundled build) — dropping notification");
+        return;
+    }
+    // UNUserNotificationCenter is thread-safe; keep the ObjC work off the
+    // NATS router task all the same.
+    std::thread::spawn(move || {
+        let content = UNMutableNotificationContent::new();
+        content.setTitle(&NSString::from_str(&title));
+        if !body.is_empty() {
+            content.setBody(&NSString::from_str(&body));
+        }
+        content.setCategoryIdentifier(&NSString::from_str(CATEGORY_ID));
+
+        if let Some(target) = &target {
+            let key = NSString::from_str(PAYLOAD_KEY);
+            let value = NSString::from_str(&target.click_payload().to_string());
+            let dict = NSDictionary::from_slices(&[&*key], &[&*value]);
+            // Erase the generics: setUserInfo takes an untyped NSDictionary.
+            // Layout-identical (generics on objc2 collections are phantom);
+            // NSStrings satisfy the plist requirement.
+            let erased: &NSDictionary =
+                unsafe { &*(Retained::as_ptr(&dict) as *const NSDictionary) };
+            unsafe { content.setUserInfo(erased) };
+        }
+
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+            &NSString::from_str(&request_id),
+            &content,
+            None,
+        );
+
+        UNUserNotificationCenter::currentNotificationCenter()
+            .addNotificationRequest_withCompletionHandler(
+                &request,
+                Some(&RcBlock::new(move |error: *mut NSError| {
+                    if let Some(error) = NonNull::new(error).map(|p| unsafe { p.as_ref() }) {
+                        tracing::warn!(
+                            "[NATS] notification request rejected: {}",
+                            error.localizedDescription()
+                        );
+                    } else {
+                        tracing::info!("[NATS] notification fired: {title}");
+                    }
+                })),
+            );
+    });
+}
+
+fn register_category(center: &UNUserNotificationCenter) {
+    // Foreground: clicking "Open" activates the app (a body click does so
+    // inherently). No CustomDismissAction — it would make macOS relaunch the
+    // app just to report a dismissal after the user quit it.
+    let action = UNNotificationAction::actionWithIdentifier_title_options(
+        &NSString::from_str(OPEN_ACTION_ID),
+        &NSString::from_str("Open"),
+        UNNotificationActionOptions::Foreground,
+    );
+    let category = UNNotificationCategory::categoryWithIdentifier_actions_intentIdentifiers_options(
+        &NSString::from_str(CATEGORY_ID),
+        &NSArray::from_retained_slice(&[action]),
+        &NSArray::new(),
+        UNNotificationCategoryOptions::empty(),
+    );
+    center.setNotificationCategories(&NSSet::from_retained_slice(&[category]));
+}
+
+fn payload_from_response(response: &UNNotificationResponse) -> Option<serde_json::Value> {
+    let user_info = response.notification().request().content().userInfo();
+    let key = NSString::from_str(PAYLOAD_KEY);
+    let key: &AnyObject = &key;
+    let value = user_info.objectForKey(key)?;
+    let json = value.downcast_ref::<NSString>()?.to_string();
+    serde_json::from_str(&json).ok()
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "OpenFrameChatNotificationDelegate"]
+    struct NotificationDelegate;
+
+    unsafe impl NSObjectProtocol for NotificationDelegate {}
+
+    unsafe impl UNUserNotificationCenterDelegate for NotificationDelegate {
+        /// Without this, macOS silently drops notifications while the app is
+        /// frontmost. `should_notify` already gates on window focus, so any
+        /// notification that reaches this point should display. Banner only —
+        /// the pre-UN path was silent.
+        #[unsafe(method(userNotificationCenter:willPresentNotification:withCompletionHandler:))]
+        fn will_present_notification(
+            &self,
+            _center: &UNUserNotificationCenter,
+            _notification: &UNNotification,
+            completion_handler: &DynBlock<dyn Fn(UNNotificationPresentationOptions)>,
+        ) {
+            completion_handler.call((UNNotificationPresentationOptions::Banner,));
+        }
+
+        /// Every response is a user click (notification body or the Open
+        /// button): dismiss events are only reported with CustomDismissAction,
+        /// which the category deliberately does not set.
+        #[unsafe(method(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:))]
+        fn did_receive_response(
+            &self,
+            _center: &UNUserNotificationCenter,
+            response: &UNNotificationResponse,
+            completion_handler: &DynBlock<dyn Fn()>,
+        ) {
+            tracing::info!(
+                "[NATS] notification response (action={})",
+                response.actionIdentifier()
+            );
+            if let Some(inner) = ROUTER.get() {
+                deliver_click_payload(inner, payload_from_response(response));
+            }
+            completion_handler.call(());
+        }
+    }
+);
+
+impl NotificationDelegate {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(());
+        unsafe { msg_send![super(this), init] }
+    }
+}

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/mod.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/mod.rs
@@ -15,7 +15,11 @@
 
 mod connection;
 mod dialogs;
+#[cfg(target_os = "macos")]
+mod macos_un;
 mod notifications;
+#[cfg(target_os = "windows")]
+mod windows_toast;
 
 pub(crate) use connection::mask_token;
 
@@ -34,7 +38,6 @@ use crate::token_watcher::TokenSource;
 use crate::ServerUrlState;
 
 use dialogs::DialogState;
-use notifications::PendingNotification;
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -103,9 +106,11 @@ struct Inner {
     /// webview still succeeds, so stale channels can't be detected by send
     /// failures and must not accumulate.
     event_channel: RwLock<Option<Channel<NatsEvent>>>,
-    /// Most recent notification's dialog id + when it was fired. Consumed
-    /// by the window-focus handler to emit `notification:click`.
-    pending_notification: StdMutex<Option<PendingNotification>>,
+    /// `true` once the WebView pulled `take_pending_notification_click`,
+    /// i.e. its `notification:click` listener is mounted. Until then click
+    /// payloads are parked in `stashed_click` (cold-start clicks).
+    webview_click_ready: AtomicBool,
+    stashed_click: StdMutex<Option<serde_json::Value>>,
 }
 
 impl NatsBridge {
@@ -123,7 +128,7 @@ impl NatsBridge {
         } else {
             tracing::warn!("[NATS] no machineId in config — OS notifications disabled");
         }
-        Self {
+        let bridge = Self {
             inner: Arc::new(Inner {
                 client: RwLock::new(None),
                 state: RwLock::new(ConnectionState::Disconnected),
@@ -140,9 +145,13 @@ impl NatsBridge {
                 notification_task: RwLock::new(None),
                 dialogs: RwLock::new(HashMap::new()),
                 event_channel: RwLock::new(None),
-                pending_notification: StdMutex::new(None),
+                webview_click_ready: AtomicBool::new(false),
+                stashed_click: StdMutex::new(None),
             }),
-        }
+        };
+        #[cfg(target_os = "macos")]
+        macos_un::init(&bridge.inner);
+        bridge
     }
 
     /// Spawn the connect task. Idempotent: subsequent calls are no-ops.

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/mod.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/mod.rs
@@ -108,7 +108,9 @@ struct Inner {
     event_channel: RwLock<Option<Channel<NatsEvent>>>,
     /// `true` once the WebView pulled `take_pending_notification_click`,
     /// i.e. its `notification:click` listener is mounted. Until then click
-    /// payloads are parked in `stashed_click` (cold-start clicks).
+    /// payloads are parked in `stashed_click` (cold-start clicks). Only
+    /// accessed while holding the `stashed_click` lock, which serializes the
+    /// ready-flip + drain against concurrent emit-or-stash decisions.
     webview_click_ready: AtomicBool,
     stashed_click: StdMutex<Option<serde_json::Value>>,
 }

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/notifications.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/notifications.rs
@@ -92,13 +92,15 @@ impl NatsBridge {
     /// mounted. Marks the gate open and drains any click that happened before
     /// (cold-start launch via a notification).
     pub fn take_startup_click(&self) -> Option<serde_json::Value> {
+        // Flip ready and drain under the stash lock — see emit_or_stash.
+        let mut stash = match self.inner.stashed_click.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
         self.inner
             .webview_click_ready
             .store(true, Ordering::Release);
-        match self.inner.stashed_click.lock() {
-            Ok(mut g) => g.take(),
-            Err(p) => p.into_inner().take(),
-        }
+        stash.take()
     }
 }
 
@@ -106,14 +108,19 @@ impl NatsBridge {
 /// not signalled readiness yet (cold start: the click that launched the app
 /// happens before React mounts the listener).
 fn emit_or_stash(inner: &Inner, payload: serde_json::Value) {
+    // The readiness check and the stash write share the stash lock: checked
+    // outside it, a concurrent take_startup_click could flip ready and drain
+    // between our check and store, stranding the payload until the next
+    // webview reload.
+    let mut stash = match inner.stashed_click.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
     if inner.webview_click_ready.load(Ordering::Acquire) {
         let _ = inner.app.emit_to("main", "notification:click", payload);
     } else {
         tracing::info!("[NATS] webview not ready — stashing notification click");
-        match inner.stashed_click.lock() {
-            Ok(mut g) => *g = Some(payload),
-            Err(p) => *p.into_inner() = Some(payload),
-        }
+        *stash = Some(payload);
     }
 }
 

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/notifications.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/notifications.rs
@@ -1,27 +1,52 @@
 // OS notifications: the core NATS subscription on
 // `machine.<machineId>.notification`, envelope parsing/dispatch, the dock
-// badge, and the pending-click handoff consumed on window focus.
+// badge, and click handling that navigates the WebView to the notification's
+// source entity.
+//
+// Click delivery per platform:
+//   - macOS bundled builds: `UNUserNotificationCenter` (`macos_un`) delivers a
+//     callback for every click — live banner, Notification Center, or a
+//     cold-start launch — with the target carried in the notification's
+//     userInfo.
+//   - Windows: toasts use protocol activation; every click opens an
+//     `openframe-chat://notify` URI which reaches the running instance via
+//     single-instance argv forwarding, or launches the app cold
+//     (`handle_notification_uri`).
+//   - macOS dev builds (unbundled — UN APIs abort there) and other platforms
+//     have no OS notification backend.
+//
+// All click paths funnel into `deliver_click_payload`, which stashes the
+// payload until the WebView signals readiness (`take_startup_click`) so
+// cold-start clicks are not emitted into a not-yet-mounted listener.
 
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use tauri::{async_runtime, AppHandle, Emitter, Manager};
 
 use super::{current_client, Inner, NatsBridge};
 
+const CLICK_URI_PREFIX: &str = "openframe-chat://notify";
+
 /// What the WebView should open when the user clicks a notification.
-#[derive(Clone, Debug)]
-enum NotificationTarget {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum NotificationTarget {
     Ticket { ticket_id: String },
     Dialog { dialog_id: String },
 }
 
-#[derive(Clone, Debug)]
-pub(super) struct PendingNotification {
-    target: NotificationTarget,
-    fired_at: Instant,
+impl NotificationTarget {
+    pub(super) fn click_payload(&self) -> serde_json::Value {
+        match self {
+            NotificationTarget::Ticket { ticket_id } => {
+                serde_json::json!({ "kind": "ticket", "id": ticket_id })
+            }
+            NotificationTarget::Dialog { dialog_id } => {
+                serde_json::json!({ "kind": "dialog", "id": dialog_id })
+            }
+        }
+    }
 }
 
 impl NatsBridge {
@@ -34,43 +59,120 @@ impl NatsBridge {
         if was != enabled {
             tracing::info!("[NATS] notifications feature flag: {enabled}");
         }
+        #[cfg(target_os = "macos")]
+        if enabled {
+            super::macos_un::ensure_authorized();
+        }
     }
 
-    /// Called from the main-window focus handler. Clears unread state and,
-    /// if a notification was fired in the last `MAX_PENDING_AGE` seconds,
-    /// emits `notification:click` so the WebView can navigate.
+    /// Called from the main-window focus handler: clears the unread badge.
     pub fn on_main_window_focused(&self) {
-        const MAX_PENDING_AGE: Duration = Duration::from_secs(30);
-
         if self.inner.unread_count.swap(0, Ordering::Relaxed) > 0 {
             set_badge(&self.inner, 0);
         }
+    }
 
-        let pending = {
-            let mut guard = match self.inner.pending_notification.lock() {
-                Ok(g) => g,
-                Err(p) => p.into_inner(),
-            };
-            guard.take()
-        };
-
-        let Some(p) = pending else { return };
-        if p.fired_at.elapsed() > MAX_PENDING_AGE {
-            tracing::debug!("[NATS] dropping stale pending notification: {:?}", p.target);
-            return;
+    /// Handles an `openframe-chat://notify` URI from a Windows toast click,
+    /// arriving either as our own argv (cold start) or forwarded by the
+    /// single-instance plugin (warm click). Returns `false` for foreign URIs.
+    pub fn handle_notification_uri(&self, uri: &str) -> bool {
+        if !uri.starts_with(CLICK_URI_PREFIX) {
+            return false;
         }
+        let payload = parse_click_payload(uri);
+        tracing::info!(
+            "[NATS] notification click URI received (target: {})",
+            payload.is_some()
+        );
+        deliver_click_payload(&self.inner, payload);
+        true
+    }
 
-        let payload = match p.target {
-            NotificationTarget::Ticket { ticket_id } => {
-                tracing::info!("[NATS] window focused — emitting notification:click for ticket {ticket_id}");
-                serde_json::json!({ "kind": "ticket", "id": ticket_id })
-            }
-            NotificationTarget::Dialog { dialog_id } => {
-                tracing::info!("[NATS] window focused — emitting notification:click for dialog {dialog_id}");
-                serde_json::json!({ "kind": "dialog", "id": dialog_id })
-            }
+    /// Invoked once by the WebView when its `notification:click` listener is
+    /// mounted. Marks the gate open and drains any click that happened before
+    /// (cold-start launch via a notification).
+    pub fn take_startup_click(&self) -> Option<serde_json::Value> {
+        self.inner
+            .webview_click_ready
+            .store(true, Ordering::Release);
+        match self.inner.stashed_click.lock() {
+            Ok(mut g) => g.take(),
+            Err(p) => p.into_inner().take(),
+        }
+    }
+}
+
+/// Emit `notification:click` to the WebView, or stash it if the WebView has
+/// not signalled readiness yet (cold start: the click that launched the app
+/// happens before React mounts the listener).
+fn emit_or_stash(inner: &Inner, payload: serde_json::Value) {
+    if inner.webview_click_ready.load(Ordering::Acquire) {
+        let _ = inner.app.emit_to("main", "notification:click", payload);
+    } else {
+        tracing::info!("[NATS] webview not ready — stashing notification click");
+        match inner.stashed_click.lock() {
+            Ok(mut g) => *g = Some(payload),
+            Err(p) => *p.into_inner() = Some(payload),
+        }
+    }
+}
+
+/// The OS identified the exact notification that was clicked: deliver the
+/// payload and activate the window.
+pub(super) fn deliver_click_payload(inner: &Inner, payload: Option<serde_json::Value>) {
+    match payload {
+        Some(payload) => {
+            tracing::info!("[NATS] notification activated — opening {payload}");
+            emit_or_stash(inner, payload);
+        }
+        None => tracing::info!("[NATS] notification activated — opening window"),
+    }
+    crate::activate_main_window(&inner.app);
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn click_uri(target: Option<&NotificationTarget>) -> String {
+    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    let encode = |id: &str| utf8_percent_encode(id, NON_ALPHANUMERIC).to_string();
+    match target {
+        Some(NotificationTarget::Ticket { ticket_id }) => {
+            format!("{CLICK_URI_PREFIX}?kind=ticket&id={}", encode(ticket_id))
+        }
+        Some(NotificationTarget::Dialog { dialog_id }) => {
+            format!("{CLICK_URI_PREFIX}?kind=dialog&id={}", encode(dialog_id))
+        }
+        None => CLICK_URI_PREFIX.to_string(),
+    }
+}
+
+/// `openframe-chat://notify?kind=<ticket|dialog>&id=<percent-encoded>` →
+/// the `notification:click` payload. `None` for a bare/malformed URI (the
+/// click still activates the window, it just doesn't navigate).
+fn parse_click_payload(uri: &str) -> Option<serde_json::Value> {
+    let rest = uri.strip_prefix(CLICK_URI_PREFIX)?;
+    let query = rest.strip_prefix('/').unwrap_or(rest).strip_prefix('?')?;
+    let mut kind = None;
+    let mut id = None;
+    for pair in query.split('&') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
         };
-        let _ = self.inner.app.emit_to("main", "notification:click", payload);
+        match k {
+            "kind" => kind = Some(v.to_string()),
+            "id" => {
+                id = percent_encoding::percent_decode_str(v)
+                    .decode_utf8()
+                    .ok()
+                    .map(|s| s.into_owned())
+            }
+            _ => {}
+        }
+    }
+    match (kind, id) {
+        (Some(kind), Some(id)) if !id.is_empty() => {
+            Some(serde_json::json!({ "kind": kind, "id": id }))
+        }
+        _ => None,
     }
 }
 
@@ -136,7 +238,9 @@ async fn notification_router(inner: Arc<Inner>, mut subscriber: async_nats::Subs
     // of treating the dead handle as "already subscribed". No generation
     // guard needed: this task is installed once and never replaced.
     *inner.notification_task.write().await = None;
-    tracing::info!("[NATS] notification router exited (stream closed) — will re-subscribe on next connect");
+    tracing::info!(
+        "[NATS] notification router exited (stream closed) — will re-subscribe on next connect"
+    );
 }
 
 /// A backend notification reduced to what we render + where a click lands.
@@ -164,8 +268,12 @@ fn parse_notification(payload: &serde_json::Value) -> Option<ParsedNotification>
 }
 
 fn parse_target(context: &serde_json::Value) -> Option<NotificationTarget> {
-    let ticket = || string_field(context, "ticketId").map(|ticket_id| NotificationTarget::Ticket { ticket_id });
-    let dialog = || string_field(context, "dialogId").map(|dialog_id| NotificationTarget::Dialog { dialog_id });
+    let ticket = || {
+        string_field(context, "ticketId").map(|ticket_id| NotificationTarget::Ticket { ticket_id })
+    };
+    let dialog = || {
+        string_field(context, "dialogId").map(|dialog_id| NotificationTarget::Dialog { dialog_id })
+    };
 
     match string_field(context, "type").as_deref() {
         Some("CLIENT_AI_MESSAGE") => dialog(),
@@ -205,59 +313,43 @@ fn maybe_notify(inner: &Arc<Inner>, payload: &serde_json::Value) {
         return;
     }
 
-    if let Some(target) = &parsed.target {
-        if let Ok(mut guard) = inner.pending_notification.lock() {
-            *guard = Some(PendingNotification {
-                target: target.clone(),
-                fired_at: Instant::now(),
-            });
-        }
-    }
-
     let n = inner.unread_count.fetch_add(1, Ordering::Relaxed) + 1;
     set_badge(inner, n);
 
-    let ParsedNotification { title, body, .. } = parsed;
-    fire_notification(app.clone(), title, body);
+    let ParsedNotification {
+        title,
+        body,
+        target,
+    } = parsed;
+    #[cfg(target_os = "macos")]
+    super::macos_un::fire(title, body, target);
+    #[cfg(target_os = "windows")]
+    fire_toast(inner, title, body, target);
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (title, body, target);
+        tracing::debug!("[NATS] no notification backend on this platform");
+    }
 }
 
-fn fire_notification(app: AppHandle, title: String, body: String) {
-    std::thread::spawn(move || {
-        let mut notification = notify_rust::Notification::new();
-        notification.summary(&title);
-        if !body.is_empty() {
-            notification.body(&body);
-        }
-        notification.action("open", "Open");
+#[cfg(target_os = "windows")]
+fn fire_toast(inner: &Arc<Inner>, title: String, body: String, target: Option<NotificationTarget>) {
+    // Dev builds have no registered AUMID; PowerShell's works out of the box.
+    const POWERSHELL_APP_ID: &str =
+        "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe";
+    let app_id = if tauri::is_dev() {
+        POWERSHELL_APP_ID.to_string()
+    } else {
+        inner.app.config().identifier.clone()
+    };
+    let uri = click_uri(target.as_ref());
 
-        #[cfg(target_os = "macos")]
-        {
-            let identifier = if tauri::is_dev() {
-                "com.apple.Terminal".to_string()
-            } else {
-                app.config().identifier.clone()
-            };
-            let _ = notify_rust::set_application(&identifier);
-        }
-        #[cfg(target_os = "windows")]
-        if !tauri::is_dev() {
-            notification.app_id(&app.config().identifier);
-        }
-
-        match notification.show() {
-            Ok(handle) => {
-                tracing::info!("[NATS] notification fired: {title}");
-                use notify_rust::NotificationResponse;
-                let _ = handle.wait_for_response(|response: &NotificationResponse| {
-                    if !matches!(response, NotificationResponse::Closed(_)) {
-                        tracing::info!("[NATS] notification activated — opening window");
-                        crate::activate_main_window(&app);
-                    }
-                });
-            }
-            Err(err) => tracing::warn!("[NATS] notification show failed: {err}"),
-        }
-    });
+    std::thread::spawn(
+        move || match super::windows_toast::show(&app_id, &title, &body, &uri) {
+            Ok(()) => tracing::info!("[NATS] notification fired: {title}"),
+            Err(err) => tracing::warn!("[NATS] notification show failed: {err:?}"),
+        },
+    );
 }
 
 fn should_notify(app: &AppHandle) -> bool {
@@ -287,4 +379,34 @@ fn truncate_for_notification(text: &str, max: usize) -> String {
     let mut out: String = text.chars().take(max.saturating_sub(1)).collect();
     out.push('…');
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn click_uri_roundtrip() {
+        let target = NotificationTarget::Ticket {
+            ticket_id: "6a4fda9ba8b65c28c4dbf6ba".into(),
+        };
+        let payload = parse_click_payload(&click_uri(Some(&target))).unwrap();
+        assert_eq!(payload["kind"], "ticket");
+        assert_eq!(payload["id"], "6a4fda9ba8b65c28c4dbf6ba");
+
+        let target = NotificationTarget::Dialog {
+            dialog_id: "abc/д ф".into(),
+        };
+        let payload = parse_click_payload(&click_uri(Some(&target))).unwrap();
+        assert_eq!(payload["kind"], "dialog");
+        assert_eq!(payload["id"], "abc/д ф");
+    }
+
+    #[test]
+    fn bare_uri_has_no_payload() {
+        assert_eq!(click_uri(None), "openframe-chat://notify");
+        assert!(parse_click_payload("openframe-chat://notify").is_none());
+        assert!(parse_click_payload("openframe-chat://notify?kind=ticket&id=").is_none());
+        assert!(parse_click_payload("openframe-chat://notify?id=x").is_none());
+    }
 }

--- a/clients/openframe-chat/src-tauri/src/nats_bridge/windows_toast.rs
+++ b/clients/openframe-chat/src-tauri/src/nats_bridge/windows_toast.rs
@@ -1,0 +1,51 @@
+// Protocol-activation toasts, hand-built because tauri-winrt-notification
+// only supports foreground activation (in-process `Activated` handlers),
+// which dies with the process: clicks on toasts left in the Action Center by
+// a previous app session went nowhere. `activationType="protocol"` makes the
+// OS open the `openframe-chat://notify` URI instead — a warm click reaches
+// the running instance through single-instance argv forwarding, a cold click
+// launches the app with the URI in argv. Both land in
+// `NatsBridge::handle_notification_uri`.
+
+use windows::core::HSTRING;
+use windows::Data::Xml::Dom::XmlDocument;
+use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};
+
+pub(super) fn show(app_id: &str, title: &str, body: &str, uri: &str) -> windows::core::Result<()> {
+    let body_element = if body.is_empty() {
+        String::new()
+    } else {
+        format!("<text>{}</text>", escape_xml(body))
+    };
+    // Silent to match the previously shipped toasts. The launch attribute
+    // covers body clicks; the action covers the Open button.
+    let xml = format!(
+        r#"<toast duration="short" activationType="protocol" launch="{uri}">
+    <visual><binding template="ToastGeneric"><text>{title}</text>{body_element}</binding></visual>
+    <audio silent="true"/>
+    <actions><action content="Open" activationType="protocol" arguments="{uri}"/></actions>
+</toast>"#,
+        uri = escape_xml(uri),
+        title = escape_xml(title),
+    );
+
+    let document = XmlDocument::new()?;
+    document.LoadXml(&HSTRING::from(xml.as_str()))?;
+    let toast = ToastNotification::CreateToastNotification(&document)?;
+    ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(app_id))?.Show(&toast)
+}
+
+fn escape_xml(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}

--- a/clients/openframe-chat/src/views/ChatView.tsx
+++ b/clients/openframe-chat/src/views/ChatView.tsx
@@ -21,6 +21,7 @@ import {
 import { Ellipsis01Icon, PlusCircleIcon, TagIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatDialogScreen } from '../components/ChatDialogScreen';
@@ -399,17 +400,16 @@ export function ChatView() {
     return () => clearInterval(interval);
   }, [isTicketPreview, previewTicketId, resumeDialog]);
 
-  // Rust emits notification:click when the window gains focus shortly after a
-  // NATS-driven OS notification; open the entity it came from. The ref keeps
-  // the Tauri listener registered once instead of churning per render.
+  // Rust emits notification:click with the clicked OS notification's target
+  // (see nats_bridge/notifications.rs); open the entity it came from. The ref
+  // keeps the Tauri listener registered once instead of churning per render.
   const notificationClickRef = useRef({ handleTicketClick, resumeDialog, dialogId });
   notificationClickRef.current = { handleTicketClick, resumeDialog, dialogId };
 
   useEffect(() => {
     if (!isTauri) return;
     type NotificationClickPayload = { kind: string; id: string };
-    const unlistenPromise = listen<NotificationClickPayload>('notification:click', event => {
-      const { kind, id } = event.payload;
+    const handleClick = ({ kind, id }: NotificationClickPayload) => {
       if (!id) return;
       if (kind === 'ticket') {
         void notificationClickRef.current.handleTicketClick(id);
@@ -418,7 +418,15 @@ export function ChatView() {
         // Already viewing this dialog — the live subscription has the message.
         if (id !== dialogId) void resumeDialog(id);
       }
-    });
+    };
+    const unlistenPromise = listen<NotificationClickPayload>('notification:click', event => handleClick(event.payload));
+    // A click that launched the app is stashed Rust-side until this listener
+    // exists; pulling it also opens the gate for future direct emits.
+    invoke<NotificationClickPayload | null>('take_pending_notification_click')
+      .then(payload => {
+        if (payload) handleClick(payload);
+      })
+      .catch(() => undefined);
     return () => {
       unlistenPromise.then(unlisten => unlisten()).catch(() => undefined);
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native macOS notifications with permission handling and foreground display.
  * Added Windows toast notifications with clickable links that open the relevant chat or ticket.
  * Notification clicks now work when the app is already open or launched from a notification.
  * Improved startup handling so notification destinations open automatically.

* **Bug Fixes**
  * Restored the main window when opening the app from a macOS notification.
  * Improved unread badge clearing when the window regains focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->