### PR TITLE
fix(argocd): create destination namespaces on sync to end the "namespace not found" race

### DIFF
--- a/manifests/apps/templates/datasources-apps.yaml
+++ b/manifests/apps/templates/datasources-apps.yaml
@@ -56,7 +56,10 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false
+      # Create the destination namespace on sync rather than depending on a
+      # separate namespace-* app to have created it first (see platform-apps.yaml
+      # for the rationale — avoids the `namespaces "<ns>" not found` race).
+      - CreateNamespace=true
       - ServerSideApply={{ (get $app "syncOptions" | default dict).ServerSideApply | default false }}
       - RespectIgnoreDifferences={{ (get $app "syncOptions" | default dict).RespectIgnoreDifferences | default false }}
 

--- a/manifests/apps/templates/datasources-apps.yaml
+++ b/manifests/apps/templates/datasources-apps.yaml
@@ -56,9 +56,6 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      # Create the destination namespace on sync rather than depending on a
-      # separate namespace-* app to have created it first (see platform-apps.yaml
-      # for the rationale — avoids the `namespaces "<ns>" not found` race).
       - CreateNamespace=true
       - ServerSideApply={{ (get $app "syncOptions" | default dict).ServerSideApply | default false }}
       - RespectIgnoreDifferences={{ (get $app "syncOptions" | default dict).RespectIgnoreDifferences | default false }}

--- a/manifests/apps/templates/platform-apps.yaml
+++ b/manifests/apps/templates/platform-apps.yaml
@@ -66,11 +66,6 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      # Create the destination namespace on sync rather than depending on a
-      # separate namespace-* app to have created it first. That cross-app
-      # ordering was fragile (app-of-apps does not reliably gate wave 0 on the
-      # namespace being Healthy), causing `namespaces "<ns>" not found` on clean
-      # installs. CreateNamespace is idempotent (create-if-not-exists).
       - CreateNamespace=true
       - ServerSideApply={{ (get $app "syncOptions" | default dict).ServerSideApply | default false }}
       - RespectIgnoreDifferences={{ (get $app "syncOptions" | default dict).RespectIgnoreDifferences | default false }}

--- a/manifests/apps/templates/platform-apps.yaml
+++ b/manifests/apps/templates/platform-apps.yaml
@@ -66,7 +66,12 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false
+      # Create the destination namespace on sync rather than depending on a
+      # separate namespace-* app to have created it first. That cross-app
+      # ordering was fragile (app-of-apps does not reliably gate wave 0 on the
+      # namespace being Healthy), causing `namespaces "<ns>" not found` on clean
+      # installs. CreateNamespace is idempotent (create-if-not-exists).
+      - CreateNamespace=true
       - ServerSideApply={{ (get $app "syncOptions" | default dict).ServerSideApply | default false }}
       - RespectIgnoreDifferences={{ (get $app "syncOptions" | default dict).RespectIgnoreDifferences | default false }}
 

--- a/manifests/apps/templates/tenant-app.yaml
+++ b/manifests/apps/templates/tenant-app.yaml
@@ -50,9 +50,6 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      # Create the destination namespace on sync rather than depending on a
-      # separate namespace-* app to have created it first (see platform-apps.yaml
-      # for the rationale — avoids the `namespaces "<ns>" not found` race).
       - CreateNamespace=true
       - ServerSideApply=false
       - RespectIgnoreDifferences=false

--- a/manifests/apps/templates/tenant-app.yaml
+++ b/manifests/apps/templates/tenant-app.yaml
@@ -50,7 +50,10 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false
+      # Create the destination namespace on sync rather than depending on a
+      # separate namespace-* app to have created it first (see platform-apps.yaml
+      # for the rationale — avoids the `namespaces "<ns>" not found` race).
+      - CreateNamespace=true
       - ServerSideApply=false
       - RespectIgnoreDifferences=false
 {{- end }}


### PR DESCRIPTION
Every platform/datasources/tenant Application hardcoded CreateNamespace=false, so each depended on a separate namespace-* app (sync-wave -1) to have created its destination namespace first. app-of-apps does not reliably gate wave 0 on that namespace being Healthy, so on a clean install ingress-nginx and openframe-config synced before the `platform` namespace existed and failed with `namespaces "platform" not found` — with autoSync off they then sat OutOfSync indefinitely.

Set CreateNamespace=true on the three app templates so each Application creates its own destination namespace on sync (idempotent, create-if-not-exists), removing the cross-app ordering dependency entirely. The namespace-* creator apps are left in place — harmless and still the owner of the namespace when they win the race; the flag only guarantees the namespace exists before dependents apply.

Verified: `helm template manifests/apps` renders cleanly with 16 Applications at CreateNamespace=true and none at false; `helm lint` passes.