### PR TITLE
fix(agent): register Linux hosts as LINUX instead of MAC_OS

### DIFF
--- a/clients/openframe-client/src/services/device_data_fetcher.rs
+++ b/clients/openframe-client/src/services/device_data_fetcher.rs
@@ -89,11 +89,21 @@ impl DeviceDataFetcher {
         Some(version)
     }
 
+    /// The platform this host runs, reported once at registration and stored verbatim as
+    /// `Machine.osType`. The spelling is a contract rather than a label: the backend scopes
+    /// script schedules to devices by matching it against a platform, so a host that reports
+    /// the wrong one is targeted by the wrong schedules.
+    ///
+    /// `MAC_OS` is kept as the macOS spelling deliberately — it is what every already-registered
+    /// Mac carries, and changing it here would introduce a second spelling for the same platform
+    /// without repairing any existing device.
     pub fn get_os_type(&self) -> String {
         if cfg!(target_os = "windows") {
             "WINDOWS".to_string()
-        } else {
+        } else if cfg!(target_os = "macos") {
             "MAC_OS".to_string()
+        } else {
+            "LINUX".to_string()
         }
     }
 } 


### PR DESCRIPTION
## Problem

`get_os_type()` branched on Windows and treated **everything else** as macOS:

```rust
if cfg!(target_os = "windows") { "WINDOWS" } else { "MAC_OS" }
```

So every Linux host registers with `osType = "MAC_OS"`. The value is stored verbatim as `Machine.osType`, and the backend scopes script schedules by matching it against a platform — so a Linux box is offered to **macOS** schedules and never to Linux ones, and a `LINUX` schedule matches nothing at all, because no device has ever reported that platform.

## Fix

Three branches instead of two. macOS keeps the spelling `MAC_OS` **on purpose**: that is what every already-registered Mac carries, and switching to `MACOS` here would add a second spelling for one platform while repairing no existing device.

## Database

No migration and no change to existing documents. Newly-registered Linux hosts start reporting `LINUX` instead of `MAC_OS`; nothing rewrites what is already stored. Linux devices registered before this ship keep their wrong `MAC_OS` value until they re-register.

## Verification

`cargo check` passes. Because these are `cfg!` (a runtime boolean) rather than `#[cfg]` attributes, all three branches are type-checked regardless of build target.

## Related

flamingo-stack/openframe-oss-lib#1596 fixes the other half of this: the backend compared platform names to `osType` directly, which meant `MACOS` never matched a Mac's stored `MAC_OS` — Macs were missing from a schedule's Available Devices entirely. That PR makes the backend accept every spelling, including the `LINUX` this one introduces, so the two are independent and can land in either order.
