### PR TITLE
fix(client): kill timed-out agentId command; mesh self-heal refreshes .msh on every heal path

### DIFF
--- a/clients/openframe-client/src/services/.mesh_self_heal_service.md
+++ b/clients/openframe-client/src/services/.mesh_self_heal_service.md
@@ -1,5 +1,5 @@
 <!-- source-hash: 2ba1220ec3a46a95ed59b29a3cd9ea2f -->
-Monitors the MeshCentral agent's health by continuously scanning its log file for connection failure/success markers and automatically restarting or reconfiguring the agent when it becomes stuck or silent.
+Monitors the MeshCentral agent's health by continuously scanning its log file for connection failure/success markers and healing (refreshing the `.msh`, then restarting the agent) when it becomes stuck, silent, or loses its ServerID.
 
 ## Key Components
 
@@ -8,6 +8,7 @@ Monitors the MeshCentral agent's health by continuously scanning its log file fo
 | `MeshSelfHealService` | Main service struct holding references to directory management, tool lifecycle, config, and an HTTP client |
 | `run()` | Spawns the background watcher loop as a detached Tokio task |
 | `watch()` | Core polling loop — reads new log lines every 30s, tracks health state, and triggers heal actions |
+| `heal()` | Single heal path used by every unhealthy branch (missing ServerID, stuck, silent): refreshes the `.msh`, then restarts the agent so it re-imports it |
 | `restart_agent()` | Attempts a guarded restart via `ToolRestartService`, falling back to a process kill if the agent is unregistered |
 | `try_refresh_msh()` | Fetches a fresh `.msh` config from `/generate-msh` and atomically rewrites the file if `MeshID` or `ServerID` changed |
 | `current_msh_missing_serverid()` | Returns `true` when the on-disk `.msh` lacks a `ServerID` (agent cannot authenticate) |

--- a/clients/openframe-client/src/services/.tool_connection_processing_manager.md
+++ b/clients/openframe-client/src/services/.tool_connection_processing_manager.md
@@ -21,7 +21,7 @@ Main struct coordinating tool connection workflows with the following dependenci
 | Constant | Value | Purpose |
 |---|---|---|
 | `RETRY_DELAY_SECONDS` | `15` | Standard retry interval |
-| `AGENT_ID_COMMAND_TIMEOUT_SECONDS` | `30` | agentId command timeout; the spawned process is killed on expiry |
+| `AGENT_ID_COMMAND_TIMEOUT_SECONDS` | `15` | agentId command timeout; the spawned process is killed on expiry |
 | `AGENT_ID_MAX_FAST_RETRIES` | `5` | Failures before degraded backoff |
 | `AGENT_ID_DEGRADED_BACKOFF_SECONDS` | `300` | Backoff delay after repeated failures |
 | `REPUBLISH_INTERVAL_SECONDS` | `3600` | Cadence of the periodic re-resolve + re-publish |
@@ -34,7 +34,7 @@ Main struct coordinating tool connection workflows with the following dependenci
 ### Private Methods
 
 - **`try_mark_running(tool_id)`** – Atomically marks a tool as running and registers its wake handle, returning it (or `None` if already in flight)
-- **`process_tool(tool)`** – Spawns a loop that resolves the agent ID via command execution (30s timeout, `kill_on_drop` so a timed-out command can't leak a live process), publishes and persists the `ToolConnection`, then repeats hourly (or when woken) so a re-keyed agent heals without a restart; exits when the tool is uninstalled
+- **`process_tool(tool)`** – Spawns a loop that resolves the agent ID via command execution (15s timeout, `kill_on_drop` so a timed-out command can't leak a live process), publishes and persists the `ToolConnection`, then repeats hourly (or when woken) so a re-keyed agent heals without a restart; exits when the tool is uninstalled
 
 ## Usage Example
 

--- a/clients/openframe-client/src/services/.tool_connection_processing_manager.md
+++ b/clients/openframe-client/src/services/.tool_connection_processing_manager.md
@@ -21,6 +21,7 @@ Main struct coordinating tool connection workflows with the following dependenci
 | Constant | Value | Purpose |
 |---|---|---|
 | `RETRY_DELAY_SECONDS` | `15` | Standard retry interval |
+| `AGENT_ID_COMMAND_TIMEOUT_SECONDS` | `30` | agentId command timeout; the spawned process is killed on expiry |
 | `AGENT_ID_MAX_FAST_RETRIES` | `5` | Failures before degraded backoff |
 | `AGENT_ID_DEGRADED_BACKOFF_SECONDS` | `300` | Backoff delay after repeated failures |
 | `REPUBLISH_INTERVAL_SECONDS` | `3600` | Cadence of the periodic re-resolve + re-publish |
@@ -33,7 +34,7 @@ Main struct coordinating tool connection workflows with the following dependenci
 ### Private Methods
 
 - **`try_mark_running(tool_id)`** – Atomically marks a tool as running and registers its wake handle, returning it (or `None` if already in flight)
-- **`process_tool(tool)`** – Spawns a loop that resolves the agent ID via command execution (with 15s timeout), publishes and persists the `ToolConnection`, then repeats hourly (or when woken) so a re-keyed agent heals without a restart; exits when the tool is uninstalled
+- **`process_tool(tool)`** – Spawns a loop that resolves the agent ID via command execution (30s timeout, `kill_on_drop` so a timed-out command can't leak a live process), publishes and persists the `ToolConnection`, then repeats hourly (or when woken) so a re-keyed agent heals without a restart; exits when the tool is uninstalled
 
 ## Usage Example
 

--- a/clients/openframe-client/src/services/mesh_self_heal_service.rs
+++ b/clients/openframe-client/src/services/mesh_self_heal_service.rs
@@ -172,38 +172,38 @@ impl MeshSelfHealService {
             let silent = last_activity.elapsed() >= SILENCE_DURATION;
             let msh_missing_serverid = self.current_msh_missing_serverid().await;
 
-            if msh_missing_serverid || stuck {
-                let reason = if msh_missing_serverid {
-                    "current .msh is missing or has no ServerID (agent cannot authenticate the server)".to_string()
-                } else {
-                    format!("no successful connect within {}s", STUCK_DURATION.as_secs())
-                };
-                warn!("meshcentral-agent unhealthy: {reason} — refreshing .msh and restarting the agent");
+            let reason = if msh_missing_serverid {
+                Some("current .msh is missing or has no ServerID (agent cannot authenticate the server)".to_string())
+            } else if stuck {
+                Some(format!("no successful connect within {}s", STUCK_DURATION.as_secs()))
+            } else if silent {
+                Some(format!(
+                    "silent for {}s (last_marker_healthy={last_marker_healthy})",
+                    last_activity.elapsed().as_secs()
+                ))
+            } else {
+                None
+            };
 
+            if let Some(reason) = reason {
                 // Arm the cooldown before acting so no outcome (busy, error, no-op) can spin the loop.
                 last_action = Some(Instant::now());
-                match self.try_refresh_msh().await {
-                    Ok(true) => info!("mesh self-heal: refreshed .msh (NodeID preserved)"),
-                    Ok(false) => debug!("mesh self-heal: .msh already current"),
-                    Err(e) => error!("mesh self-heal: .msh refresh failed (restarting anyway): {e:#}"),
-                }
-                self.restart_agent().await;
-
-                stuck_since = None;
-                last_activity = Instant::now();
-            } else if silent {
-                warn!(
-                    "meshcentral-agent silent for {}s (last_marker_healthy={last_marker_healthy}) — restarting the agent",
-                    last_activity.elapsed().as_secs()
-                );
-
-                last_action = Some(Instant::now());
-                self.restart_agent().await;
-
+                self.heal(&reason).await;
                 stuck_since = None;
                 last_activity = Instant::now();
             }
         }
+    }
+
+    /// Single heal path for every unhealthy branch: refresh the .msh, then restart so the agent re-imports it.
+    async fn heal(&self, reason: &str) {
+        warn!("meshcentral-agent unhealthy: {reason} — refreshing .msh and restarting the agent");
+        match self.try_refresh_msh().await {
+            Ok(true) => info!("mesh self-heal: refreshed .msh (NodeID preserved)"),
+            Ok(false) => debug!("mesh self-heal: .msh already current"),
+            Err(e) => error!("mesh self-heal: .msh refresh failed (restarting anyway): {e:#}"),
+        }
+        self.restart_agent().await;
     }
 
     /// Restart through the shared guarded flow; a missing registry entry degrades to a process kill so the OS supervisor can relaunch.
@@ -223,6 +223,9 @@ impl MeshSelfHealService {
 
     /// Refresh the .msh from /generate-msh; returns true when it was rewritten.
     async fn try_refresh_msh(&self) -> Result<bool> {
+        // Resolve the target path first: it fails fast when the tool isn't installed, before any network call.
+        let msh_path = self.mesh_msh_path().await?;
+
         let host = self.initial_config.get_server_url()?;
         let url = format!("https://{host}/tools/agent/meshcentral-server/generate-msh?host={host}");
 
@@ -243,7 +246,6 @@ impl MeshSelfHealService {
             return Err(anyhow!("/generate-msh response has neither MeshID nor ServerID"));
         }
 
-        let msh_path = self.mesh_msh_path().await?;
         let current = tokio::fs::read_to_string(&msh_path).await.ok();
         let cur_mesh = current.as_deref().and_then(|s| parse_msh_field(s, "MeshID"));
         let cur_server = current.as_deref().and_then(|s| parse_msh_field(s, "ServerID"));

--- a/clients/openframe-client/src/services/tool_connection_processing_manager.rs
+++ b/clients/openframe-client/src/services/tool_connection_processing_manager.rs
@@ -17,6 +17,8 @@ use crate::services::tool_connection_service::ToolConnectionService;
 use crate::services::tool_run_manager::ToolRunManager;
 
 const RETRY_DELAY_SECONDS: u64 = 15;
+/// agentId command timeout; generous because `-nodeid-base64` boots the full agent runtime.
+const AGENT_ID_COMMAND_TIMEOUT_SECONDS: u64 = 30;
 /// Consecutive agentId-resolution failures tolerated at the normal cadence before the tool
 /// connection is treated as degraded and the retry loop backs off (e.g. a hung `-nodeid-base64`).
 const AGENT_ID_MAX_FAST_RETRIES: u32 = 5;
@@ -214,9 +216,12 @@ impl ToolConnectionProcessingManager {
                     if !std::path::Path::new(&command_path).exists() {
                         warn!("Executable not found at: {}", command_path);
                     }
-                    // Execute command with a 15-second timeout and capture output
-                    let command_future = Command::new(&command_path).args(&processed_args).output();
-                    let output = match timeout(Duration::from_secs(15), command_future).await {
+                    // kill_on_drop: a timed-out agent must die with the future, or it leaks and holds the tool's db open
+                    let command_future = Command::new(&command_path)
+                        .args(&processed_args)
+                        .kill_on_drop(true)
+                        .output();
+                    let output = match timeout(Duration::from_secs(AGENT_ID_COMMAND_TIMEOUT_SECONDS), command_future).await {
                         // Command finished within timeout
                         Ok(Ok(out)) => {
                             info!("Command completed successfully: {}", String::from_utf8_lossy(&out.stdout));
@@ -230,7 +235,7 @@ impl ToolConnectionProcessingManager {
                         }
                         // Timeout expired
                         Err(_) => {
-                            error!("agentId command timed out after 15 seconds – retrying");
+                            error!("agentId command timed out after {AGENT_ID_COMMAND_TIMEOUT_SECONDS} seconds – killed it, retrying");
                             backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }

--- a/clients/openframe-client/src/services/tool_connection_processing_manager.rs
+++ b/clients/openframe-client/src/services/tool_connection_processing_manager.rs
@@ -17,8 +17,8 @@ use crate::services::tool_connection_service::ToolConnectionService;
 use crate::services::tool_run_manager::ToolRunManager;
 
 const RETRY_DELAY_SECONDS: u64 = 15;
-/// agentId command timeout; generous because `-nodeid-base64` boots the full agent runtime.
-const AGENT_ID_COMMAND_TIMEOUT_SECONDS: u64 = 30;
+/// agentId command timeout; the spawned process is killed when it expires.
+const AGENT_ID_COMMAND_TIMEOUT_SECONDS: u64 = 15;
 /// Consecutive agentId-resolution failures tolerated at the normal cadence before the tool
 /// connection is treated as degraded and the retry loop backs off (e.g. a hung `-nodeid-base64`).
 const AGENT_ID_MAX_FAST_RETRIES: u32 = 5;


### PR DESCRIPTION
## Problem

On Engineering-One (tenant cavaliertechnologiesllc) the mesh agent has been dead for hours in a loop:

1. `agent.exe -nodeid-base64` (agentId resolution) timed out every attempt, and **each timeout leaked a live `agent.exe`** — tokio's `Command::output()` only kills the child on drop when `kill_on_drop(true)` is set (default false). The 12:12 self-heal kill sweep found **13 accumulated agent.exe processes**.
2. Leaked instances can end up holding the mesh agent's `agent.db` read-write (the agent's "read-only" db open falls into a Compact/reopen-RW path), which makes the restarting service fall back to an empty cache-only db, skip the `.msh` import, and die with `ServerID entry not found in Db!` — permanently, since that failure line emits no connect attempt and therefore no `Connection FAILED` marker.
3. Self-heal's only branch that fired was the 90-min **silence** branch, which did a plain restart **without** the `.msh` refresh — restarting straight back into the same dead state.

## Fix

- **`tool_connection_processing_manager.rs`**: `kill_on_drop(true)` on the agentId command so a timed-out process dies with the future instead of leaking; the 15s timeout is unchanged (now a named constant, `AGENT_ID_COMMAND_TIMEOUT_SECONDS`).
- **`mesh_self_heal_service.rs`**: all three unhealthy branches (missing ServerID in `.msh`, stuck, silent) now go through a single `heal()` = refresh `.msh` + restart. Branch priority and the arm-cooldown-before-acting invariant are unchanged.
- `try_refresh_msh()` resolves the `.msh` path before the network call, so hosts without meshcentral installed don't fetch `/generate-msh` from the silence branch.
- Doc sidecars updated (source-hash left for the doc bot).

With the leak gone, the next self-heal restart runs with no stray db holders, the agent re-imports `ServerID` from its `.msh` at startup, and reconnects.

## Testing

- `cargo test --lib` — 124 passed; the 2 failures in `platform::directories` are pre-existing on pristine `origin/main` (local macOS environment, unrelated).
- Log-line shapes: the silence message becomes `meshcentral-agent unhealthy: silent for {N}s (…) — refreshing .msh and restarting the agent` (still contains `silent for {N}s`); the timeout message becomes `agentId command timed out after 15 seconds – killed it, retrying` (prefix preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MeshCentral agent self-healing for missing identifiers, failed connections, and silent agents.
  * Refreshes configuration before restarting an unhealthy agent.
  * Ensures timed-out agent ID commands are terminated after 15 seconds.

* **Documentation**
  * Updated service documentation to describe unified healing behavior, timeout handling, and process cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->