### PR TITLE
fix(tenant): point the frontend image at the renamed repo's package

### DIFF
--- a/manifests/tenant/values.yaml
+++ b/manifests/tenant/values.yaml
@@ -188,9 +188,6 @@ openframe-saas:
   frontend:
     enabled: true
     image:
-      # The frontend repo was renamed openframe-frontend -> openframe-oss-frontend;
-      # ghcr packages do not follow repo renames, so the old path 403s anonymously.
-      # Its CI publishes ghcr.io/flamingo-stack/<repo>/<repo>.
       registry: ghcr.io/flamingo-stack/openframe-oss-frontend
       repository: openframe-oss-frontend
       tag: ""

--- a/manifests/tenant/values.yaml
+++ b/manifests/tenant/values.yaml
@@ -188,8 +188,11 @@ openframe-saas:
   frontend:
     enabled: true
     image:
-      registry: ghcr.io/flamingo-stack/openframe-frontend
-      repository: openframe-frontend
+      # The frontend repo was renamed openframe-frontend -> openframe-oss-frontend;
+      # ghcr packages do not follow repo renames, so the old path 403s anonymously.
+      # Its CI publishes ghcr.io/flamingo-stack/<repo>/<repo>.
+      registry: ghcr.io/flamingo-stack/openframe-oss-frontend
+      repository: openframe-oss-frontend
       tag: ""
     # frontend has no /metrics endpoint; only ship logs
     podAnnotations:


### PR DESCRIPTION
The frontend repo was renamed openframe-frontend -> openframe-oss-frontend. ghcr packages do not follow repo renames, so the image path in values.yaml kept pointing at ghcr.io/flamingo-stack/openframe-frontend/openframe-frontend, which now 403s even for anonymous pulls -> ImagePullBackOff on every fresh install (no imagePullSecret can fix a package that isn't published anymore).

The renamed repo's CI publishes ghcr.io/flamingo-stack/<repo>/<repo>:
  ghcr.io/flamingo-stack/openframe-oss-frontend/openframe-oss-frontend
verified public (anonymous pull token HTTP 200) with tags latest + 1.0.x. Helm render confirmed the deployment now resolves exactly that reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the tenant frontend container image source to the correct OpenFrame OSS location, replacing the previous registry/repository reference. This resolves image access issues caused by the prior incorrect path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->