### PR TITLE
test: CLI 0.4.8 verification (CI e2e run)

### DIFF
--- a/manifests/app-of-apps/values.yaml
+++ b/manifests/app-of-apps/values.yaml
@@ -4,3 +4,4 @@ repository:
   appsDir: apps
   URL: https://github.com/flamingo-stack/openframe-oss-tenant.git
   branch: main
+# CI e2e trigger: cli 0.4.8 verification


### PR DESCRIPTION
CI run to verify bootstrap --non-interactive with CLI 0.4.8 (latest release). Do not merge — will close after the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comment documenting the CI end-to-end trigger and CLI 0.4.8 verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->