### PR TITLE
chore(deps): bump @flamingo-stack/openframe-frontend-core to 0.0.406

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.401",
+    "@flamingo-stack/openframe-frontend-core": "0.0.406",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.403",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.406",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.403",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.403.tgz",
-      "integrity": "sha512-4NL6qSS4rw+pX3OuoAXH9gV2zMN8KWIpw4bAtNRLzlk5G/vPrj2GEwmOBLUrVqVPRqfPlRRCPC+UZjvDYYR1Qw==",
+      "version": "0.0.406",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.406.tgz",
+      "integrity": "sha512-yCBD1yr6uO+VGUmrzuKxWABlhi++Ah2sYAp61qLThDpNufTf1iTUde1l0MR8ehF6AYTBTozMN+TC7Mh1E2lZvw==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.403",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.406",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the frontend experience to the latest shared release.
  - Includes the newest available fixes, refinements, and compatibility improvements across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->