### PR TITLE
fix(client): ascii-only updater script, write with utf-8 bom

### DIFF
--- a/clients/openframe-client/src/platform/update_scripts/mod.rs
+++ b/clients/openframe-client/src/platform/update_scripts/mod.rs
@@ -9,3 +9,31 @@ pub use windows::UPDATE_SCRIPT_WINDOWS;
 
 #[cfg(target_os = "macos")]
 pub use macos::{UPDATE_SCRIPT_MACOS, UPDATER_PLIST_TEMPLATE};
+
+#[cfg(test)]
+mod tests {
+    // Windows PowerShell 5.1 reads BOM-less script files as ANSI: a multi-byte
+    // UTF-8 character can decode into a smart quote (e.g. 0x94 from an em-dash)
+    // that terminates a string early and structurally breaks the script.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_update_script_is_ascii() {
+        assert!(
+            super::windows::UPDATE_SCRIPT_WINDOWS.is_ascii(),
+            "UPDATE_SCRIPT_WINDOWS must stay pure ASCII"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_update_script_is_ascii() {
+        assert!(
+            super::macos::UPDATE_SCRIPT_MACOS.is_ascii(),
+            "UPDATE_SCRIPT_MACOS must stay pure ASCII"
+        );
+        assert!(
+            super::macos::UPDATER_PLIST_TEMPLATE.is_ascii(),
+            "UPDATER_PLIST_TEMPLATE must stay pure ASCII"
+        );
+    }
+}

--- a/clients/openframe-client/src/platform/update_scripts/windows.rs
+++ b/clients/openframe-client/src/platform/update_scripts/windows.rs
@@ -157,7 +157,7 @@ try {
                     break
                 }
                 if ($markerVersion) {
-                    Write-Output "Boot marker reports '$markerVersion', expected '$TargetVersion' — wrong binary booted"
+                    Write-Output "Boot marker reports '$markerVersion', expected '$TargetVersion' - wrong binary booted"
                     break
                 }
             }
@@ -188,7 +188,7 @@ catch {
     Write-Output "Updater failed: $_"
 
     if (Test-AgentUninstalled) {
-        Write-Output "Update state file is gone (agent uninstalled mid-update) — standing down without touching the service"
+        Write-Output "Update state file is gone (agent uninstalled mid-update) - standing down without touching the service"
         if ($TempExtract -and (Test-Path $TempExtract)) {
             Remove-Item -Path $TempExtract -Recurse -Force -ErrorAction SilentlyContinue
         }

--- a/clients/openframe-client/src/platform/updater_launcher/windows.rs
+++ b/clients/openframe-client/src/platform/updater_launcher/windows.rs
@@ -20,7 +20,9 @@ pub async fn launch_updater(params: UpdaterParams) -> Result<()> {
         Uuid::new_v4()
     ));
 
-    tokio::fs::write(&script_path, UPDATE_SCRIPT_WINDOWS).await
+    // UTF-8 BOM: without it Windows PowerShell 5.1 reads the file as ANSI, and
+    // any multi-byte character can decode into a smart quote that breaks parsing.
+    tokio::fs::write(&script_path, format!("\u{FEFF}{}", UPDATE_SCRIPT_WINDOWS)).await
         .context("Failed to write PowerShell script")?;
 
     info!("PowerShell script saved to: {}", script_path.display());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows update reliability when using PowerShell 5.1, including scripts containing non-ASCII characters.
  * Clarified updater error messages for boot-version mismatches and interrupted updates.
  * Prevented potential script parsing issues during Windows update and rollback operations.
* **Tests**
  * Added validation to ensure embedded update scripts use compatible character encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->