### PR TITLE
Chat: bump @flamingo-stack/openframe-frontend-core to 0.0.442

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.441",
+    "@flamingo-stack/openframe-frontend-core": "0.0.442",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenFrame frontend core dependency to version 0.0.442.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->