### PR TITLE
chore(meshcentral): bump chart to 0.0.26

### DIFF
--- a/manifests/tenant/Chart.yaml
+++ b/manifests/tenant/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
     repository: "oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"
     condition: fleet.enabled
   - name: meshcentral
-    version: "0.0.22"
+    version: "0.0.25"
     repository: "oci://ghcr.io/flamingo-stack/meshcentral/helm-charts"
     condition: meshcentral.enabled

--- a/manifests/tenant/Chart.yaml
+++ b/manifests/tenant/Chart.yaml
@@ -11,6 +11,6 @@ dependencies:
     repository: "oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"
     condition: fleet.enabled
   - name: meshcentral
-    version: "0.0.25"
+    version: "0.0.26"
     repository: "oci://ghcr.io/flamingo-stack/meshcentral/helm-charts"
     condition: meshcentral.enabled

--- a/manifests/tenant/values.yaml
+++ b/manifests/tenant/values.yaml
@@ -104,6 +104,15 @@ fleet:
 meshcentral:
   enabled: true
   restartPod: "2"  # Bump to rollout (any string works)
+  podSecurityContext:
+    fsGroup: 1000
+    runAsNonRoot: null
+    runAsUser: null
+    runAsGroup: null
+    seccompProfile: null
+  securityContext: null
+  initImage:
+    securityContext: null
   image:
     registry: ghcr.io/flamingo-stack/meshcentral
     repository: meshcentral

--- a/manifests/tenant/values.yaml
+++ b/manifests/tenant/values.yaml
@@ -100,19 +100,9 @@ fleet:
     enabled: false
 
 
-
 meshcentral:
   enabled: true
   restartPod: "2"  # Bump to rollout (any string works)
-  podSecurityContext:
-    fsGroup: 1000
-    runAsNonRoot: null
-    runAsUser: null
-    runAsGroup: null
-    seccompProfile: null
-  securityContext: null
-  initImage:
-    securityContext: null
   image:
     registry: ghcr.io/flamingo-stack/meshcentral
     repository: meshcentral


### PR DESCRIPTION
Enables the securityContext hardening and turns off MeshCentral's own backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MeshCentral component to version 0.0.26.
  * Removed an unused empty configuration section from the tenant settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->