### PR TITLE
fix(client): stable macos hostname via scutil, log it at registration

### DIFF
--- a/clients/openframe-client/src/services/agent_registration_service.rs
+++ b/clients/openframe-client/src/services/agent_registration_service.rs
@@ -138,8 +138,11 @@ impl AgentRegistrationService {
     }
 
     fn build_registration_request(&self) -> Result<AgentRegistrationRequest> {
-        let hostname = self.device_data_fetcher.get_hostname()
-            .unwrap_or_default();
+        let hostname = self.device_data_fetcher.get_hostname().unwrap_or_default();
+        if hostname.is_empty() {
+            warn!("Could not resolve any hostname — registering with an empty one");
+        }
+        info!("Registering with hostname: '{}'", hostname);
         let agent_version = self.device_data_fetcher.get_agent_version()
             .unwrap_or_default();
         let os_type = self.device_data_fetcher.get_os_type();

--- a/clients/openframe-client/src/services/device_data_fetcher.rs
+++ b/clients/openframe-client/src/services/device_data_fetcher.rs
@@ -11,16 +11,52 @@ impl DeviceDataFetcher {
     }
 
     pub fn get_hostname(&self) -> Option<String> {
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(name) = Self::scutil_get("LocalHostName") {
+                return Some(format!("{}.local", name));
+            }
+            if let Some(name) = Self::scutil_get("ComputerName") {
+                return Some(name);
+            }
+        }
+
         match hostname::get() {
             Ok(hostname) => {
-                let hostname_str = hostname.to_string_lossy().to_string();
-                Some(hostname_str)
+                let hostname_str = hostname.to_string_lossy().trim().to_string();
+                if hostname_str.is_empty() {
+                    warn!("OS returned an empty hostname");
+                    None
+                } else {
+                    Some(hostname_str)
+                }
             }
             Err(e) => {
                 warn!("Failed to get hostname: {:#}", e);
                 None
             }
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn scutil_get(key: &str) -> Option<String> {
+        let output = std::process::Command::new("/usr/sbin/scutil")
+            .args(["--get", key])
+            .output()
+            .map_err(|e| warn!("Failed to run scutil --get {}: {:#}", key, e))
+            .ok()?;
+
+        if !output.status.success() {
+            warn!(
+                "scutil --get {} failed: {}",
+                key,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            return None;
+        }
+
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if value.is_empty() { None } else { Some(value) }
     }
 
     pub fn get_agent_version(&self) -> Option<String> {


### PR DESCRIPTION
MacOS registered machines under network-derived names gethostname() follows DHCP/reverse-DNS when no static HostName is set - machines showed up as nats or IP-derived names. Hostname on macOS now resolves LocalHostName + ".local" (identical to the current good-case naming) → ComputerName → gethostname() as last resort; empty results count as failures. The registered hostname is now logged at registration. Existing misnamed machines keep their name until they re-register.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname detection on macOS using system-configured names.
  * Added fallback handling for unavailable, empty, or invalid hostname values.
  * Added clearer warnings when hostname discovery fails.

* **Logging**
  * Added informational logging to indicate which hostname is used during agent registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->