### PR TITLE
client: disable tool-restart listener until backend support, align it with sibling listeners

### DIFF
--- a/clients/openframe-client/src/config/update_config.rs
+++ b/clients/openframe-client/src/config/update_config.rs
@@ -24,4 +24,3 @@ pub const CONSUMER_ACK_WAIT_SECS: u64 = 120;
 pub const CONSUMER_MAX_DELIVER: i64 = 10; // Maximum delivery attempts
 pub const UNINSTALL_CONSUMER_MAX_DELIVER: i64 = 20; // Larger budget: uninstall may defer behind a long install holding the tool lock
 pub const RESTART_CONSUMER_MAX_DELIVER: i64 = 20; // Larger budget: restart may defer behind a long install holding the tool lock
-pub const RESTART_CONSUMER_QUIET_PAUSE_MS: u64 = 300_000; // Quiet retry cadence once consumer creation keeps failing (subject/grants not provisioned yet)

--- a/clients/openframe-client/src/lib.rs
+++ b/clients/openframe-client/src/lib.rs
@@ -147,6 +147,7 @@ pub struct Client {
     nats_connection_manager: NatsConnectionManager,
     tool_installation_message_listener: ToolInstallationMessageListener,
     tool_uninstall_message_listener: ToolUninstallMessageListener,
+    #[allow(dead_code)] // TODO: remove when tool-restart is implemented on backend
     tool_restart_message_listener: ToolRestartMessageListener,
     openframe_client_update_listener: OpenFrameClientUpdateListener,
     tool_agent_update_listener: ToolAgentUpdateListener,
@@ -549,7 +550,8 @@ impl Client {
 
         self.tool_uninstall_message_listener.start().await?;
 
-        self.tool_restart_message_listener.start().await?;
+        // TODO: uncomment when implemented on backend
+        // self.tool_restart_message_listener.start().await?;
 
         // Start OpenFrame client update listener in background
         self.openframe_client_update_listener.start().await?;

--- a/clients/openframe-client/src/listener/tool_restart_message_listener.rs
+++ b/clients/openframe-client/src/listener/tool_restart_message_listener.rs
@@ -11,7 +11,6 @@ use crate::config::update_config::{
     RECONNECTION_DELAY_MS,
     CONSUMER_ACK_WAIT_SECS,
     RESTART_CONSUMER_MAX_DELIVER,
-    RESTART_CONSUMER_QUIET_PAUSE_MS,
 };
 use async_nats::jetstream::consumer::PushConsumer;
 use async_nats::jetstream::consumer::push;
@@ -20,7 +19,7 @@ use tokio::time::Duration;
 use anyhow::Result;
 use async_nats::jetstream;
 use futures::StreamExt;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct ToolRestartMessageListener {
@@ -71,33 +70,46 @@ impl ToolRestartMessageListener {
 
     async fn listen(&self) -> Result<()> {
         info!("Run tool restart message listener");
-        let client = self.nats_connection_manager
-            .get_client()
-            .await?;
-        let js = jetstream::new((*client).clone());
-
         let machine_id = self.config_service.get_machine_id()?;
 
-        let consumer = self.create_consumer(&js, &machine_id).await;
+        loop {
+            let client = self.nats_connection_manager
+                .get_client()
+                .await?;
+            let mut reconnect_rx = self.nats_connection_manager.subscribe_reconnect();
+            let js = jetstream::new((*client).clone());
 
-        info!("Start listening for tool restart messages");
-        let mut messages = consumer.messages().await?;
+            let consumer = self.create_consumer(&js, &machine_id).await;
 
-        while let Some(msg_result) = messages.next().await {
-            let message = match msg_result {
-                Ok(msg) => msg,
-                Err(e) => {
-                    error!("Failed to receive message: {:#}", e);
-                    continue;
+            info!("Start listening for tool restart messages");
+            let mut messages = consumer.messages().await?;
+
+            loop {
+                tokio::select! {
+                    msg_result = messages.next() => {
+                        match msg_result {
+                            Some(Ok(message)) => {
+                                if let Err(e) = self.handle_message(message).await {
+                                    error!("Failed to handle message: {:#}", e);
+                                }
+                            }
+                            Some(Err(e)) => {
+                                error!("Message stream error, recreating consumer: {:#}", e);
+                                return Err(anyhow::anyhow!("Message stream error: {}", e));
+                            }
+                            None => {
+                                warn!("Message stream ended, rebinding consumer");
+                                break;
+                            }
+                        }
+                    }
+                    _ = reconnect_rx.recv() => {
+                        info!("NATS reconnected, re-provisioning tool restart consumer");
+                        self.create_consumer(&js, &machine_id).await;
+                    }
                 }
-            };
-
-            if let Err(e) = self.handle_message(message).await {
-                error!("Failed to handle message: {:#}", e);
             }
         }
-
-        Ok(())
     }
 
     async fn handle_message(&self, message: Message) -> Result<()> {
@@ -147,21 +159,12 @@ impl ToolRestartMessageListener {
         loop {
             cycle += 1;
             let mut delay_ms = INITIAL_RETRY_DELAY_MS;
-            // First cycle logs loudly; later cycles go quiet with a long pause so a server missing the tool-restart subject/grants can't spam the fleet's logs.
-            let loud = cycle == 1;
 
             for attempt in 1..=CONSUMER_RETRY_ATTEMPTS_PER_CYCLE {
-                if loud {
-                    info!(
-                        "Creating restart consumer for stream {} (cycle {}, attempt {}/{})",
-                        Self::STREAM_NAME, cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE
-                    );
-                } else {
-                    debug!(
-                        "Creating restart consumer for stream {} (cycle {}, attempt {}/{})",
-                        Self::STREAM_NAME, cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE
-                    );
-                }
+                info!(
+                    "Creating restart consumer for stream {} (cycle {}, attempt {}/{})",
+                    Self::STREAM_NAME, cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE
+                );
 
                 match js.create_consumer_on_stream(consumer_configuration.clone(), Self::STREAM_NAME).await {
                     Ok(consumer) => {
@@ -179,38 +182,28 @@ impl ToolRestartMessageListener {
                             }
                         }
 
-                        if loud {
+                        if attempt < CONSUMER_RETRY_ATTEMPTS_PER_CYCLE {
+                            warn!(
+                                "Failed to create restart consumer (cycle {}, attempt {}/{}): {:#}. Retrying in {} ms...",
+                                cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, e, delay_ms
+                            );
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                            delay_ms = (delay_ms * 2).min(MAX_RETRY_DELAY_MS);
+                        } else {
                             warn!(
                                 "Failed to create restart consumer (cycle {}, attempt {}/{}): {:#}",
                                 cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, e
                             );
-                        } else {
-                            debug!(
-                                "Failed to create restart consumer (cycle {}, attempt {}/{}): {:#}",
-                                cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, e
-                            );
-                        }
-                        if attempt < CONSUMER_RETRY_ATTEMPTS_PER_CYCLE {
-                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                            delay_ms = (delay_ms * 2).min(MAX_RETRY_DELAY_MS);
                         }
                     }
                 }
             }
 
-            let pause_ms = if loud { CONSUMER_CYCLE_PAUSE_MS } else { RESTART_CONSUMER_QUIET_PAUSE_MS };
-            if loud {
-                warn!(
-                    "All {} attempts in cycle {} failed (tool-restart stream subject/permissions may not be provisioned yet). Retrying quietly every {} seconds...",
-                    CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, cycle, RESTART_CONSUMER_QUIET_PAUSE_MS / 1000
-                );
-            } else {
-                debug!(
-                    "All {} attempts in cycle {} failed. Pausing {} seconds before next cycle...",
-                    CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, cycle, pause_ms / 1000
-                );
-            }
-            tokio::time::sleep(Duration::from_millis(pause_ms)).await;
+            info!(
+                "All {} attempts in cycle {} failed. Pausing {} seconds before next cycle...",
+                CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, cycle, CONSUMER_CYCLE_PAUSE_MS / 1000
+            );
+            tokio::time::sleep(Duration::from_millis(CONSUMER_CYCLE_PAUSE_MS)).await;
         }
     }
 


### PR DESCRIPTION
## Summary

- Comment out `tool_restart_message_listener.start()` — the backend does not publish `machine.<id>.tool-restart` messages yet, so the listener only produced consumer-creation errors in fleet logs. A `TODO` marks the re-enable point; the field keeps an `#[allow(dead_code)]` tied to the same TODO. Mesh self-heal is unaffected (it calls `ToolRestartService` directly, not via NATS).
- Drop the restart listener's special-case "quiet after first failed cycle" retry logic and the now-unused `RESTART_CONSUMER_QUIET_PAUSE_MS` constant — `create_consumer` now matches the other listeners (same shape as the uninstall listener).
- Port the reconnect-aware `listen()` shape from 7f63f6b3f ("fix: nats message lost during rebind") into the restart listener, so re-enabling it later cannot resurrect the rebind message-loss bug its siblings were just cured of.

## Test plan

- `cargo check` clean (no new warnings; the restart-listener dead-code warning is suppressed intentionally).
- Mesh self-heal verified end-to-end on a live machine with this build: killed `meshagent` via `launchctl bootout`, self-heal detected it and restarted the agent, mesh reconnected (`Received CoreOk`).
- Restart listener is disabled, so no runtime path exercises the ported `listen()` yet; it is a verbatim analog of the uninstall listener's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when restart-related messaging connections are interrupted or message streams end.
  * Added clearer retry behavior with progressive delays when consumer connections cannot be established.
  * Improved handling of connection errors to support more reliable service operation.

* **Known Limitations**
  * Automatic tool-restart message handling is temporarily inactive during client startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->