### PR TITLE
revert(scroll): drop GlobalOverlayScrollbars, bump core to 0.0.459 in openframe-chat

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.458",
+    "@flamingo-stack/openframe-frontend-core": "0.0.459",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/clients/openframe-chat/src/App.tsx
+++ b/clients/openframe-chat/src/App.tsx
@@ -1,5 +1,5 @@
 import './styles/globals.css';
-import { GlobalOverlayScrollbars, Toaster } from '@flamingo-stack/openframe-frontend-core';
+import { Toaster } from '@flamingo-stack/openframe-frontend-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { DebugModeProvider } from './contexts/DebugModeContext';
@@ -47,8 +47,6 @@ function App() {
         </FeatureFlagsProvider>
       </QueryClientProvider>
       <Toaster />
-      {/* Standardized overlay scrollbar for the page scroller (desktop only) */}
-      <GlobalOverlayScrollbars />
     </>
   );
 }


### PR DESCRIPTION
## Description

Lib reverted the custom OverlayScrollbars. Remove the page-level mount from App and move to 0.0.459; the page now uses the native scrollbar styled by the ODS globals. QuickActionWall migration stays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the custom global scrollbar layer from the chat experience, allowing standard browser scrolling behavior.
  - Preserved existing notifications and application functionality while simplifying page scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->