### PR TITLE
chore: bump @flamingo-stack/openframe-frontend-core to 0.0.465

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.464",
+    "@flamingo-stack/openframe-frontend-core": "0.0.465",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",


### PR DESCRIPTION
Routine core-lib bump after release. Type-check passes. (package-lock.json is gitignored in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)