### PR TITLE
fix(deps): bump openframe.libs.version 5.64.0 -> 6.20.9 (unblock openframe-stream)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <grpc.version>1.58.0</grpc.version>
         <!-- Centralized OpenFrame OSS libs version -->
-        <openframe.libs.version>5.64.0</openframe.libs.version>
+        <openframe.libs.version>6.20.9</openframe.libs.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
openframe.libs.version was pinned to 5.64.0, published 2026-04-21 — three months BEFORE the tactical-rmm listener was removed from the lib (openframe-oss-lib #1368 / 041b5210, 2026-07-14). So openframe-stream's image bundled openframe-stream-service-core-5.64.0.jar, whose JsonKafkaListener still references ${openframe.oss-tenant.kafka.topics.inbound.tactical-rmm-events.name}. That key was correctly removed from configs/base/openframe-stream.yml, so the listener fails placeholder resolution at startup:

  BeanCreationException: 'jsonKafkaListener' ... Could not resolve placeholder
  'openframe.oss-tenant.kafka.topics.inbound.tactical-rmm-events.name'

-> CrashLoopBackOff -> the `tenant` ArgoCD app (and its parent app-of-apps) go Degraded -> every fresh platform install hangs at ~15/17. Reproduced live on local k3d.

6.16.0 (2026-07-14) is the first lib release without the tactical listener; 6.20.9 is the current latest and matches the topics the current openframe-stream.yml provides. Bumping this single property rebuilds all 12 lib-backed services against the clean lib.

NOTE: this is a 3-month catch-up jump (5.64.0 -> 6.20.9) across all OSS libs — run the full platform install test before merging. If a smaller blast radius is preferred, 6.16.0 is the minimal version that fixes just this crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying OpenFrame libraries to the latest managed release for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->