### PR TITLE
Update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -73,9 +73,9 @@ Subject to this License:
 ## 6. Product-Specific Terms
 
 ### 6.1 OpenFrame  
-- OpenFrame integrates upstream software (Fleet, MeshCentral, Osquery, Tactical RMM) and Flamingo contributions.  
+- OpenFrame integrates upstream software (Fleet, MeshCentral, Osquery) and Flamingo contributions.  
 - Upstream components remain under their original licenses (see Appendix).  
-- SaaS restriction applies fully to Flamingo contributions.  
+- SaaS restriction applies fully to Flamingo contributions. 
 
 ### 6.2 OpenMSP  
 - Covers community knowledge base and contributions.  
@@ -127,7 +127,6 @@ This License is governed by the laws of the State of Delaware, USA.
 
 The following upstream components are incorporated into Flamingo Software and remain under their original licenses. This License does not alter their terms:  
 
-- **Tactical RMM** — Tactical RMM License v1.0 (proprietary, AmidaWare LLC).  
 - **Fleet** — MIT License (with documentation under CC BY-SA 4.0).  
 - **Osquery** — Dual-licensed under Apache-2.0 OR GPL-2.0-only.  
 - **MeshCentral Agent** — Apache-2.0.  


### PR DESCRIPTION
Remove Tactical (TacticalRMM) references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated licensing documentation to remove Tactical RMM from the listed upstream software integrations and appendix.
  * Preserved all other licensing terms and provisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->