### PR TITLE
fix(client): prefer kernel hostname, fall back to scutil on junk values

### DIFF
--- a/clients/openframe-client/Cargo.lock
+++ b/clients/openframe-client/Cargo.lock
@@ -1046,13 +1046,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1400,12 +1400,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"

--- a/clients/openframe-client/Cargo.toml
+++ b/clients/openframe-client/Cargo.toml
@@ -74,7 +74,7 @@ tar = "0.4"
 service-manager = "0.8"
 plist = "1.7.1"
 # System information collection dependencies
-hostname = "0.3"
+hostname = "0.4"
 bytes = "1.10.1"
 async-nats = { git = "https://github.com/flamingo-stack/nats.rs.git", branch = "main", features = ["websockets"] }
 rustls-pemfile = "1.0"

--- a/clients/openframe-client/src/services/device_data_fetcher.rs
+++ b/clients/openframe-client/src/services/device_data_fetcher.rs
@@ -11,31 +11,49 @@ impl DeviceDataFetcher {
     }
 
     pub fn get_hostname(&self) -> Option<String> {
+        match hostname::get() {
+            Ok(hostname) => {
+                let hostname_str = hostname.to_string_lossy().trim().to_string();
+                if Self::is_valid_hostname(&hostname_str) {
+                    info!("Resolved hostname '{}' from kernel", hostname_str);
+                    return Some(hostname_str);
+                }
+                warn!(
+                    "Kernel hostname '{}' is empty or looks like junk — falling back",
+                    hostname_str
+                );
+            }
+            Err(e) => {
+                warn!("Failed to get hostname: {:#}", e);
+            }
+        }
+
         #[cfg(target_os = "macos")]
         {
             if let Some(name) = Self::scutil_get("LocalHostName") {
-                return Some(format!("{}.local", name));
+                let name = format!("{}.local", name);
+                info!("Resolved hostname '{}' from LocalHostName", name);
+                return Some(name);
             }
             if let Some(name) = Self::scutil_get("ComputerName") {
+                info!("Resolved hostname '{}' from ComputerName", name);
                 return Some(name);
             }
         }
 
-        match hostname::get() {
-            Ok(hostname) => {
-                let hostname_str = hostname.to_string_lossy().trim().to_string();
-                if hostname_str.is_empty() {
-                    warn!("OS returned an empty hostname");
-                    None
-                } else {
-                    Some(hostname_str)
-                }
-            }
-            Err(e) => {
-                warn!("Failed to get hostname: {:#}", e);
-                None
-            }
+        warn!("Could not resolve any hostname");
+        None
+    }
+
+    fn is_valid_hostname(name: &str) -> bool {
+        if name.is_empty() {
+            return false;
         }
+        if name.parse::<std::net::IpAddr>().is_ok() {
+            return false;
+        }
+        let lower = name.to_lowercase();
+        lower != "localhost" && lower != "localhost.localdomain"
     }
 
     #[cfg(target_os = "macos")]

--- a/clients/openframe-client/src/services/device_data_fetcher.rs
+++ b/clients/openframe-client/src/services/device_data_fetcher.rs
@@ -32,12 +32,18 @@ impl DeviceDataFetcher {
         {
             if let Some(name) = Self::scutil_get("LocalHostName") {
                 let name = format!("{}.local", name);
-                info!("Resolved hostname '{}' from LocalHostName", name);
-                return Some(name);
+                if Self::is_valid_hostname(&name) {
+                    info!("Resolved hostname '{}' from LocalHostName", name);
+                    return Some(name);
+                }
+                warn!("LocalHostName '{}' is invalid — falling back", name);
             }
             if let Some(name) = Self::scutil_get("ComputerName") {
-                info!("Resolved hostname '{}' from ComputerName", name);
-                return Some(name);
+                if Self::is_valid_hostname(&name) {
+                    info!("Resolved hostname '{}' from ComputerName", name);
+                    return Some(name);
+                }
+                warn!("ComputerName '{}' is invalid — falling back", name);
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device hostname detection for greater reliability.
  * Rejects unusable values such as empty hostnames, IP addresses, and default localhost names.
  * Adds fallback resolution on macOS to identify the device using configured local or computer names.
  * Devices without a valid hostname are handled safely instead of reporting misleading information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->