### PR TITLE
chore(openframe-chat): bump @flamingo-stack/openframe-frontend-core to 0.0.479

### DIFF
--- a/clients/openframe-chat/package.json
+++ b/clients/openframe-chat/package.json
@@ -18,7 +18,7 @@
     "format:fix": "biome format --fix ."
   },
   "dependencies": {
-    "@flamingo-stack/openframe-frontend-core": "0.0.473",
+    "@flamingo-stack/openframe-frontend-core": "0.0.479",
     "@tanstack/react-query": "^5.90.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",


### PR DESCRIPTION
## What

Bumps `@flamingo-stack/openframe-frontend-core` in `openframe-chat` from `0.0.473` → `0.0.479`.

## Why

Pull in the latest core design-system changes published to the registry.

## Notes

- Only `clients/openframe-chat/package.json` changed, consistent with the previous bump (#2188).