### PR TITLE
feat(onboarding): embed demo videos + yellow reset-onboarding

### DIFF
--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.402",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.403",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.402",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.402.tgz",
-      "integrity": "sha512-QXZ5PL6IfiHiU9fyKTZyyOVnjAt9QRxYfD/qsrs+SAElob90KNoGdb7pNcqodP4XGNcWhCYHeqkLAdN8AKLGEA==",
+      "version": "0.0.403",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.403.tgz",
+      "integrity": "sha512-4NL6qSS4rw+pX3OuoAXH9gV2zMN8KWIpw4bAtNRLzlk5G/vPrj2GEwmOBLUrVqVPRqfPlRRCPC+UZjvDYYR1Qw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.402",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.403",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/mingo-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/mingo-step.tsx
@@ -7,6 +7,7 @@ import {
   type QuickActionChip,
   useEmptyStateConfig,
 } from '@flamingo-stack/openframe-frontend-core/components/chat';
+import { Video } from '@flamingo-stack/openframe-frontend-core/components/features';
 import { CheckCircleIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useChatRuntime } from '@flamingo-stack/openframe-frontend-core/contexts';
@@ -16,6 +17,9 @@ import { useMingoLauncherStore } from '@/app/(app)/mingo/stores/mingo-launcher-s
 import { useMingoMessagesStore } from '@/app/(app)/mingo/stores/mingo-messages-store';
 
 const GUARDRAILS_HREF = '/settings/ai-settings?tab=guardrails';
+
+// Placeholder demo clip until the real onboarding videos are ready.
+const DEMO_VIDEO_ID = 'i4H_XqrI3RA';
 
 /**
  * Inner body of the "Meet Mingo" onboarding step — an intro to the Mingo AI co-pilot.
@@ -105,43 +109,45 @@ export function MingoStep({
           )}
         </div>
 
-        <div className="flex aspect-[976/558] w-full flex-1 items-center justify-center rounded-md border border-ods-text-secondary bg-ods-border">
-          <span className="font-mono text-h2 text-ods-text-secondary">DEMO VIDEO</span>
+        <div className="w-full flex-1">
+          <Video kind="youtube" url={DEMO_VIDEO_ID} title="Meet Mingo demo video" priority />
         </div>
       </div>
 
-      {/* Footer actions */}
-      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+      {/* Footer actions — right column mirrors the intro/video split above so the
+          buttons line up flush with the demo video block. */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-l)] md:flex-row">
         <div className="hidden flex-1 md:block" />
-        <div className="hidden flex-1 md:block" />
-        {!completed ? (
+        <div className="flex w-full flex-1 flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+          {!completed ? (
+            <Button
+              variant="outline"
+              leftIcon={<CheckCircleIcon className="size-5" />}
+              onClick={() => onComplete?.()}
+              loading={completing}
+              disabled={completing}
+              className="w-full md:flex-1"
+            >
+              Mark as Complete
+            </Button>
+          ) : (
+            // Keep the completed step's primary button its own width — don't let it
+            // stretch into the removed "Mark as Complete" slot.
+            <div className="hidden md:block md:flex-1" aria-hidden />
+          )}
           <Button
-            variant="outline"
-            leftIcon={<CheckCircleIcon className="size-5" />}
-            onClick={() => onComplete?.()}
-            loading={completing}
-            disabled={completing}
+            variant="accent"
+            onClick={() => {
+              // Opening a Mingo chat completes the step in the background (if not already
+              // done) — no spinner; the drawer opening is the feedback.
+              if (!completed) onCompleteBackground?.();
+              startNewChat();
+            }}
             className="w-full md:flex-1"
           >
-            Mark as Complete
+            Start New Chat
           </Button>
-        ) : (
-          // Keep the completed step's primary button its own width — don't let it
-          // stretch into the removed "Mark as Complete" slot.
-          <div className="hidden md:block md:flex-1" aria-hidden />
-        )}
-        <Button
-          variant="accent"
-          onClick={() => {
-            // Opening a Mingo chat completes the step in the background (if not already
-            // done) — no spinner; the drawer opening is the feedback.
-            if (!completed) onCompleteBackground?.();
-            startNewChat();
-          }}
-          className="w-full md:flex-1"
-        >
-          Start New Chat
-        </Button>
+        </div>
       </div>
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/tickets-step.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/onboarding/components/tickets-step.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Video } from '@flamingo-stack/openframe-frontend-core/components/features';
 import { CheckCircleIcon, DotsLoaderIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import { Button } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { usePathname, useRouter } from 'next/navigation';
@@ -7,6 +8,9 @@ import type { ReactNode } from 'react';
 import { isSaasTenantMode } from '@/lib/app-mode';
 import { useTicketStatistics } from '../../tickets/hooks/use-ticket-statistics';
 import { onboardingHintUrl } from '../onboarding-coach-marks';
+
+// Placeholder demo clip until the real onboarding videos are ready.
+const DEMO_VIDEO_ID = 'Ch984JTweV8';
 
 /** Uppercase section label + content, e.g. "INSIDE A TICKET". */
 function LabeledBlock({ label, children }: { label: string; children: ReactNode }) {
@@ -67,8 +71,8 @@ export function TicketsStep({
             }
           </p>
         </div>
-        <div className="flex aspect-[976/558] w-full flex-1 items-center justify-center rounded-md border border-ods-text-secondary bg-ods-border">
-          <span className="font-mono text-h2 text-ods-text-secondary">DEMO VIDEO</span>
+        <div className="w-full flex-1">
+          <Video kind="youtube" url={DEMO_VIDEO_ID} title="Tickets demo video" priority />
         </div>
       </div>
 
@@ -91,46 +95,48 @@ export function TicketsStep({
         </div>
       </LabeledBlock>
 
-      {/* Footer actions */}
-      <div className="flex w-full flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+      {/* Footer actions — right column mirrors the intro/video split above so the
+          buttons line up flush with the demo video block. */}
+      <div className="flex w-full flex-col gap-[var(--spacing-system-l)] md:flex-row">
         <div className="hidden flex-1 md:block" />
-        <div className="hidden flex-1 md:block" />
-        {!completed ? (
-          <Button
-            variant="outline"
-            leftIcon={<CheckCircleIcon className="size-5" />}
-            onClick={() => onComplete?.()}
-            loading={completing}
-            disabled={completing}
-            className="w-full md:flex-1"
-          >
-            Mark as Complete
-          </Button>
-        ) : (
-          // Keep the completed step's primary button its own width — don't let it
-          // stretch into the removed "Mark as Complete" slot.
-          <div className="hidden md:block md:flex-1" aria-hidden />
-        )}
-        {/* No tickets yet → passive "waiting" state; once one arrives → primary action. */}
-        {hasTickets ? (
-          <Button
-            variant="accent"
-            onClick={() => {
-              // Reaching Tickets from onboarding completes the step in the background
-              // (if not already done) — no spinner, navigation is the feedback.
-              if (!completed) onCompleteBackground?.();
-              router.push(onboardingHintUrl('/tickets', 'tickets', pathname));
-            }}
-            className="w-full md:flex-1"
-          >
-            Go to Tickets
-          </Button>
-        ) : (
-          <div className="flex w-full items-center justify-center gap-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] py-[var(--spacing-system-sf)] text-ods-text-secondary md:flex-1">
-            <DotsLoaderIcon size={24} />
-            <span className="whitespace-nowrap text-h4">Waiting for first ticket</span>
-          </div>
-        )}
+        <div className="flex w-full flex-1 flex-col gap-[var(--spacing-system-m)] md:flex-row md:items-center">
+          {!completed ? (
+            <Button
+              variant="outline"
+              leftIcon={<CheckCircleIcon className="size-5" />}
+              onClick={() => onComplete?.()}
+              loading={completing}
+              disabled={completing}
+              className="w-full md:flex-1"
+            >
+              Mark as Complete
+            </Button>
+          ) : (
+            // Keep the completed step's primary button its own width — don't let it
+            // stretch into the removed "Mark as Complete" slot.
+            <div className="hidden md:block md:flex-1" aria-hidden />
+          )}
+          {/* No tickets yet → passive "waiting" state; once one arrives → primary action. */}
+          {hasTickets ? (
+            <Button
+              variant="accent"
+              onClick={() => {
+                // Reaching Tickets from onboarding completes the step in the background
+                // (if not already done) — no spinner, navigation is the feedback.
+                if (!completed) onCompleteBackground?.();
+                router.push(onboardingHintUrl('/tickets', 'tickets', pathname));
+              }}
+              className="w-full md:flex-1"
+            >
+              Go to Tickets
+            </Button>
+          ) : (
+            <div className="flex w-full items-center justify-center gap-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] py-[var(--spacing-system-sf)] text-ods-text-secondary md:flex-1">
+              <DotsLoaderIcon size={24} />
+              <span className="whitespace-nowrap text-h4">Waiting for first ticket</span>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/settings/components/profile-card.tsx
@@ -113,6 +113,7 @@ export function ProfileCard({ onEditProfile, onVerifyEmail }: ProfileCardProps) 
         description="This replays your Get Started tour from the beginning. Your existing data isn't affected."
         confirmLabel="Reset Onboarding"
         cancelLabel="Cancel"
+        variant="warning"
         isPending={isResettingOnboarding}
         pendingLabel="Resetting..."
         onConfirm={() => resetUser(() => setIsResetConfirmOpen(false))}


### PR DESCRIPTION
- Onboarding "Tickets" and "Meet Mingo" steps: replace the "DEMO VIDEO" placeholders with real YouTube embeds via the core-lib <Video> component (high-res maxres poster, lazy click-to-play facade).
- Footer actions in both steps now line up flush with the demo-video column.
- Settings profile card: "Reset Onboarding" confirm uses the warning (yellow) variant — the action isn't destructive (data is untouched).
- Bump @flamingo-stack/openframe-frontend-core to ^0.0.403 (ships the maxres YouTube facade poster fix, oss-lib#1419).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added embedded YouTube demo videos to the Mingo and Tickets onboarding steps.
  - Updated onboarding layouts to better align video content and action buttons across screen sizes.

- **Bug Fixes**
  - Improved the visual presentation of the “Reset onboarding” confirmation dialog by applying a warning style.

- **User Experience**
  - Preserved existing onboarding actions, including completion, navigation, ticket status, and starting a new chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->