### PR TITLE
hotfix/openframe-config. added env XDG_CONFIG_HOME for readonly fs

### DIFF
--- a/manifests/platform/openframe-config/templates/deployment.yaml
+++ b/manifests/platform/openframe-config/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           env:
             - name: RELEASE_VERSION
               value: "{{ .Values.image.tag }}"
+            # jgit caches
+            - name: XDG_CONFIG_HOME
+              value: /tmp/.config
 
           volumeMounts:
             - name: tmp


### PR DESCRIPTION
added env XDG_CONFIG_HOME for readonly fs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration and cache handling for the OpenFrame service by setting a writable configuration directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->