### PR TITLE
fix: stale chile script process

### DIFF
--- a/clients/openframe-client/src/executor/output.rs
+++ b/clients/openframe-client/src/executor/output.rs
@@ -1,6 +1,33 @@
 use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
 
 pub(crate) const MAX_OUTPUT_SIZE: usize = 10 * 1024 * 1024;
+
+pub(crate) async fn join_reads(
+    mut stdout_task: JoinHandle<Vec<u8>>,
+    mut stderr_task: JoinHandle<Vec<u8>>,
+    grace: Duration,
+    kill: impl FnOnce(),
+) -> (Vec<u8>, Vec<u8>) {
+    let pair = async {
+        let out = (&mut stdout_task).await.unwrap_or_default();
+        let err = (&mut stderr_task).await.unwrap_or_default();
+        (out, err)
+    };
+    tokio::pin!(pair);
+
+    match timeout(grace, &mut pair).await {
+        Ok(result) => result,
+        Err(_) => {
+            tracing::warn!(
+                "output streams still open after exit (backgrounded child?), killing process tree"
+            );
+            kill();
+            timeout(grace, &mut pair).await.unwrap_or_default()
+        }
+    }
+}
 
 pub(crate) async fn read_capped<R>(reader: Option<R>) -> Vec<u8>
 where

--- a/clients/openframe-client/src/executor/unix/process.rs
+++ b/clients/openframe-client/src/executor/unix/process.rs
@@ -2,10 +2,9 @@ use std::os::unix::process::ExitStatusExt;
 use std::process::Stdio;
 
 use tokio::process::Command;
-use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 
-use crate::executor::output::{clean_string, read_capped};
+use crate::executor::output::{clean_string, join_reads, read_capped};
 use crate::executor::ExecResult;
 
 const READ_GRACE: Duration = Duration::from_secs(5);
@@ -32,7 +31,9 @@ pub(crate) async fn execute_with_timeout(mut cmd: Command, timeout_secs: u32) ->
 
     match timeout(Duration::from_secs(timeout_secs as u64), child.wait()).await {
         Ok(Ok(status)) => {
-            let (out, err) = join_reads(stdout_task, stderr_task, pid).await;
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || kill_process_tree(pid))
+                    .await;
             let retcode = status
                 .code()
                 .unwrap_or_else(|| status.signal().map(|s| 128 + s).unwrap_or(1));
@@ -44,7 +45,9 @@ pub(crate) async fn execute_with_timeout(mut cmd: Command, timeout_secs: u32) ->
             }
         }
         Ok(Err(e)) => {
-            let (out, err) = join_reads(stdout_task, stderr_task, pid).await;
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || kill_process_tree(pid))
+                    .await;
             ExecResult {
                 stdout: clean_string(&out),
                 stderr: format!("{}\n{}", clean_string(&err), e),
@@ -54,7 +57,9 @@ pub(crate) async fn execute_with_timeout(mut cmd: Command, timeout_secs: u32) ->
         }
         Err(_) => {
             kill_process_tree(pid);
-            let (out, err) = join_reads(stdout_task, stderr_task, pid).await;
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || kill_process_tree(pid))
+                    .await;
             let _ = timeout(READ_GRACE, child.wait()).await;
             ExecResult {
                 stdout: clean_string(&out),
@@ -94,31 +99,6 @@ async fn spawn_with_retry(
         }
     }
     Err(last_err.unwrap())
-}
-
-async fn join_reads(
-    mut stdout_task: JoinHandle<Vec<u8>>,
-    mut stderr_task: JoinHandle<Vec<u8>>,
-    pid: u32,
-) -> (Vec<u8>, Vec<u8>) {
-    let pair = async {
-        let out = (&mut stdout_task).await.unwrap_or_default();
-        let err = (&mut stderr_task).await.unwrap_or_default();
-        (out, err)
-    };
-    tokio::pin!(pair);
-
-    match timeout(READ_GRACE, &mut pair).await {
-        Ok(result) => result,
-        Err(_) => {
-            tracing::warn!(
-                pid,
-                "output streams still open after exit (backgrounded child?), killing process group"
-            );
-            kill_process_tree(pid);
-            timeout(READ_GRACE, &mut pair).await.unwrap_or_default()
-        }
-    }
 }
 
 fn kill_process_tree(pid: u32) {

--- a/clients/openframe-client/src/executor/windows/process.rs
+++ b/clients/openframe-client/src/executor/windows/process.rs
@@ -7,10 +7,11 @@ use tokio::time::{timeout, Duration};
 use super::job::JobHandle;
 use super::Interpreter;
 use crate::executor::env::apply_env_vars;
-use crate::executor::output::{clean_string, read_capped};
+use crate::executor::output::{clean_string, join_reads, read_capped};
 use crate::executor::{ExecResult, ScriptParams};
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+const READ_GRACE: Duration = Duration::from_secs(5);
 
 pub(super) async fn run_normal(
     interpreter: &Interpreter,
@@ -53,8 +54,8 @@ pub(super) async fn run_normal(
     .await
     {
         Ok(Ok(status)) => {
-            let out = stdout_task.await.unwrap_or_default();
-            let err = stderr_task.await.unwrap_or_default();
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || job.terminate()).await;
             ExecResult {
                 stdout: clean_string(&out),
                 stderr: clean_string(&err),
@@ -63,8 +64,8 @@ pub(super) async fn run_normal(
             }
         }
         Ok(Err(e)) => {
-            let out = stdout_task.await.unwrap_or_default();
-            let err = stderr_task.await.unwrap_or_default();
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || job.terminate()).await;
             ExecResult {
                 stdout: clean_string(&out),
                 stderr: format!("{}\n{}", clean_string(&err), e),
@@ -75,8 +76,8 @@ pub(super) async fn run_normal(
         Err(_) => {
             job.terminate();
             let _ = child.start_kill();
-            let out = stdout_task.await.unwrap_or_default();
-            let err = stderr_task.await.unwrap_or_default();
+            let (out, err) =
+                join_reads(stdout_task, stderr_task, READ_GRACE, || job.terminate()).await;
             let _ = child.wait().await;
             ExecResult {
                 stdout: clean_string(&out),
@@ -91,3 +92,4 @@ pub(super) async fn run_normal(
         }
     }
 }
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output handling when processes exit unexpectedly or time out.
  * Added a bounded grace period for collecting standard output and error streams.
  * Ensured lingering processes are terminated and output collection completes reliably across Unix and Windows.
  * Prevented stalled output tasks from blocking command execution indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->