### PR TITLE
Chat: lock composer while approved commands execute (onAgentBusy)

### DIFF
--- a/clients/openframe-chat/src/hooks/useChat.ts
+++ b/clients/openframe-chat/src/hooks/useChat.ts
@@ -229,6 +229,18 @@ export function useChat({
           messagesRef.current.updateSegments(segments, metadata?.streamSeq);
         }
       },
+      // EXECUTING_TOOL / approved APPROVAL_RESULT chunks land OUTSIDE the
+      // message_start/end window (approved commands run between the approval
+      // bubble and the continuation stream) — without this the composer
+      // unlocks and the typing indicator drops while commands execute.
+      // Cleared by the continuation's onStreamEnd / onError / Stop. A
+      // replayed dead tail (tool started, then a crash — no continuation
+      // ever emitted) can re-assert the lock on a resumed dialog, but
+      // natsStreaming keeps the Stop button available as the escape hatch.
+      onAgentBusy: () => {
+        setNatsStreaming(true);
+        setIsTyping(true);
+      },
       onError: (_errorText: string) => {
         setNatsStreaming(false);
         setIsTyping(false);


### PR DESCRIPTION
## What

Fae chat (openframe-chat) left the composer unlocked and dropped the typing indicator while the agent executed tools. Mingo sidebar and tickets already lock via the core lib's `onAgentBusy` callback — this brings the same behavior to Fae chat.

## Why

`EXECUTING_TOOL` and approved `APPROVAL_RESULT` chunks land **outside** the `MESSAGE_START`/`MESSAGE_END` window (approved commands run between the approval bubble and the continuation stream), so none of the existing callbacks re-asserted the lock. The user could type and send while a command was still running.

## How

Added the missing `onAgentBusy` callback to `realtimeCallbacks` in `useChat.ts`:
- `setNatsStreaming(true)` → disables `ChatInput` (`sending`) and switches the send button to Stop mode
- `setIsTyping(true)` → keeps the typing indicator visible

Released by the continuation's `onStreamEnd` / `onError` / manual Stop — all of which already clear both flags.

## Known edges (accepted)

- **Replayed dead tail**: a resumed dialog whose turn died mid-execution (no `MESSAGE_END` ever emitted) can re-assert the lock from replayed chunks. Unlike the lib adapter there is no catchup suppression here, but `natsStreaming` keeps the **Stop** button available as the escape hatch, and JetStream retention (~10 min) narrows the window.
- **Approve-click gap**: the lock engages on the `APPROVAL_RESULT` chunk, a beat later than the sidebar adapter's on-click lock.

## Verification

- `tsc --noEmit` clean (with core lib 0.0.458 per main's package.json)
- Biome clean on the touched file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The chat interface now remains in a busy, typing state while the assistant performs approved tool actions.
  * Prevents the chat from appearing idle or unlocked during tool execution outside the standard response stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->