### PR TITLE
FE: "Customers" page: last-activity date filter & sort (desktop, tablet, mobile)

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table-columns.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table-columns.tsx
@@ -1,17 +1,24 @@
 'use client';
 
-import { ArrowRightUpIcon, SearchIcon } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
+import {
+  ArrowRightUpIcon,
+  CalendarIcon,
+  SearchIcon,
+} from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
 import {
   Button,
   type ColumnDef,
   DataTable,
+  DateFilterMenu,
+  type DateFilterResult,
+  type DateRange,
   EntityImage,
   Input,
   type Row,
   TruncateText,
   useDataTable,
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
-import { formatRelativeTime } from '@flamingo-stack/openframe-frontend-core/utils';
+import { cn, formatRelativeTime } from '@flamingo-stack/openframe-frontend-core/utils';
 import { type ReactNode, useMemo } from 'react';
 import { formatDateTime } from '@/lib/format-date';
 import { getFullImageUrl } from '@/lib/image-url';
@@ -65,7 +72,14 @@ export function transformCustomerToEntry(org: Customer, deviceCount: number | nu
   };
 }
 
-export const CUSTOMERS_COLUMNS: ColumnDef<UiCustomerEntry>[] = [
+/** Last Activity sort + date-range filter wiring (desktop/tablet header popover). */
+export interface CustomersDateFilter {
+  sortDirection: 'asc' | 'desc';
+  range: DateRange | undefined;
+  onApply: (result: DateFilterResult) => void;
+}
+
+export const buildCustomersColumns = (dateFilter?: CustomersDateFilter): ColumnDef<UiCustomerEntry>[] => [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -91,14 +105,46 @@ export const CUSTOMERS_COLUMNS: ColumnDef<UiCustomerEntry>[] = [
   },
   {
     accessorKey: 'lastActivityDate',
-    header: 'Last Activity',
+    // With a date filter wired: label + calendar popover (timestamp sort +
+    // range filter). No own vertical padding — the HeaderCell wrapper pads.
+    header: dateFilter
+      ? () => (
+          <div className="group flex items-center gap-[var(--spacing-system-xsf)] select-none">
+            <span className="text-h5 text-ods-text-secondary whitespace-nowrap transition-colors duration-200 group-hover:text-ods-text-primary">
+              Last Activity
+            </span>
+            <DateFilterMenu
+              mode="range"
+              sort={dateFilter.sortDirection}
+              range={dateFilter.range}
+              onApply={dateFilter.onApply}
+              // Compact inline trigger — keeps the header row height identical
+              // to the other columns (the default lib trigger is a 48px Button).
+              trigger={
+                <button type="button" aria-label="Sort and filter by last activity" className="flex items-center">
+                  <CalendarIcon
+                    className={cn(
+                      'w-4 h-4 transition-colors duration-200',
+                      // Active when a date range or a non-default sort is applied
+                      dateFilter.range || dateFilter.sortDirection !== 'desc'
+                        ? 'text-ods-accent'
+                        : 'text-ods-text-secondary group-hover:text-ods-text-primary',
+                    )}
+                  />
+                </button>
+              }
+            />
+          </div>
+        )
+      : 'Last Activity',
     cell: ({ row }: { row: Row<UiCustomerEntry> }) => (
       <div className="flex flex-col justify-center min-w-0">
         <TruncateText>{row.original.lastActivityDate}</TruncateText>
         <span className="text-h6 text-ods-text-secondary truncate">{row.original.lastActivityRelative}</span>
       </div>
     ),
-    meta: { width: 'w-[200px] shrink-0', hideAt: 'md' },
+    // alwaysShowHeader keeps the date filter reachable on tablet (md–lg)
+    meta: { width: 'w-[200px] shrink-0', hideAt: 'md', alwaysShowHeader: Boolean(dateFilter) },
   },
   {
     id: 'open',
@@ -144,6 +190,8 @@ interface CustomersTableBodyProps {
   skeletonRows?: number;
   stickyHeaderOffset?: string;
   footerSlot?: ReactNode;
+  /** When set, the Last Activity header hosts the date sort + range popover. */
+  dateFilter?: CustomersDateFilter;
 }
 
 export function CustomersTableBody({
@@ -153,6 +201,7 @@ export function CustomersTableBody({
   skeletonRows = 10,
   stickyHeaderOffset,
   footerSlot,
+  dateFilter,
 }: CustomersTableBodyProps) {
   const orgIds = useMemo(() => customers.map(c => c.organizationId), [customers]);
   const { deviceCounts } = useCustomerDeviceCounts(orgIds);
@@ -168,9 +217,11 @@ export function CustomersTableBody({
     [customers, deviceCounts],
   );
 
+  const columns = useMemo(() => buildCustomersColumns(dateFilter), [dateFilter]);
+
   const table = useDataTable<UiCustomerEntry>({
     data: rows,
-    columns: CUSTOMERS_COLUMNS,
+    columns,
     getRowId: row => row.id,
     enableSorting: false,
   });

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/components/customers-table.tsx
@@ -3,22 +3,34 @@
 import { MingoIcon } from '@flamingo-stack/openframe-frontend-core/components/icons';
 import {
   BuildingsIcon,
+  Filter02Icon,
   GraphMixSquareIcon,
   IdCardIcon,
   PlusCircleIcon,
   ShieldCheckIcon,
 } from '@flamingo-stack/openframe-frontend-core/components/icons-v2';
-import { DataTable, PageLayout } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import {
+  Button,
+  DataTable,
+  type DateFilterResult,
+  type DateRange,
+  FilterModal,
+  PageLayout,
+} from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useApiParams } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { cn } from '@flamingo-stack/openframe-frontend-core/utils';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EmptyState } from '@/app/components/shared';
 import { useSearchParam } from '@/app/hooks/use-search-param';
 import { useStickyToolbar } from '@/app/hooks/use-sticky-toolbar';
-import { useCustomers } from '../hooks/use-customers';
-import { CustomersSearchInput, CustomersTableBody } from './customers-table-columns';
+import { dateRangeFromParams, dateRangeToInstantBounds, toDayParam } from '@/lib/date-filter-params';
+import { type CustomersDateQuery, useCustomers } from '../hooks/use-customers';
+import { type CustomersDateFilter, CustomersSearchInput, CustomersTableBody } from './customers-table-columns';
+
+const EMPTY_FILTER_GROUPS: never[] = [];
+const noopFilterChange = () => {};
 
 interface CustomersTableProps {
   status?: string;
@@ -28,8 +40,11 @@ export function CustomersTable({ status }: CustomersTableProps) {
   const router = useRouter();
   const askMingo = useAskMingo();
 
-  const { params, setParam } = useApiParams({
+  const { params, setParam, setParams } = useApiParams({
     search: { type: 'string', default: '' },
+    dateFrom: { type: 'string', default: '' },
+    dateTo: { type: 'string', default: '' },
+    sortDirection: { type: 'string', default: 'desc' },
   });
 
   // Local search keeps typing responsive; the shared hook debounces it to the
@@ -40,10 +55,42 @@ export function CustomersTable({ status }: CustomersTableProps) {
     debouncedSearch,
   } = useSearchParam(params.search, value => setParam('search', value), 500);
   const { toolbarRef, containerStyle, stickyHeaderOffset } = useStickyToolbar();
+  const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
+
+  // Applied last-activity filter restored from the URL
+  const dateRange: DateRange | undefined = useMemo(
+    () => dateRangeFromParams(params.dateFrom, params.dateTo),
+    [params.dateFrom, params.dateTo],
+  );
+  const sortDirection: CustomersDateQuery['sortDirection'] = params.sortDirection === 'asc' ? 'asc' : 'desc';
+
+  const dateQuery: CustomersDateQuery = useMemo(() => {
+    const bounds = dateRangeToInstantBounds(dateRange);
+    return { lastActivityFrom: bounds.from, lastActivityTo: bounds.to, sortDirection };
+  }, [dateRange, sortDirection]);
+
+  const handleDateFilterApply = useCallback(
+    (result: DateFilterResult) => {
+      setParams({
+        // Default direction stays out of the URL
+        sortDirection: result.sort === 'desc' ? '' : result.sort,
+        dateFrom: result.range?.from ? toDayParam(result.range.from) : '',
+        dateTo: result.range?.to ? toDayParam(result.range.to) : '',
+      });
+      document.querySelector('main')?.scrollTo({ top: 0, behavior: 'instant' });
+    },
+    [setParams],
+  );
+
+  const dateFilter: CustomersDateFilter = useMemo(
+    () => ({ sortDirection, range: dateRange, onApply: handleDateFilterApply }),
+    [sortDirection, dateRange, handleDateFilterApply],
+  );
 
   const { customers, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error } = useCustomers(
     debouncedSearch,
     status,
+    dateQuery,
   );
 
   const isInitialMountRef = useRef(true);
@@ -61,7 +108,7 @@ export function CustomersTable({ status }: CustomersTableProps) {
     router.push('/customers/new');
   }, [router]);
 
-  const showEmptyState = !isLoading && !debouncedSearch && customers.length === 0;
+  const showEmptyState = !isLoading && !debouncedSearch && !dateRange && customers.length === 0;
 
   const actions = useMemo(
     () => [
@@ -122,14 +169,23 @@ export function CustomersTable({ status }: CustomersTableProps) {
             <div className="flex-1 min-w-0">
               <CustomersSearchInput value={localSearch} onChange={setLocalSearch} />
             </div>
+            <Button
+              variant="outline"
+              size="icon"
+              className="md:hidden"
+              onClick={() => setMobileFilterOpen(true)}
+              aria-label="Open filters"
+              leftIcon={<Filter02Icon />}
+            />
           </div>
 
           <CustomersTableBody
             customers={customers}
             isLoading={isLoading}
-            emptyMessage="No customers found. Try adjusting your search."
+            emptyMessage="No customers found. Try adjusting your search or filters."
             skeletonRows={10}
             stickyHeaderOffset={stickyHeaderOffset}
+            dateFilter={dateFilter}
             footerSlot={
               hasNextPage && (
                 <DataTable.InfiniteFooter
@@ -143,6 +199,19 @@ export function CustomersTable({ status }: CustomersTableProps) {
           />
         </div>
       )}
+
+      <FilterModal
+        isOpen={mobileFilterOpen}
+        onClose={() => setMobileFilterOpen(false)}
+        filterGroups={EMPTY_FILTER_GROUPS}
+        onFilterChange={noopFilterChange}
+        dateFilter={{
+          title: 'Last Activity',
+          sort: sortDirection,
+          range: dateRange,
+          onChange: handleDateFilterApply,
+        }}
+      />
     </PageLayout>
   );
 }

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/hooks/use-customers.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/hooks/use-customers.ts
@@ -3,6 +3,7 @@
 import { useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
+import { OrganizationSortField, SortDirection } from '@/generated/schema-enums';
 import { apiClient } from '@/lib/api-client';
 import { GET_ORGANIZATIONS_QUERY } from '../queries/customers-queries';
 
@@ -37,6 +38,7 @@ export interface OrganizationNode {
   contractEndDate?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
+  lastActivityAt?: string | null;
   contactInformation?: {
     contacts?: Array<{ contactName?: string | null; email?: string | null }> | null;
   } | null;
@@ -58,7 +60,7 @@ export function mapOrganizationNode(node: OrganizationNode): Customer {
     mrrUsd: node.monthlyRevenue ?? 0,
     numberOfEmployees: node.numberOfEmployees ?? 0,
     contractDue: node.contractEndDate ?? '',
-    lastActivity: node.updatedAt || node.createdAt || new Date().toISOString(),
+    lastActivity: node.lastActivityAt || node.updatedAt || node.createdAt || new Date().toISOString(),
     imageUrl: node.image?.imageUrl ?? null,
     imageHash: node.image?.hash ?? null,
   };
@@ -80,16 +82,32 @@ interface GraphQlResponse<T> {
   errors?: Array<{ message: string }>;
 }
 
+/** Server-side last-activity range (UTC instants) + sort direction. */
+export interface CustomersDateQuery {
+  lastActivityFrom?: string;
+  lastActivityTo?: string;
+  sortDirection: 'asc' | 'desc';
+}
+
 export const customersQueryKeys = {
   all: ['organizations'] as const,
-  list: (search: string, status?: string) => ['organizations', 'list', search, status] as const,
+  list: (search: string, status?: string, dateQuery?: CustomersDateQuery) =>
+    [
+      'organizations',
+      'list',
+      search,
+      status,
+      dateQuery?.lastActivityFrom,
+      dateQuery?.lastActivityTo,
+      dateQuery?.sortDirection,
+    ] as const,
 };
 
-export function useCustomers(search = '', status?: string) {
+export function useCustomers(search = '', status?: string, dateQuery?: CustomersDateQuery) {
   const { toast } = useToast();
 
   const query = useInfiniteQuery<CustomersPage, Error>({
-    queryKey: customersQueryKeys.list(search, status),
+    queryKey: customersQueryKeys.list(search, status, dateQuery),
     queryFn: async ({ pageParam }) => {
       const response = await apiClient.post<
         GraphQlResponse<{
@@ -110,7 +128,18 @@ export function useCustomers(search = '', status?: string) {
           search: search || '',
           first: ORGANIZATIONS_PAGE_SIZE,
           after: (pageParam as string) || null,
-          filter: status ? { status } : undefined,
+          filter:
+            status || dateQuery?.lastActivityFrom || dateQuery?.lastActivityTo
+              ? {
+                  ...(status ? { status } : {}),
+                  ...(dateQuery?.lastActivityFrom ? { lastActivityFrom: dateQuery.lastActivityFrom } : {}),
+                  ...(dateQuery?.lastActivityTo ? { lastActivityTo: dateQuery.lastActivityTo } : {}),
+                }
+              : undefined,
+          orderBy: {
+            field: OrganizationSortField.LAST_ACTIVITY,
+            direction: dateQuery?.sortDirection === 'asc' ? SortDirection.ASC : SortDirection.DESC,
+          },
         },
       });
 

--- a/openframe/services/openframe-frontend/src/app/(app)/customers/queries/customers-queries.ts
+++ b/openframe/services/openframe-frontend/src/app/(app)/customers/queries/customers-queries.ts
@@ -1,6 +1,6 @@
 export const GET_ORGANIZATIONS_QUERY = `#graphql
-  query GetOrganizations($search: String, $first: Int, $after: String, $filter: OrganizationFilterInput) {
-    organizations(search: $search, first: $first, after: $after, filter: $filter) {
+  query GetOrganizations($search: String, $first: Int, $after: String, $filter: OrganizationFilterInput, $orderBy: OrganizationSortInput) {
+    organizations(search: $search, first: $first, after: $after, filter: $filter, orderBy: $orderBy) {
       edges {
         node {
           id
@@ -24,6 +24,7 @@ export const GET_ORGANIZATIONS_QUERY = `#graphql
           }
           createdAt
           updatedAt
+          lastActivityAt
           status
           statusChangedAt
         }

--- a/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
+++ b/openframe/services/openframe-frontend/src/app/(app)/logs-page/components/logs-table.tsx
@@ -32,7 +32,6 @@ import {
 } from '@flamingo-stack/openframe-frontend-core/components/ui';
 import { useApiParams, useToast } from '@flamingo-stack/openframe-frontend-core/hooks';
 import { cn, normalizeToolTypeWithFallback, toToolLabel } from '@flamingo-stack/openframe-frontend-core/utils';
-import { endOfDay, format, parse, startOfDay } from 'date-fns';
 import {
   forwardRef,
   Suspense,
@@ -52,6 +51,7 @@ import { useAskMingo } from '@/app/(app)/mingo/hooks/use-ask-mingo';
 import { EMBEDDED_PAGE_OFFSET, EmptyState, LogDrawer } from '@/app/components/shared';
 import { useSearchParam } from '@/app/hooks/use-search-param';
 import { LogSortField, SortDirection } from '@/generated/schema-enums';
+import { dateRangeFromParams, dateRangeToInstantBounds, toDayParam } from '@/lib/date-filter-params';
 import { transformOrganizationFilters } from '@/lib/filter-utils';
 import { formatDateTime } from '@/lib/format-date';
 import { openInNewTab } from '@/lib/open-in-new-tab';
@@ -121,14 +121,6 @@ const logsTableRelayFragment = graphql`
     }
   }
 `;
-
-// Day-granular date filter <-> URL param (local yyyy-MM-dd)
-const DAY_PARAM_FORMAT = 'yyyy-MM-dd';
-const toDayParam = (date: Date): string => format(date, DAY_PARAM_FORMAT);
-const parseDayParam = (value: string): Date | undefined => {
-  const parsed = parse(value, DAY_PARAM_FORMAT, new Date());
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-};
 
 // ----------------------------------------------------------------
 // Types
@@ -823,11 +815,10 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
   const lockedOrgIds = useMemo(() => (organizationId ? [organizationId] : undefined), [organizationId]);
 
   // Applied date filter (Log ID column) restored from the URL
-  const dateRange: DateRange | undefined = useMemo(() => {
-    const from = params.dateFrom ? parseDayParam(params.dateFrom) : undefined;
-    const to = params.dateTo ? parseDayParam(params.dateTo) : undefined;
-    return from || to ? { from, to } : undefined;
-  }, [params.dateFrom, params.dateTo]);
+  const dateRange: DateRange | undefined = useMemo(
+    () => dateRangeFromParams(params.dateFrom, params.dateTo),
+    [params.dateFrom, params.dateTo],
+  );
 
   const sortDirection: UiSortDirection = params.sortDirection === 'asc' ? 'asc' : 'desc';
 
@@ -840,16 +831,14 @@ export const LogsTable = forwardRef<LogsTableRef, LogsTableProps>(function LogsT
   );
 
   const backendFilters: LogFilterInput = useMemo(() => {
-    // Inclusive UTC instants covering the selected local days; a single picked
-    // day (no `to`) filters that one day.
-    const upperBoundDay = dateRange?.to ?? dateRange?.from;
+    const bounds = dateRangeToInstantBounds(dateRange);
     return {
       severities: params.severities,
       toolTypes: params.toolTypes,
       organizationIds: lockedOrgIds ?? params.organizationIds,
       deviceId,
-      timestampFrom: dateRange?.from ? startOfDay(dateRange.from).toISOString() : undefined,
-      timestampTo: upperBoundDay ? endOfDay(upperBoundDay).toISOString() : undefined,
+      timestampFrom: bounds.from,
+      timestampTo: bounds.to,
     };
   }, [params.severities, params.toolTypes, params.organizationIds, deviceId, lockedOrgIds, dateRange]);
 

--- a/openframe/services/openframe-frontend/src/lib/date-filter-params.ts
+++ b/openframe/services/openframe-frontend/src/lib/date-filter-params.ts
@@ -1,0 +1,35 @@
+import type { DateRange } from '@flamingo-stack/openframe-frontend-core/components/ui';
+import { endOfDay, format, parse, startOfDay } from 'date-fns';
+
+// Day-granular date filter <-> URL param (local yyyy-MM-dd), shared by the
+// table date filters (Logs, Customers).
+const DAY_PARAM_FORMAT = 'yyyy-MM-dd';
+
+export const toDayParam = (date: Date): string => format(date, DAY_PARAM_FORMAT);
+
+export const parseDayParam = (value: string): Date | undefined => {
+  const parsed = parse(value, DAY_PARAM_FORMAT, new Date());
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+/** Rebuild the applied calendar range from its URL params. */
+export function dateRangeFromParams(dateFrom: string, dateTo: string): DateRange | undefined {
+  const from = dateFrom ? parseDayParam(dateFrom) : undefined;
+  const to = dateTo ? parseDayParam(dateTo) : undefined;
+  return from || to ? { from, to } : undefined;
+}
+
+/**
+ * Inclusive UTC instants covering the selected local days for the BE range
+ * filter; a single picked day (no `to`) covers that one day.
+ */
+export function dateRangeToInstantBounds(range: DateRange | undefined): {
+  from?: string;
+  to?: string;
+} {
+  const upperBoundDay = range?.to ?? range?.from;
+  return {
+    from: range?.from ? startOfDay(range.from).toISOString() : undefined,
+    to: upperBoundDay ? endOfDay(upperBoundDay).toISOString() : undefined,
+  };
+}


### PR DESCRIPTION
## Description

Adds the date filter + sort to the Customers page (Last Activity column), reusing the shared date-picker stack from the core lib across all breakpoints:
- **Desktop & tablet** — DateFilterMenu popover in the Last Activity column header (sort by ascending/descending + date-range calendar, Apply/Reset). The compact calendar trigger highlights when a filter or non-default sort is active. On tablet the header stays visible via `meta.alwaysShowHeader`.
- **Mobile** — filter button next to the search input opens the "Sort and Filter" modal with the Last Activity date section (same DateFilterPanel, built-in scroll shadows).
## How
- `GET_ORGANIZATIONS_QUERY` extended with `$orderBy: OrganizationSortInput` and the canonical `lastActivityAt` node field (displayed value falls back to `updatedAt`/`createdAt` for older rows).
- `useCustomers` sends `filter.lastActivityFrom/To` (inclusive UTC bounds of the selected local days; a single picked day covers that one day) and `orderBy { LAST_ACTIVITY, ASC|DESC }`; the new params are part of the react-query key, so pagination resets on change.
- Filter state persists in the URL (`dateFrom`/`dateTo` as `yyyy-MM-dd`, `sortDirection` — default `desc` stays out of the URL), applied in a single `setParams` write.
- Day-param/date-bounds helpers extracted to `src/lib/date-filter-params.ts` and reused by the Logs table (removes the duplicated copy).
- An applied period counts as an active query: an empty result keeps the table header (and the filter trigger) instead of collapsing into the onboarding empty state.
- The assignments Customers table (shared `CustomersTableBody`) is unchanged — the date filter is opt-in via the new `dateFilter` prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Last Activity date-range filtering and sorting to the Customers table.
  * Added mobile-friendly date filter controls and filter-aware empty states.
  * Customer filter selections now persist in the URL and update results automatically.

* **Bug Fixes**
  * Improved Last Activity date handling by using the most accurate available activity timestamp.

* **Refactor**
  * Standardized date-range parsing and backend date boundaries across Customers and Logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->