### PR TITLE
fix(deps): bump openframe.libs.version 6.20.9 -> 6.21.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <grpc.version>1.58.0</grpc.version>
         <!-- Centralized OpenFrame OSS libs version -->
-        <openframe.libs.version>6.20.9</openframe.libs.version>
+        <openframe.libs.version>6.21.1</openframe.libs.version>
     </properties>
 
     <modules>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the centralized library version to 6.21.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->