### PR TITLE
feat(client): NATS listener for dashboard-triggered client uninstall

### DIFF
--- a/clients/openframe-client/src/lib.rs
+++ b/clients/openframe-client/src/lib.rs
@@ -55,6 +55,7 @@ use crate::listener::tool_uninstall_message_listener::ToolUninstallMessageListen
 use crate::listener::tool_restart_message_listener::ToolRestartMessageListener;
 use crate::listener::openframe_client_update_listener::OpenFrameClientUpdateListener;
 use crate::listener::tool_agent_update_listener::ToolAgentUpdateListener;
+use crate::listener::client_uninstall_message_listener::ClientUninstallMessageListener;
 use crate::services::openframe_client_update_service::OpenFrameClientUpdateService;
 use crate::services::tool_agent_update_service::ToolAgentUpdateService;
 use crate::services::openframe_client_info_service::OpenFrameClientInfoService;
@@ -154,6 +155,8 @@ pub struct Client {
     tool_restart_message_listener: ToolRestartMessageListener,
     openframe_client_update_listener: OpenFrameClientUpdateListener,
     tool_agent_update_listener: ToolAgentUpdateListener,
+    #[allow(dead_code)] // TODO: remove when the CLIENT_UNINSTALL stream exists on the backend
+    client_uninstall_message_listener: ClientUninstallMessageListener,
     command_execution_listener: ExecutionListener<CommandMessage>,
     script_execution_listener: ExecutionListener<ScriptMessage>,
     script_schedule_execution_listener: ExecutionListener<ScriptScheduleExecutionMessage>,
@@ -476,6 +479,13 @@ impl Client {
             tool_run_manager.clone(),
         );
 
+        // Initialize client uninstall listener (dashboard-triggered device uninstall)
+        let client_uninstall_message_listener = ClientUninstallMessageListener::new(
+            nats_connection_manager.clone(),
+            deactivation_service.clone(),
+            config_service.clone(),
+        );
+
         let execution_service = ExecutionService::new();
         let execution_concurrency = std::thread::available_parallelism()
             .map(|n| n.get())
@@ -551,6 +561,7 @@ impl Client {
             tool_restart_message_listener,
             openframe_client_update_listener,
             tool_agent_update_listener,
+            client_uninstall_message_listener,
             command_execution_listener,
             script_execution_listener,
             script_schedule_execution_listener,
@@ -639,6 +650,9 @@ impl Client {
 
         // Start tool agent update listener in background
         self.tool_agent_update_listener.start().await?;
+
+        // TODO: uncomment when the CLIENT_UNINSTALL stream exists on the backend
+        // self.client_uninstall_message_listener.start().await?;
 
         // Recover interrupted scheduled scripts, then start the outbox flusher,
         // both strictly before any execution listener can accept new batches

--- a/clients/openframe-client/src/lib.rs
+++ b/clients/openframe-client/src/lib.rs
@@ -155,7 +155,6 @@ pub struct Client {
     tool_restart_message_listener: ToolRestartMessageListener,
     openframe_client_update_listener: OpenFrameClientUpdateListener,
     tool_agent_update_listener: ToolAgentUpdateListener,
-    #[allow(dead_code)] // TODO: remove when the CLIENT_UNINSTALL stream exists on the backend
     client_uninstall_message_listener: ClientUninstallMessageListener,
     command_execution_listener: ExecutionListener<CommandMessage>,
     script_execution_listener: ExecutionListener<ScriptMessage>,
@@ -651,8 +650,8 @@ impl Client {
         // Start tool agent update listener in background
         self.tool_agent_update_listener.start().await?;
 
-        // TODO: uncomment when the CLIENT_UNINSTALL stream exists on the backend
-        // self.client_uninstall_message_listener.start().await?;
+        // Start client uninstall listener in background
+        self.client_uninstall_message_listener.start().await?;
 
         // Recover interrupted scheduled scripts, then start the outbox flusher,
         // both strictly before any execution listener can accept new batches

--- a/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
+++ b/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
@@ -1,0 +1,216 @@
+use crate::services::deactivation_service::DeactivationService;
+use crate::services::nats_connection_manager::NatsConnectionManager;
+use crate::services::AgentConfigurationService;
+use crate::config::update_config::{
+    CONSUMER_RETRY_ATTEMPTS_PER_CYCLE,
+    INITIAL_RETRY_DELAY_MS,
+    MAX_RETRY_DELAY_MS,
+    CONSUMER_CYCLE_PAUSE_MS,
+    RECONNECTION_DELAY_MS,
+    CONSUMER_ACK_WAIT_SECS,
+    CONSUMER_MAX_DELIVER,
+};
+use async_nats::jetstream::consumer::PushConsumer;
+use async_nats::jetstream::consumer::push;
+use async_nats::jetstream::consumer::DeliverPolicy;
+use async_nats::jetstream::Message;
+use std::sync::Arc;
+use tokio::time::Duration;
+use anyhow::Result;
+use async_nats::jetstream;
+use futures::StreamExt;
+use tracing::{error, info, warn};
+
+#[derive(Clone)]
+pub struct ClientUninstallMessageListener {
+    nats_connection_manager: NatsConnectionManager,
+    deactivation_service: Arc<DeactivationService>,
+    config_service: AgentConfigurationService,
+}
+
+impl ClientUninstallMessageListener {
+
+    const STREAM_NAME: &'static str = "CLIENT_UNINSTALL";
+
+    pub fn new(
+        nats_connection_manager: NatsConnectionManager,
+        deactivation_service: Arc<DeactivationService>,
+        config_service: AgentConfigurationService,
+    ) -> Self {
+        Self {
+            nats_connection_manager,
+            deactivation_service,
+            config_service,
+        }
+    }
+
+    /// Start listening for messages in a background task
+    pub async fn start(&self) -> Result<tokio::task::JoinHandle<()>> {
+        let listener = self.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                info!("Starting client uninstall message listener...");
+                match listener.listen().await {
+                    Ok(_) => {
+                        warn!("Client uninstall message listener exited normally (unexpected)");
+                    }
+                    Err(e) => {
+                        error!("Client uninstall message listener error: {:#}", e);
+                    }
+                }
+
+                info!(
+                    "Reconnecting client uninstall message listener in {} seconds...",
+                    RECONNECTION_DELAY_MS / 1000
+                );
+                tokio::time::sleep(Duration::from_millis(RECONNECTION_DELAY_MS)).await;
+            }
+        });
+        Ok(handle)
+    }
+
+    async fn listen(&self) -> Result<()> {
+        info!("Run client uninstall message listener");
+        let machine_id = self.config_service.get_machine_id()?;
+
+        loop {
+            let client = self.nats_connection_manager
+                .get_client()
+                .await?;
+            let mut reconnect_rx = self.nats_connection_manager.subscribe_reconnect();
+            let js = jetstream::new((*client).clone());
+
+            let consumer = self.create_consumer(&js, &machine_id).await;
+
+            info!("Start listening for client uninstall messages");
+            let mut messages = consumer.messages().await?;
+
+            loop {
+                tokio::select! {
+                    msg_result = messages.next() => {
+                        match msg_result {
+                            Some(Ok(message)) => {
+                                if let Err(e) = self.handle_message(message).await {
+                                    error!("Failed to handle message: {:#}", e);
+                                }
+                            }
+                            Some(Err(e)) => {
+                                error!("Message stream error, recreating consumer: {:#}", e);
+                                return Err(anyhow::anyhow!("Message stream error: {}", e));
+                            }
+                            None => {
+                                warn!("Message stream ended, rebinding consumer");
+                                break;
+                            }
+                        }
+                    }
+                    _ = reconnect_rx.recv() => {
+                        info!("NATS reconnected, re-provisioning client uninstall consumer");
+                        self.create_consumer(&js, &machine_id).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_message(&self, message: Message) -> Result<()> {
+        let payload = String::from_utf8_lossy(&message.payload);
+        info!("Received client uninstall message: {:?}", payload);
+
+        // Any message on this machine-scoped subject is the command; no payload contract yet.
+        self.deactivation_service.request_uninstall().await;
+
+        // Ack right away: request_uninstall is idempotent and its supervisor retries the spawn.
+        message.ack().await
+            .map_err(|e| anyhow::anyhow!("Failed to ack client uninstall message: {}", e))?;
+        info!("Client uninstall message acknowledged");
+
+        Ok(())
+    }
+
+    async fn create_consumer(&self, js: &jetstream::Context, machine_id: &str) -> PushConsumer {
+        let consumer_configuration = Self::build_consumer_configuration(machine_id);
+        let mut cycle = 0u32;
+
+        loop {
+            cycle += 1;
+            let mut delay_ms = INITIAL_RETRY_DELAY_MS;
+
+            for attempt in 1..=CONSUMER_RETRY_ATTEMPTS_PER_CYCLE {
+                info!(
+                    "Creating client uninstall consumer for stream {} (cycle {}, attempt {}/{})",
+                    Self::STREAM_NAME, cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE
+                );
+
+                match js.create_consumer_on_stream(consumer_configuration.clone(), Self::STREAM_NAME).await {
+                    Ok(consumer) => {
+                        info!("Client uninstall consumer created for stream: {}", Self::STREAM_NAME);
+                        return consumer;
+                    }
+                    Err(e) => {
+                        let error_msg = format!("{:?}", e);
+                        if error_msg.contains("consumer name already in use") || error_msg.contains("10013") {
+                            warn!("Client uninstall consumer already exists, attempting to get existing consumer");
+                            let durable_name = Self::build_durable_name(machine_id);
+                            if let Ok(existing_consumer) = js.get_consumer_from_stream(Self::STREAM_NAME, &durable_name).await {
+                                info!("Retrieved existing client uninstall consumer for stream: {}", Self::STREAM_NAME);
+                                return existing_consumer;
+                            }
+                        }
+
+                        if attempt < CONSUMER_RETRY_ATTEMPTS_PER_CYCLE {
+                            warn!(
+                                "Failed to create client uninstall consumer (cycle {}, attempt {}/{}): {:#}. Retrying in {} ms...",
+                                cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, e, delay_ms
+                            );
+                            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                            delay_ms = (delay_ms * 2).min(MAX_RETRY_DELAY_MS);
+                        } else {
+                            warn!(
+                                "Failed to create client uninstall consumer (cycle {}, attempt {}/{}): {:#}",
+                                cycle, attempt, CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, e
+                            );
+                        }
+                    }
+                }
+            }
+
+            info!(
+                "All {} attempts in cycle {} failed. Pausing {} seconds before next cycle...",
+                CONSUMER_RETRY_ATTEMPTS_PER_CYCLE, cycle, CONSUMER_CYCLE_PAUSE_MS / 1000
+            );
+            tokio::time::sleep(Duration::from_millis(CONSUMER_CYCLE_PAUSE_MS)).await;
+        }
+    }
+
+    fn build_consumer_configuration(machine_id: &str) -> push::Config {
+        let filter_subject = Self::build_filter_subject(machine_id);
+        let deliver_subject = Self::build_deliver_subject(machine_id);
+        let durable_name = Self::build_durable_name(machine_id);
+
+        info!("Client uninstall consumer configuration - filter subject: {}, deliver subject: {}, durable name: {}", filter_subject, deliver_subject, durable_name);
+
+        push::Config {
+            filter_subject,
+            deliver_subject,
+            durable_name: Some(durable_name),
+            ack_wait: Duration::from_secs(CONSUMER_ACK_WAIT_SECS),
+            // New: never replay a stale uninstall command to a reinstalled client.
+            deliver_policy: DeliverPolicy::New,
+            max_deliver: CONSUMER_MAX_DELIVER,
+            ..Default::default()
+        }
+    }
+
+    fn build_filter_subject(machine_id: &str) -> String {
+        format!("machine.{}.client-uninstall", machine_id)
+    }
+
+    fn build_deliver_subject(machine_id: &str) -> String {
+        format!("machine.{}.client-uninstall.inbox", machine_id)
+    }
+
+    fn build_durable_name(machine_id: &str) -> String {
+        format!("machine_{}_client-uninstall_consumer", machine_id)
+    }
+}

--- a/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
+++ b/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
@@ -14,6 +14,7 @@ use async_nats::jetstream::consumer::PushConsumer;
 use async_nats::jetstream::consumer::push;
 use async_nats::jetstream::consumer::DeliverPolicy;
 use async_nats::jetstream::Message;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::time::Duration;
 use anyhow::Result;
@@ -26,6 +27,7 @@ pub struct ClientUninstallMessageListener {
     nats_connection_manager: NatsConnectionManager,
     deactivation_service: Arc<DeactivationService>,
     config_service: AgentConfigurationService,
+    uninstall_dispatched: Arc<AtomicBool>,
 }
 
 impl ClientUninstallMessageListener {
@@ -41,6 +43,7 @@ impl ClientUninstallMessageListener {
             nats_connection_manager,
             deactivation_service,
             config_service,
+            uninstall_dispatched: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -57,6 +60,12 @@ impl ClientUninstallMessageListener {
                     Err(e) => {
                         error!("Client uninstall message listener error: {:#}", e);
                     }
+                }
+
+                // Stay down after a dispatched uninstall so the deleted durable is not recreated.
+                if listener.uninstall_dispatched.load(Ordering::Acquire) {
+                    info!("Client uninstall dispatched, listener stopping permanently");
+                    break;
                 }
 
                 info!(
@@ -90,8 +99,11 @@ impl ClientUninstallMessageListener {
                     msg_result = messages.next() => {
                         match msg_result {
                             Some(Ok(message)) => {
-                                if let Err(e) = self.handle_message(message).await {
+                                if let Err(e) = self.handle_message(message, &js, &machine_id).await {
                                     error!("Failed to handle message: {:#}", e);
+                                }
+                                if self.uninstall_dispatched.load(Ordering::Acquire) {
+                                    return Ok(());
                                 }
                             }
                             Some(Err(e)) => {
@@ -113,9 +125,17 @@ impl ClientUninstallMessageListener {
         }
     }
 
-    async fn handle_message(&self, message: Message) -> Result<()> {
+    async fn handle_message(&self, message: Message, js: &jetstream::Context, machine_id: &str) -> Result<()> {
         let payload = String::from_utf8_lossy(&message.payload);
         info!("Received client uninstall message: {:?}", payload);
+
+        // Client self-uninstall is macOS/Windows only; drop the command elsewhere.
+        if !cfg!(any(target_os = "macos", target_os = "windows")) {
+            warn!("Client self-uninstall is not supported on this platform, ignoring message");
+            message.ack().await
+                .map_err(|e| anyhow::anyhow!("Failed to ack unsupported-platform message: {}", e))?;
+            return Ok(());
+        }
 
         // Any message on this machine-scoped subject is the command; no payload contract yet.
         self.deactivation_service.request_uninstall().await;
@@ -124,6 +144,15 @@ impl ClientUninstallMessageListener {
         message.ack().await
             .map_err(|e| anyhow::anyhow!("Failed to ack client uninstall message: {}", e))?;
         info!("Client uninstall message acknowledged");
+
+        // Drop the durable so a reinstall starts a fresh consumer instead of inheriting a stale command.
+        let durable_name = Self::build_durable_name(machine_id);
+        match js.delete_consumer_from_stream(&durable_name, Self::STREAM_NAME).await {
+            Ok(_) => info!("Deleted client uninstall consumer {}", durable_name),
+            Err(e) => warn!("Failed to delete client uninstall consumer {} (continuing with uninstall): {:#}", durable_name, e),
+        }
+
+        self.uninstall_dispatched.store(true, Ordering::Release);
 
         Ok(())
     }

--- a/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
+++ b/clients/openframe-client/src/listener/client_uninstall_message_listener.rs
@@ -55,7 +55,9 @@ impl ClientUninstallMessageListener {
                 info!("Starting client uninstall message listener...");
                 match listener.listen().await {
                     Ok(_) => {
-                        warn!("Client uninstall message listener exited normally (unexpected)");
+                        if !listener.uninstall_dispatched.load(Ordering::Acquire) {
+                            warn!("Client uninstall message listener exited normally (unexpected)");
+                        }
                     }
                     Err(e) => {
                         error!("Client uninstall message listener error: {:#}", e);
@@ -241,5 +243,26 @@ impl ClientUninstallMessageListener {
 
     fn build_durable_name(machine_id: &str) -> String {
         format!("machine_{}_client-uninstall_consumer", machine_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_and_durable_names_follow_machine_scoped_convention() {
+        assert_eq!(
+            ClientUninstallMessageListener::build_filter_subject("abc123"),
+            "machine.abc123.client-uninstall"
+        );
+        assert_eq!(
+            ClientUninstallMessageListener::build_deliver_subject("abc123"),
+            "machine.abc123.client-uninstall.inbox"
+        );
+        assert_eq!(
+            ClientUninstallMessageListener::build_durable_name("abc123"),
+            "machine_abc123_client-uninstall_consumer"
+        );
     }
 }

--- a/clients/openframe-client/src/listener/mod.rs
+++ b/clients/openframe-client/src/listener/mod.rs
@@ -4,6 +4,7 @@ pub mod tool_uninstall_message_listener;
 pub mod tool_restart_message_listener;
 pub mod openframe_client_update_listener;
 pub mod tool_agent_update_listener;
+pub mod client_uninstall_message_listener;
 pub mod execution_listener;
 
 pub use tool_installation_message_listener::ToolInstallationMessageListener;
@@ -11,4 +12,5 @@ pub use tool_uninstall_message_listener::ToolUninstallMessageListener;
 pub use tool_restart_message_listener::ToolRestartMessageListener;
 pub use openframe_client_update_listener::OpenFrameClientUpdateListener;
 pub use tool_agent_update_listener::ToolAgentUpdateListener;
+pub use client_uninstall_message_listener::ClientUninstallMessageListener;
 pub use execution_listener::ExecutionListener;


### PR DESCRIPTION
## Summary

Implements the client side of [Allow device uninstall action from dashboard](https://app.clickup.com/t/86ahw2uyy): a JetStream listener that lets the backend remotely uninstall the openframe-client from a device.

- New `ClientUninstallMessageListener`, closely mirroring the existing listeners (`openframe_client_update_listener` / `tool_uninstall_message_listener`): durable push consumer, reconnect re-provisioning, exponential consumer-create retries.
- Any message on the machine-scoped subject is the command (no payload contract yet); dispatch funnels through the existing idempotent `DeactivationService::request_uninstall()`, which launches the detached self-uninstall with spawn retries.
- On dispatch: ack, then best-effort delete of the durable consumer and permanent listener shutdown — combined with `DeliverPolicy::New` this guarantees a reinstalled client (same persisted machine_id) can never replay an uninstall published while the machine was gone.
- Linux (self-uninstall unsupported) acks and ignores the command instead of latching a spawn that can only fail.
- `start()` is commented out with a TODO (same precedent as the tool-restart listener) until the backend provisions the stream — otherwise every client would warn-spam consumer-create retries forever.

## Backend contract (not in this PR)

| | Value |
|---|---|
| Stream | `CLIENT_UNINSTALL` (subject filter `machine.*.client-uninstall`) |
| Publish subject | `machine.{machineId}.client-uninstall`, any payload (`{}` is fine) |
| Device-user NATS perms | publish: `$JS.API.CONSUMER.CREATE.CLIENT_UNINSTALL.*.machine.*.client-uninstall`, `$JS.API.CONSUMER.DELETE.CLIENT_UNINSTALL.*`, `$JS.ACK.CLIENT_UNINSTALL.>` — subscribe: `machine.*.client-uninstall.inbox` |

Stream retention should exceed the longest plausible offline period so queued uninstalls survive until the device reconnects.

## Testing

- `cargo check` clean — no new warnings (baseline unchanged).
- `cargo test -- --skip test_ensure_admin`: 119 passed; the 2 `platform::directories` failures are pre-existing local-env failures, identical on `main`.
- Pre-PR agent review applied: durable-consumer replay trap fixed via delete-on-dispatch; unsupported-platform guard added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving dashboard-triggered client uninstall commands.
  * Uninstall requests are handled for supported desktop platforms and trigger the client’s deactivation process.
  * Listener activity stops after an uninstall command is processed to prevent stale commands from being reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->