### PR TITLE
Chat: client (Fae) quick actions — Product Hub defaults with tenant override

### DIFF
--- a/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
+++ b/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
@@ -19,14 +19,11 @@ function readConnectionState(): ConnectionState {
 }
 
 /**
- * Loads the client assistant's appearance (clientView) and quick actions
- * (clientAiConfig) from /chat/graphql. `data` is `null` when no record exists yet.
- * The query waits for the token/API URL to be available; readiness is
- * recomputed on every token/API update (and can flip back to false when
- * credentials drop), and the cache is keyed by the API base URL so a connection
- * change refetches instead of serving stale settings.
+ * Live token/API-URL readiness, recomputed on every tokenService update.
+ * Shared by the server-backed queries so their `enabled` and cache keys track
+ * connection changes identically.
  */
-export function useAiSettingsQuery({ enabled }: { enabled: boolean }) {
+export function useApiConnectionState(): ConnectionState {
   const [connection, setConnection] = useState<ConnectionState>(readConnectionState);
 
   useEffect(() => {
@@ -42,6 +39,20 @@ export function useAiSettingsQuery({ enabled }: { enabled: boolean }) {
       unsubUrl();
     };
   }, []);
+
+  return connection;
+}
+
+/**
+ * Loads the client assistant's appearance (clientView) and quick actions
+ * (clientAiConfig) from /chat/graphql. `data` is `null` when no record exists yet.
+ * The query waits for the token/API URL to be available; readiness is
+ * recomputed on every token/API update (and can flip back to false when
+ * credentials drop), and the cache is keyed by the API base URL so a connection
+ * change refetches instead of serving stale settings.
+ */
+export function useAiSettingsQuery({ enabled }: { enabled: boolean }) {
+  const connection = useApiConnectionState();
 
   return useQuery<AiSettingsResponse | null>({
     queryKey: aiSettingsQueryKey(connection.apiBaseUrl),

--- a/clients/openframe-chat/src/hooks/useChatConfig.ts
+++ b/clients/openframe-chat/src/hooks/useChatConfig.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import quickActionsData from '../config/quickActions.json';
 import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
 import { useAiSettingsQuery } from './useAiSettingsQuery';
+import { useHubQuickActionsQuery } from './useHubQuickActionsQuery';
 
 export interface QuickAction {
   id: string;
@@ -12,8 +13,7 @@ export interface QuickAction {
 }
 
 // Bundled defaults - used while the customer-ai-assistant-settings flag is off,
-// the server has no AiSettings record (or its quickActions is null), or the
-// query errors out. An explicitly saved empty list does NOT fall back here.
+// or as the last resort when the hub defaults cannot be loaded.
 const FALLBACK_QUICK_ACTIONS: QuickAction[] = quickActionsData.actions.map(action => ({
   id: action.id,
   name: action.text,
@@ -25,13 +25,29 @@ export function useChatConfig() {
   const customizationEnabled = flags['customer-ai-assistant-settings'];
   const query = useAiSettingsQuery({ enabled: customizationEnabled });
 
+  // Source switch: `clientAiConfig.quickActionsIsDefault` (true until the org
+  // customizes, and while the settings are still loading) selects the OpenFrame
+  // defaults published in the Product Hub — the CLIENT (Fae) set, distinct from
+  // the admin (Mingo) one. The tenant BE only stores the org's customs.
+  const useHubDefaults = query.data?.quickActionsIsDefault ?? true;
+  const hubQuery = useHubQuickActionsQuery({ enabled: customizationEnabled && useHubDefaults });
+
   const quickActions = useMemo<QuickAction[]>(() => {
-    // Nullable vs empty matters here: `null`/missing means "nothing configured
-    // yet" and falls back to the bundled defaults, while an explicitly saved
-    // empty list means the admin chose to hide quick actions entirely - so we
-    // return it as-is and the UI renders no action row.
+    if (!customizationEnabled) {
+      return FALLBACK_QUICK_ACTIONS;
+    }
+
+    if (useHubDefaults) {
+      // Hub unreachable/errored → bundled defaults rather than an empty row.
+      return hubQuery.data ?? FALLBACK_QUICK_ACTIONS;
+    }
+
+    // Customs. Nullable vs empty matters here: `null`/missing means "nothing
+    // configured yet" and falls back to the bundled defaults, while an
+    // explicitly saved empty list means the admin chose to hide quick actions
+    // entirely - so we return it as-is and the UI renders no action row.
     const serverActions = query.data?.quickActions;
-    if (customizationEnabled && serverActions) {
+    if (serverActions) {
       return serverActions.map(action => ({
         id: action.id,
         name: action.name,
@@ -39,14 +55,14 @@ export function useChatConfig() {
       }));
     }
     return FALLBACK_QUICK_ACTIONS;
-  }, [customizationEnabled, query.data]);
+  }, [customizationEnabled, useHubDefaults, hubQuery.data, query.data]);
 
   return {
     quickActions,
     aiSettings: query.data ?? null,
-    // True while we still expect an AiSettings result from the server (flag on
-    // and the query hasn't settled - including the brief wait for the token).
+    // True while we still expect a server-resolved action set (flag on and
+    // either query hasn't settled - including the brief wait for the token).
     // Lets callers hold off on bundled fallbacks until the server answers.
-    isSettingsLoading: customizationEnabled && query.isPending,
+    isSettingsLoading: customizationEnabled && (query.isPending || (useHubDefaults && hubQuery.isPending)),
   };
 }

--- a/clients/openframe-chat/src/hooks/useHubQuickActionsQuery.ts
+++ b/clients/openframe-chat/src/hooks/useHubQuickActionsQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchHubDefaultQuickActions, type HubQuickAction } from '../services/hubQuickActionsService';
+import { useApiConnectionState } from './useAiSettingsQuery';
+
+/** Cache key scoped to the active connection, like `aiSettingsQueryKey`. */
+export const hubQuickActionsQueryKey = (apiBaseUrl: string | null) => ['hubQuickActions', { apiBaseUrl }] as const;
+
+/**
+ * OpenFrame default quick actions for the Fae chat, from the Product Hub via
+ * the gateway proxy. Fetched only while the tenant config says defaults apply
+ * (`quickActionsIsDefault`), which the caller expresses through `enabled`.
+ */
+export function useHubQuickActionsQuery({ enabled }: { enabled: boolean }) {
+  const connection = useApiConnectionState();
+
+  return useQuery<HubQuickAction[]>({
+    queryKey: hubQuickActionsQueryKey(connection.apiBaseUrl),
+    queryFn: fetchHubDefaultQuickActions,
+    enabled: enabled && connection.isReady,
+    retry: 1,
+    // The hub set changes rarely; refresh on refocus like the AI settings do.
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });
+}

--- a/clients/openframe-chat/src/services/aiSettingsService.ts
+++ b/clients/openframe-chat/src/services/aiSettingsService.ts
@@ -18,6 +18,8 @@ export interface AiSettingsResponse {
   assistantAvatar: { imageUrl: string; hash: string | null } | null;
   applicationTheme: string;
   accentColor: string;
+  /** True → show the OpenFrame defaults from the Product Hub; false → `quickActions` customs. */
+  quickActionsIsDefault: boolean;
   quickActions: AiQuickAction[] | null;
 }
 
@@ -30,6 +32,7 @@ interface ClientViewGql {
 }
 
 interface ClientAiConfigGql {
+  quickActionsIsDefault: boolean | null;
   quickActions: AiQuickAction[] | null;
 }
 
@@ -49,6 +52,7 @@ const AI_SETTINGS_QUERY = gql`
       accentColor
     }
     clientAiConfig {
+      quickActionsIsDefault
       quickActions {
         id
         name
@@ -125,6 +129,8 @@ class AiSettingsService {
       assistantAvatar: view?.assistantAvatar ?? null,
       applicationTheme: view?.applicationTheme ?? '',
       accentColor: view?.accentColor ?? '',
+      // BE default is true: hub defaults apply until the tenant customizes.
+      quickActionsIsDefault: aiConfig?.quickActionsIsDefault ?? true,
       quickActions: aiConfig?.quickActions ?? null,
     };
   }

--- a/clients/openframe-chat/src/services/hubQuickActionsService.ts
+++ b/clients/openframe-chat/src/services/hubQuickActionsService.ts
@@ -1,0 +1,54 @@
+import { tokenService } from './tokenService';
+
+/** The Fae agent's public config slug in the Product Hub (`agent-fae` source). */
+const FAE_AGENT_SLUG = 'fae';
+
+/** Hub quick action as served by the agent public-config endpoint. */
+interface HubQuickActionDto {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+/** Chat-facing shape (matches the tenant `AiQuickAction`: name = chip label, instructions = prompt). */
+export interface HubQuickAction {
+  id: string;
+  name: string;
+  instructions: string;
+}
+
+/**
+ * OpenFrame default quick actions for the client (Fae) chat, published in the
+ * Product Hub separately from the admin (Mingo) set. Served through the tenant
+ * gateway's `/chat/content/**` hub proxy (`chat_guide_route`), so the call uses
+ * the same base URL + Bearer auth as every other chat request. Applied while
+ * `clientAiConfig.quickActionsIsDefault` is true; the tenant BE only stores the
+ * org's customized list.
+ */
+export async function fetchHubDefaultQuickActions(): Promise<HubQuickAction[]> {
+  await tokenService.ensureTokenReady();
+  const baseUrl = tokenService.getCurrentApiBaseUrl();
+  const token = tokenService.getCurrentToken();
+
+  if (!baseUrl || !token) {
+    throw new Error('API base URL or token not available');
+  }
+
+  const response = await fetch(`${baseUrl}/chat/content/api/ai-agents/${FAE_AGENT_SLUG}`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load hub default quick actions (${response.status})`);
+  }
+
+  const data = (await response.json()) as { quickActions?: HubQuickActionDto[] | null };
+  return (data.quickActions ?? []).map(action => ({
+    id: action.id,
+    name: action.label,
+    instructions: action.prompt,
+  }));
+}


### PR DESCRIPTION
## Description

The hub publishes SEPARATE quick action sets for the admin (Mingo) and client (Fae) chats; this app now resolves the client set:

- clientAiConfig query gains quickActionsIsDefault (default true)
- new hubQuickActionsService + useHubQuickActionsQuery fetch the Fae agent's public config via the gateway's /chat/content/** hub proxy (chat_guide_route), same base URL + Bearer as other chat calls (label→name, prompt→instructions)
- useChatConfig source switch: flag off → bundled JSON; quickActionsIsDefault → hub defaults (bundled JSON as last-resort fallback); otherwise the tenant's customized actions (explicit [] still hides the row)
- shared useApiConnectionState extracted from useAiSettingsQuery

## Task
[Fetch default quick actions from Product Hub with OpenFrame override](https://app.clickup.com/t/9013925967/86ajav2t3)
