### PR TITLE
fix(client): stable macos hostname via scutil, log it at registration

### DIFF
--- a/clients/openframe-client/src/services/agent_registration_service.rs
+++ b/clients/openframe-client/src/services/agent_registration_service.rs
@@ -140,6 +140,7 @@ impl AgentRegistrationService {
     fn build_registration_request(&self) -> Result<AgentRegistrationRequest> {
         let hostname = self.device_data_fetcher.get_hostname()
             .unwrap_or_default();
+        info!("Registering with hostname: '{}'", hostname);
         let agent_version = self.device_data_fetcher.get_agent_version()
             .unwrap_or_default();
         let os_type = self.device_data_fetcher.get_os_type();

--- a/clients/openframe-client/src/services/device_data_fetcher.rs
+++ b/clients/openframe-client/src/services/device_data_fetcher.rs
@@ -11,13 +11,55 @@ impl DeviceDataFetcher {
     }
 
     pub fn get_hostname(&self) -> Option<String> {
+        // gethostname() on macOS is dynamic: with no static HostName set it follows
+        // the DHCP/reverse-DNS name of the current lease, so a machine can register
+        // under a foreign DNS record or an IP-derived name. LocalHostName is the
+        // stable source of the same "<name>.local" value gethostname yields when
+        // the network does not interfere.
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(name) = Self::scutil_get("LocalHostName") {
+                return Some(format!("{}.local", name));
+            }
+            if let Some(name) = Self::scutil_get("ComputerName") {
+                return Some(name);
+            }
+        }
+
         match hostname::get() {
             Ok(hostname) => {
-                let hostname_str = hostname.to_string_lossy().to_string();
-                Some(hostname_str)
+                let hostname_str = hostname.to_string_lossy().trim().to_string();
+                if hostname_str.is_empty() {
+                    warn!("OS returned an empty hostname");
+                    None
+                } else {
+                    Some(hostname_str)
+                }
             }
             Err(e) => {
                 warn!("Failed to get hostname: {:#}", e);
+                None
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn scutil_get(key: &str) -> Option<String> {
+        match std::process::Command::new("scutil").arg("--get").arg(key).output() {
+            Ok(output) if output.status.success() => {
+                let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if value.is_empty() { None } else { Some(value) }
+            }
+            Ok(output) => {
+                warn!(
+                    "scutil --get {} failed: {}",
+                    key,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+                None
+            }
+            Err(e) => {
+                warn!("Failed to run scutil --get {}: {:#}", key, e);
                 None
             }
         }


### PR DESCRIPTION
MacOS registered machines under network-derived names gethostname() follows DHCP/reverse-DNS when no static HostName is set - machines showed up as nats or IP-derived names. Hostname on macOS now resolves LocalHostName + ".local" (identical to the current good-case naming) → ComputerName → gethostname() as last resort; empty results count as failures. The registered hostname is now logged at registration. Existing misnamed machines keep their name until they re-register.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device hostname detection on macOS using stable system names.
  * Added fallback handling for missing, empty, or invalid hostname values.
  * Trimmed hostname results to provide cleaner device identification.
  * Added informative logging during agent registration and hostname lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->