### PR TITLE
chore: bump @flamingo-stack/openframe-frontend-core to 0.0.458

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.457",
+    "@flamingo-stack/openframe-frontend-core": "0.0.458",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",


### PR DESCRIPTION
Picks up the OverlayScrollbars padding/gap regression fixes.