### PR TITLE
FE: stop role label flicker on settings profile card

### DIFF
--- a/openframe/services/openframe-frontend/src/app/(auth)/auth/stores/auth-store.ts
+++ b/openframe/services/openframe-frontend/src/app/(auth)/auth/stores/auth-store.ts
@@ -150,6 +150,10 @@ export const useAuthStore = create<AuthState>()(
               set(state => {
                 if (state.user) {
                   const { image, ...rest } = fullProfile;
+                  // Roles come from the auth session (/me); the profile GET can
+                  // return a different set, so dropping it here keeps the role
+                  // label stable instead of flickering when both responses land.
+                  delete rest.roles;
                   Object.assign(state.user, rest);
                   if (
                     image &&


### PR DESCRIPTION
## Description

Full-profile GET (/api/users/{id}) returned a different role set than the auth session (/api/me), so its merge overwrote roles mid-render and the label flashed 2 tags -> 1. Drop roles from the profile merge; roles stay sourced from /me. Editable profile fields are unaffected (roles are never edited; PUT sends only firstName/lastName).

## Task

[Role label flickers on render](https://app.clickup.com/t/9013925967/86ajdrqub)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented user role information from flickering or being unexpectedly overwritten when profile data is refreshed.
  * Kept roles consistent with the authenticated session while other profile details continue to update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->