### PR TITLE
Use named targetPorts for services

### DIFF
--- a/manifests/platform/dev-tools/Chart.yaml
+++ b/manifests/platform/dev-tools/Chart.yaml
@@ -10,5 +10,5 @@ dependencies:
     version: "~1.6.3"
     repository: https://kafbat.github.io/helm-charts
   - name: telepresence-oss
-    version: "~2.28.0"
+    version: "~2.30.1"
     repository: oci://ghcr.io/flamingo-stack/registry/helm-charts

--- a/manifests/platform/dev-tools/values.yaml
+++ b/manifests/platform/dev-tools/values.yaml
@@ -58,7 +58,7 @@ telepresence-oss:
   image:
     registry: ghcr.io/flamingo-stack/registry/telepresenceio
     name: tel2  # not configurable
-    tag: "2.27.0"
+    tag: "2.30.1"
   podAnnotations:
     loki.grafana.com/scrape: "true"
 

--- a/manifests/platform/openframe-config/templates/service.yaml
+++ b/manifests/platform/openframe-config/templates/service.yaml
@@ -9,9 +9,9 @@ spec:
     app: openframe-config
   ports:
     - port: 8888
-      targetPort: 8888
+      targetPort: http
       name: http
     - port: 8889
-      targetPort: 8889
+      targetPort: management
       name: management
   type: ClusterIP

--- a/manifests/tenant/templates/openframe-api/service.yaml
+++ b/manifests/tenant/templates/openframe-api/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-api
   ports:
     - port: 8090
-      targetPort: 8090
+      targetPort: http
       name: http
     - port: 8091
-      targetPort: 8091
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-authorization-server/service.yaml
+++ b/manifests/tenant/templates/openframe-authorization-server/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-authorization-server
   ports:
     - port: 9005
-      targetPort: 9005
+      targetPort: http
       name: http
     - port: 9006
-      targetPort: 9006
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-client/service.yaml
+++ b/manifests/tenant/templates/openframe-client/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-client
   ports:
     - port: 8097
-      targetPort: 8097
+      targetPort: http
       name: http
     - port: 8102
-      targetPort: 8102
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-external-api/service.yaml
+++ b/manifests/tenant/templates/openframe-external-api/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-external-api
   ports:
     - port: 8092
-      targetPort: 8092
+      targetPort: http
       name: http
     - port: 8093
-      targetPort: 8093
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-frontend/service.yaml
+++ b/manifests/tenant/templates/openframe-frontend/service.yaml
@@ -12,7 +12,7 @@ spec:
     app: openframe-frontend
   ports:
     - port: 3000
-      targetPort: 3000
+      targetPort: http
       name: http
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-gateway/service.yaml
+++ b/manifests/tenant/templates/openframe-gateway/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-gateway
   ports:
     - port: 8100
-      targetPort: 8100
+      targetPort: http
       name: http
     - port: 8101
-      targetPort: 8101
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-management/service.yaml
+++ b/manifests/tenant/templates/openframe-management/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-management
   ports:
     - port: 8095
-      targetPort: 8095
+      targetPort: http
       name: http
     - port: 8096
-      targetPort: 8096
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}

--- a/manifests/tenant/templates/openframe-stream/service.yaml
+++ b/manifests/tenant/templates/openframe-stream/service.yaml
@@ -12,10 +12,10 @@ spec:
     app: openframe-stream
   ports:
     - port: 8082
-      targetPort: 8082
+      targetPort: http
       name: http
     - port: 8083
-      targetPort: 8083
+      targetPort: management
       name: management
   type: ClusterIP
 {{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Telepresence development tools to version 2.30.1.
  * Ensured the bundled image and deployment configuration use the same updated version.

* **Bug Fixes**
  * Improved service routing across platform and tenant components by using named application and management ports.
  * Updated frontend routing to target its named HTTP port for more reliable connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->