### PR TITLE
Remove tacticalrmm-agent-version feature flag

### DIFF
--- a/clients/openframe-client/Cargo.toml
+++ b/clients/openframe-client/Cargo.toml
@@ -27,7 +27,6 @@ default = []
 openframe-chat-version     = []
 meshcentral-agent-version  = []
 fleetmdm-agent-version     = []
-tacticalrmm-agent-version  = []
 
 # Asset-level version overrides. Keyed by Asset.id inside a ToolInstallationMessage.
 # These binaries ship as assets under another tool and can be pinned independently.
@@ -38,7 +37,6 @@ all-tool-versions = [
     "openframe-chat-version",
     "meshcentral-agent-version",
     "fleetmdm-agent-version",
-    "tacticalrmm-agent-version",
     "osquery-version",
 ]
 

--- a/clients/openframe-client/build.rs
+++ b/clients/openframe-client/build.rs
@@ -7,8 +7,6 @@ fn main() {
     forward_required("MESHCENTRAL_AGENT_VERSION");
     #[cfg(feature = "fleetmdm-agent-version")]
     forward_required("FLEETMDM_AGENT_VERSION");
-    #[cfg(feature = "tacticalrmm-agent-version")]
-    forward_required("TACTICALRMM_AGENT_VERSION");
     #[cfg(feature = "osquery-version")]
     forward_required("OSQUERY_VERSION");
 }

--- a/clients/openframe-client/src/models/tool_version_overrides.rs
+++ b/clients/openframe-client/src/models/tool_version_overrides.rs
@@ -10,9 +10,6 @@ pub fn lookup(tool_key: &str) -> Option<&'static str> {
         #[cfg(feature = "fleetmdm-agent-version")]
         "fleetmdm-server" => Some(env!("FLEETMDM_AGENT_VERSION")),
 
-        #[cfg(feature = "tacticalrmm-agent-version")]
-        "tactical-rmm" => Some(env!("TACTICALRMM_AGENT_VERSION")),
-
         #[cfg(feature = "osquery-version")]
         "osqueryd" => Some(env!("OSQUERY_VERSION")),
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for overriding the Tactical RMM agent version.
  * Existing version override options for OpenFrame Chat, MeshCentral, FleetMDM, and osquery remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->