### PR TITLE
chore(deps): bump openframe-frontend-core to 0.0.420 (chat + frontend)

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.406",
+    "@flamingo-stack/openframe-frontend-core": "0.0.420",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/openframe/services/openframe-frontend/package-lock.json
+++ b/openframe/services/openframe-frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openframe-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@flamingo-stack/openframe-frontend-core": "^0.0.406",
+        "@flamingo-stack/openframe-frontend-core": "^0.0.420",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.90.16",
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@flamingo-stack/openframe-frontend-core": {
-      "version": "0.0.406",
-      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.406.tgz",
-      "integrity": "sha512-yCBD1yr6uO+VGUmrzuKxWABlhi++Ah2sYAp61qLThDpNufTf1iTUde1l0MR8ehF6AYTBTozMN+TC7Mh1E2lZvw==",
+      "version": "0.0.420",
+      "resolved": "https://registry.npmjs.org/@flamingo-stack/openframe-frontend-core/-/openframe-frontend-core-0.0.420.tgz",
+      "integrity": "sha512-9AiLTCM4mkmU4A2B6AUP8d37+mTcvgbp1BszdHqDoqwHvoIuf6jy3fdQkjocOhQbUgKsYoO8bW3Z1iWspjS1WQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/openframe/services/openframe-frontend/package.json
+++ b/openframe/services/openframe-frontend/package.json
@@ -24,7 +24,7 @@
     "core:unlink": "yalc remove @flamingo-stack/openframe-frontend-core"
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "^0.0.406",
+    "@flamingo-stack/openframe-frontend-core": "^0.0.420",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
Picks up the settled elevator scrollbars release.