### PR TITLE
Client Chat: no default-branding flash for customized Fae

### DIFF
--- a/clients/openframe-chat/src/hooks/.useApplyAiAppearance.md
+++ b/clients/openframe-chat/src/hooks/.useApplyAiAppearance.md
@@ -29,7 +29,7 @@ function ChatApp() {
 }
 ```
 
-> **Note:** The hook does nothing while `isSettingsLoading` is `true`, preserving any pre-paint values already applied by `index.html` to avoid a theme flash on hard reload.
+> **Note:** The hook does nothing while `isSettingsLoading` or `settingsUnavailable` is `true`, preserving any pre-paint values already applied by `index.html` — only a successfully resolved "no customization" answer reverts to defaults and clears the persisted values.
 
 ## Source
 

--- a/clients/openframe-chat/src/hooks/.useAssistantBranding.md
+++ b/clients/openframe-chat/src/hooks/.useAssistantBranding.md
@@ -7,16 +7,16 @@ Resolves and exposes the assistant's display identity (name and avatar) derived 
 
 | Field | Type | Description |
 |---|---|---|
-| `assistantName` | `string \| undefined` | Configured name or `"Fae"` default; `undefined` while settings load |
-| `assistantAvatar` | `string \| undefined` | Resolved avatar URL or bundled default; `undefined` while resolving |
-| `isLoading` | `boolean` | `true` while settings or avatar fetch are in flight |
+| `assistantName` | `string \| undefined` | Configured name or `"Fae"` default; the cached name may render while settings load, `undefined` only when there is no cache either |
+| `assistantAvatar` | `string \| undefined` | Resolved avatar data URI or bundled default; the cached avatar may render while resolving, `undefined` only when there is no cache either |
+| `isLoading` | `boolean` | `true` only when neither a resolved nor a cached identity value is available to paint |
 
 ### `useAssistantBranding()`
 
 Composes [`useChatConfig`](https://github.com/flamingo-stack/openframe-oss-tenant/blob/main/src/hooks/useChatConfig.ts) and [`useAuthenticatedImage`](https://github.com/flamingo-stack/openframe-oss-tenant/blob/main/src/hooks/useAuthenticatedImage.ts) to produce a stable branding snapshot. Key resolution logic:
 
-- **Name:** Returns the trimmed configured name if present, `"Fae"` once settings have loaded, or `undefined` while still loading.
-- **Avatar:** Prefers the authenticated custom avatar URL when a `rawAvatarUrl` exists. During resolution serves the last-resolved cached avatar for this connection (`brandingCache`), or `undefined` (skeleton) when there is no cache; falls back to the bundled `fae-avatar.png` on failure or when no avatar is configured. The resolved identity is persisted back to the cache so the next cold start paints it immediately. Avoids reading `customAvatarUrl` when no avatar is configured to prevent a one-render flash caused by the object URL cleanup effect in `useAuthenticatedImage`.
+- **Name:** Returns the trimmed configured name if present, `"Fae"` once settings have loaded, the cached name while still loading, or `undefined` when there is no cache either.
+- **Avatar:** Prefers the authenticated custom avatar URL when a `rawAvatarUrl` exists. During resolution serves the last-resolved cached avatar for this connection (`brandingCache`), or `undefined` (skeleton) when there is no cache; falls back to the bundled `fae-avatar.png` on failure or when no avatar is configured. The resolved identity is persisted back to the cache so the next cold start paints it immediately. Avoids reading `customAvatarUrl` when no avatar is configured to prevent a one-render flash caused by `customAvatarUrl` lagging one render behind `rawAvatarUrl` in `useAuthenticatedImage`.
 - **`isLoading`:** `true` only while there is nothing to paint at all (neither a resolved nor a cached name/avatar).
 
 ## Usage Example

--- a/clients/openframe-chat/src/hooks/.useAssistantBranding.md
+++ b/clients/openframe-chat/src/hooks/.useAssistantBranding.md
@@ -16,8 +16,8 @@ Resolves and exposes the assistant's display identity (name and avatar) derived 
 Composes [`useChatConfig`](https://github.com/flamingo-stack/openframe-oss-tenant/blob/main/src/hooks/useChatConfig.ts) and [`useAuthenticatedImage`](https://github.com/flamingo-stack/openframe-oss-tenant/blob/main/src/hooks/useAuthenticatedImage.ts) to produce a stable branding snapshot. Key resolution logic:
 
 - **Name:** Returns the trimmed configured name if present, `"Fae"` once settings have loaded, or `undefined` while still loading.
-- **Avatar:** Prefers the authenticated custom avatar URL when a `rawAvatarUrl` exists. Falls back to `undefined` (skeleton) during resolution, and to the bundled `fae-avatar.png` on failure or when no avatar is configured. Avoids reading `customAvatarUrl` when no avatar is configured to prevent a one-render flash caused by the object URL cleanup effect in `useAuthenticatedImage`.
-- **`isLoading`:** `true` when either `isSettingsLoading` or `isAvatarLoading` is `true`.
+- **Avatar:** Prefers the authenticated custom avatar URL when a `rawAvatarUrl` exists. During resolution serves the last-resolved cached avatar for this connection (`brandingCache`), or `undefined` (skeleton) when there is no cache; falls back to the bundled `fae-avatar.png` on failure or when no avatar is configured. The resolved identity is persisted back to the cache so the next cold start paints it immediately. Avoids reading `customAvatarUrl` when no avatar is configured to prevent a one-render flash caused by the object URL cleanup effect in `useAuthenticatedImage`.
+- **`isLoading`:** `true` only while there is nothing to paint at all (neither a resolved nor a cached name/avatar).
 
 ## Usage Example
 

--- a/clients/openframe-chat/src/hooks/.useAuthenticatedImage.md
+++ b/clients/openframe-chat/src/hooks/.useAuthenticatedImage.md
@@ -13,7 +13,7 @@ React hook that:
 1. Waits for the token service to be ready via `tokenService.ensureTokenReady()`
 2. Fetches the image with an `Authorization: Bearer <token>` header
 3. Converts the response blob to a `data:` URI via `FileReader` — persistable as-is by the branding pre-paint cache, and needing no cleanup/revocation
-5. Handles cancellation if the component unmounts or `url` changes mid-flight
+4. Handles cancellation if the component unmounts or `url` changes mid-flight
 
 ## Usage Example
 
@@ -39,4 +39,3 @@ function AgentAvatar({ avatarUrl }: { avatarUrl: string }) {
 
 - Pass `null` or `undefined` as `url` to disable fetching (e.g., when no avatar is configured)
 - Skeleton/fallback logic should gate on **both** `isLoading === false` and `url === undefined` to avoid a flash of the fallback before the real image resolves
-- Object URLs are automatically revoked on cleanup — do not call `URL.revokeObjectURL` manually

--- a/clients/openframe-chat/src/hooks/.useAuthenticatedImage.md
+++ b/clients/openframe-chat/src/hooks/.useAuthenticatedImage.md
@@ -5,15 +5,14 @@ Fetches a Bearer-token-protected image and returns a safe blob URL for use in `<
 
 ### `AuthenticatedImage` Interface
 Return type exposing two fields:
-- `url` — the resolved `blob:` object URL, or `undefined` while loading or on error
+- `url` — the resolved `data:` URI, or `undefined` while loading or on error
 - `isLoading` — `true` while the fetch is in-flight, enabling skeleton states without premature fallback flashes
 
 ### `useAuthenticatedImage(url)`
 React hook that:
 1. Waits for the token service to be ready via `tokenService.ensureTokenReady()`
 2. Fetches the image with an `Authorization: Bearer <token>` header
-3. Converts the response blob to an object URL via `URL.createObjectURL`
-4. Revokes the object URL on cleanup to prevent memory leaks
+3. Converts the response blob to a `data:` URI via `FileReader` — persistable as-is by the branding pre-paint cache, and needing no cleanup/revocation
 5. Handles cancellation if the component unmounts or `url` changes mid-flight
 
 ## Usage Example

--- a/clients/openframe-chat/src/hooks/.useChatConfig.md
+++ b/clients/openframe-chat/src/hooks/.useChatConfig.md
@@ -15,7 +15,7 @@ Aggregates AI assistant configuration for the chat interface by combining featur
   - `aiSettings` — Raw AI settings object, or `null` when the customization flag is off
   - `defaultModel` — Active `DefaultChatModel` for the footer display, or `null` if unconfigured
   - `isSettingsLoading` — `true` while the flag is on and the AiSettings query itself is still pending (drives branding/appearance skeletons)
-  - `isQuickActionsLoading` — `true` when the flag is on but quick actions have not yet resolved (drives the quick-action wall skeleton)
+  - `isQuickActionsLoading` — `true` only while the flag is on and neither live data nor a per-connection cached action set is available; cached actions suppress the skeleton even when the live request is still pending
   - `settingsUnavailable` — `true` when the real customization state is unknowable (feature-flags fallback or settings query error); appearance keeps the persisted pre-paint values instead of wiping them
 
 ## Usage Example

--- a/clients/openframe-chat/src/hooks/.useChatConfig.md
+++ b/clients/openframe-chat/src/hooks/.useChatConfig.md
@@ -14,7 +14,9 @@ Aggregates AI assistant configuration for the chat interface by combining featur
   - `quickActions` — Resolved `QuickAction[]` (empty array while loading, never fabricated defaults)
   - `aiSettings` — Raw AI settings object, or `null` when the customization flag is off
   - `defaultModel` — Active `DefaultChatModel` for the footer display, or `null` if unconfigured
-  - `isSettingsLoading` — `true` when the flag is on but quick actions have not yet resolved
+  - `isSettingsLoading` — `true` while the flag is on and the AiSettings query itself is still pending (drives branding/appearance skeletons)
+  - `isQuickActionsLoading` — `true` when the flag is on but quick actions have not yet resolved (drives the quick-action wall skeleton)
+  - `settingsUnavailable` — `true` when the real customization state is unknowable (feature-flags fallback or settings query error); appearance keeps the persisted pre-paint values instead of wiping them
 
 ## Usage Example
 
@@ -22,9 +24,9 @@ Aggregates AI assistant configuration for the chat interface by combining featur
 import { useChatConfig } from './useChatConfig';
 
 function ChatInterface() {
-  const { quickActions, aiSettings, defaultModel, isSettingsLoading } = useChatConfig();
+  const { quickActions, aiSettings, defaultModel, isQuickActionsLoading } = useChatConfig();
 
-  if (isSettingsLoading) return <QuickActionsSkeleton />;
+  if (isQuickActionsLoading) return <QuickActionsSkeleton />;
 
   return (
     <>

--- a/clients/openframe-chat/src/hooks/useApplyAiAppearance.ts
+++ b/clients/openframe-chat/src/hooks/useApplyAiAppearance.ts
@@ -59,15 +59,21 @@ const ACCENT_VAR_SHADES = {
  * Everything is reverted when settings are missing (defaults win).
  */
 export function useApplyAiAppearance() {
-  const { aiSettings, isSettingsLoading } = useChatConfig();
+  const { aiSettings, isSettingsLoading, settingsUnavailable } = useChatConfig();
   const theme = aiSettings?.applicationTheme;
   const accentColor = aiSettings?.accentColor;
+  // Only a successfully resolved "no customization" answer may revert to the
+  // ODS defaults AND wipe the persisted pre-paint values. While loading, or
+  // when the real state is unknowable (flags fallback / settings error), keep
+  // whatever the pre-paint script applied — wiping here would make the NEXT
+  // cold start flash default branding too.
+  const keepPrePaint = isSettingsLoading || settingsUnavailable;
 
   useEffect(() => {
     const root = document.documentElement;
 
-    // Still loading: keep the pre-paint theme so we don't re-flash on reload.
-    if (isSettingsLoading) return;
+    // Still loading or state unknown: keep the pre-paint theme.
+    if (keepPrePaint) return;
 
     if (!theme) {
       // No configured theme -> ODS default (dark); clear the persisted value.
@@ -91,7 +97,7 @@ export function useApplyAiAppearance() {
 
     root.setAttribute('data-theme', theme === 'LIGHT' ? 'light' : 'dark');
     return () => root.removeAttribute('data-theme');
-  }, [theme, isSettingsLoading]);
+  }, [theme, keepPrePaint]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -101,8 +107,8 @@ export function useApplyAiAppearance() {
       root.style.removeProperty('--ods-avatar-initials');
     };
 
-    // Still loading: keep the pre-paint accent so we don't re-flash on reload.
-    if (isSettingsLoading) return;
+    // Still loading or state unknown: keep the pre-paint accent.
+    if (keepPrePaint) return;
 
     if (!accentColor) {
       // No custom accent -> ODS default; drop the vars and persisted values.
@@ -128,5 +134,5 @@ export function useApplyAiAppearance() {
     persistAccent(vars);
 
     return clear;
-  }, [accentColor, isSettingsLoading]);
+  }, [accentColor, keepPrePaint]);
 }

--- a/clients/openframe-chat/src/hooks/useApplyAiAppearance.ts
+++ b/clients/openframe-chat/src/hooks/useApplyAiAppearance.ts
@@ -84,19 +84,21 @@ export function useApplyAiAppearance() {
 
     persistTheme(theme);
 
+    // Cleanups must NOT undo the applied theme: when `keepPrePaint` flips to
+    // true (settings error, connection change resetting the query) React runs
+    // the previous cleanup BEFORE the next run early-returns - removing the
+    // attribute here would wipe the very appearance we intend to keep. State
+    // transitions are handled explicitly by the branches above instead; only
+    // the media listener needs releasing.
     if (theme === 'SYSTEM') {
       const media = window.matchMedia('(prefers-color-scheme: light)');
       const applySystemTheme = () => root.setAttribute('data-theme', media.matches ? 'light' : 'dark');
       applySystemTheme();
       media.addEventListener('change', applySystemTheme);
-      return () => {
-        media.removeEventListener('change', applySystemTheme);
-        root.removeAttribute('data-theme');
-      };
+      return () => media.removeEventListener('change', applySystemTheme);
     }
 
     root.setAttribute('data-theme', theme === 'LIGHT' ? 'light' : 'dark');
-    return () => root.removeAttribute('data-theme');
   }, [theme, keepPrePaint]);
 
   useEffect(() => {
@@ -133,6 +135,8 @@ export function useApplyAiAppearance() {
     for (const [key, value] of Object.entries(vars)) root.style.setProperty(key, value);
     persistAccent(vars);
 
-    return clear;
+    // No cleanup on purpose - same reasoning as the theme effect above: a
+    // keepPrePaint transition must not clear the applied accent. Reverting to
+    // the ODS default happens only through the explicit `clear()` branch.
   }, [accentColor, keepPrePaint]);
 }

--- a/clients/openframe-chat/src/hooks/useAssistantBranding.ts
+++ b/clients/openframe-chat/src/hooks/useAssistantBranding.ts
@@ -25,7 +25,7 @@ export interface AssistantBranding {
 
 /** Assistant identity from AiSettings. */
 export function useAssistantBranding(): AssistantBranding {
-  const { aiSettings, isSettingsLoading, settingsUnavailable } = useChatConfig();
+  const { aiSettings, isSettingsLoading, settingsUnavailable, customizationEnabled } = useChatConfig();
   const configuredName = aiSettings?.assistantName?.trim();
   const avatar = aiSettings?.assistantAvatar;
 
@@ -62,9 +62,11 @@ export function useAssistantBranding(): AssistantBranding {
     (isSettingsLoading || settingsUnavailable ? (cachedName ?? (isSettingsLoading ? undefined : 'Fae')) : 'Fae');
 
   // Persist the resolved identity for the next cold start. Only authoritative
-  // resolutions are written - never the flags-fallback or query-error paths.
+  // resolutions are written - never the flags-fallback or query-error paths,
+  // and never while the feature is flag-hidden (a disabled flag is not a
+  // "no customization" answer, so it must not overwrite a resolved entry).
   useEffect(() => {
-    if (!apiBaseUrl || isSettingsLoading || settingsUnavailable || isAvatarLoading) return;
+    if (!apiBaseUrl || !customizationEnabled || isSettingsLoading || settingsUnavailable || isAvatarLoading) return;
     // A configured avatar whose fetch failed is a transient error, not a
     // "not customized" answer - don't overwrite the cached image with null.
     if (rawAvatarUrl && !customAvatarUrl) return;
@@ -74,6 +76,7 @@ export function useAssistantBranding(): AssistantBranding {
     });
   }, [
     apiBaseUrl,
+    customizationEnabled,
     isSettingsLoading,
     settingsUnavailable,
     isAvatarLoading,

--- a/clients/openframe-chat/src/hooks/useAssistantBranding.ts
+++ b/clients/openframe-chat/src/hooks/useAssistantBranding.ts
@@ -1,52 +1,90 @@
+import { useEffect, useMemo } from 'react';
 import faeAvatar from '../assets/fae-avatar.png';
+import { readBrandingCache, updateBrandingCache } from '../services/brandingCache';
 import { getFullImageUrl } from '../utils/image-url';
+import { useApiConnectionState } from './useAiSettingsQuery';
 import { useAuthenticatedImage } from './useAuthenticatedImage';
 import { useChatConfig } from './useChatConfig';
 
 export interface AssistantBranding {
   /** Assistant name. The configured name when set; otherwise the default "Fae"
-   *  once settings have loaded. `undefined` only while settings are still
-   *  loading, so callers can show a skeleton instead of flashing a name. */
+   *  once settings have loaded. While settings are still resolving, the
+   *  last-resolved cached name for this connection; `undefined` only when there
+   *  is no cache either, so callers can show a skeleton instead of flashing. */
   assistantName: string | undefined;
   /** Avatar image src. While still resolving (settings loading or the avatar
-   *  fetch in flight) this is `undefined` so the header shows a skeleton rather
-   *  than flashing a fallback. Once resolved it is either the configured avatar
-   *  or, when none came from the backend (not configured / fetch failed), the
-   *  bundled default avatar. */
+   *  fetch in flight) this is the cached data-URI avatar for this connection,
+   *  or `undefined` when there is no cache (skeleton). Once resolved it is
+   *  either the configured avatar or, when none came from the backend (not
+   *  configured / fetch failed), the bundled default avatar. */
   assistantAvatar: string | undefined;
-  /** True while the assistant identity is still resolving (AiSettings loading
-   *  or the avatar fetch in flight) - drives the header skeleton so we don't
-   *  flash the default avatar before the real value resolves. */
+  /** True while the rendered identity is still unknown (nothing to paint yet,
+   *  not even a cached value) - drives the header skeleton. */
   isLoading: boolean;
 }
 
 /** Assistant identity from AiSettings. */
 export function useAssistantBranding(): AssistantBranding {
-  const { aiSettings, isSettingsLoading } = useChatConfig();
+  const { aiSettings, isSettingsLoading, settingsUnavailable } = useChatConfig();
   const configuredName = aiSettings?.assistantName?.trim();
   const avatar = aiSettings?.assistantAvatar;
 
   const rawAvatarUrl = avatar ? getFullImageUrl(avatar.imageUrl, avatar.hash) : undefined;
   const { url: customAvatarUrl, isLoading: isAvatarLoading } = useAuthenticatedImage(rawAvatarUrl);
 
+  // Cold-start bridge: the last-resolved identity for this connection. A cache
+  // entry with null fields is an authoritative "not customized" answer from the
+  // previous session, so those paint the defaults immediately; no entry at all
+  // means skeletons until the live settings resolve.
+  const { apiBaseUrl } = useApiConnectionState();
+  const cached = useMemo(() => readBrandingCache(apiBaseUrl), [apiBaseUrl]);
+  const cachedName = cached && 'assistantName' in cached ? (cached.assistantName ?? 'Fae') : undefined;
+  const cachedAvatar = cached && 'assistantAvatar' in cached ? (cached.assistantAvatar ?? faeAvatar) : undefined;
+
   // Still resolving while settings load or the avatar fetch is in flight.
   const isResolving = isSettingsLoading || isAvatarLoading;
-  // With a configured avatar: show it once resolved, skeleton while resolving,
-  // default on failure. With none, don't read `customAvatarUrl` — it lags one
-  // render behind `rawAvatarUrl` (its object URL is cleared in an effect), so it
-  // would briefly flash the just-removed avatar; go straight to skeleton (while
-  // settings load) or the bundled default.
+  // With a configured avatar: show it once resolved, the cached value (or a
+  // skeleton) while resolving, default on failure. With none, don't read
+  // `customAvatarUrl` — it lags one render behind `rawAvatarUrl`, so it would
+  // briefly flash the just-removed avatar; serve the cache (while settings
+  // load or their real state is unknowable) or the bundled default.
   const assistantAvatar = rawAvatarUrl
-    ? (customAvatarUrl ?? (isResolving ? undefined : faeAvatar))
-    : isSettingsLoading
-      ? undefined
+    ? (customAvatarUrl ?? (isResolving ? cachedAvatar : faeAvatar))
+    : isSettingsLoading || settingsUnavailable
+      ? (cachedAvatar ?? (isSettingsLoading ? undefined : faeAvatar))
       : faeAvatar;
 
+  // Default to "Fae" once settings have loaded with no configured name; while
+  // loading (or unknowable) serve the cached name, keeping undefined only when
+  // there is nothing at all to paint.
+  const assistantName =
+    configuredName ||
+    (isSettingsLoading || settingsUnavailable ? (cachedName ?? (isSettingsLoading ? undefined : 'Fae')) : 'Fae');
+
+  // Persist the resolved identity for the next cold start. Only authoritative
+  // resolutions are written - never the flags-fallback or query-error paths.
+  useEffect(() => {
+    if (!apiBaseUrl || isSettingsLoading || settingsUnavailable || isAvatarLoading) return;
+    // A configured avatar whose fetch failed is a transient error, not a
+    // "not customized" answer - don't overwrite the cached image with null.
+    if (rawAvatarUrl && !customAvatarUrl) return;
+    updateBrandingCache(apiBaseUrl, {
+      assistantName: configuredName || null,
+      assistantAvatar: (rawAvatarUrl ? customAvatarUrl : null) ?? null,
+    });
+  }, [
+    apiBaseUrl,
+    isSettingsLoading,
+    settingsUnavailable,
+    isAvatarLoading,
+    configuredName,
+    rawAvatarUrl,
+    customAvatarUrl,
+  ]);
+
   return {
-    // Default to "Fae" once settings have loaded with no configured name;
-    // stay undefined while loading so callers don't flash a name.
-    assistantName: configuredName || (isSettingsLoading ? undefined : 'Fae'),
+    assistantName,
     assistantAvatar,
-    isLoading: isResolving,
+    isLoading: assistantName === undefined || assistantAvatar === undefined,
   };
 }

--- a/clients/openframe-chat/src/hooks/useAuthenticatedImage.ts
+++ b/clients/openframe-chat/src/hooks/useAuthenticatedImage.ts
@@ -32,19 +32,18 @@ function blobToDataUri(blob: Blob): Promise<string> {
 }
 
 export function useAuthenticatedImage(url: string | null | undefined): AuthenticatedImage {
-  const [dataUri, setDataUri] = useState<string | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(false);
+  // The settled request is stored together with the URL it answered, and
+  // `isLoading` is DERIVED from the mismatch instead of flipped in the effect:
+  // on the very first render after `url` appears (or changes) the hook already
+  // reports loading, so callers never see a "settled with nothing" frame that
+  // would flash their fallback before the effect below has even committed.
+  const [settled, setSettled] = useState<{ url: string; dataUri: string | undefined } | null>(null);
+  const isLoading = Boolean(url) && settled?.url !== url;
 
   useEffect(() => {
-    if (!url) {
-      setDataUri(undefined);
-      setIsLoading(false);
-      return;
-    }
+    if (!url) return;
 
     let cancelled = false;
-    setIsLoading(true);
-    setDataUri(undefined);
 
     (async () => {
       try {
@@ -56,12 +55,10 @@ export function useAuthenticatedImage(url: string | null | undefined): Authentic
         if (!response.ok) {
           throw new Error(`Avatar fetch failed (${response.status})`);
         }
-        const uri = await blobToDataUri(await response.blob());
-        if (!cancelled) setDataUri(uri);
+        const dataUri = await blobToDataUri(await response.blob());
+        if (!cancelled) setSettled({ url, dataUri });
       } catch (_error) {
-        if (!cancelled) setDataUri(undefined);
-      } finally {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setSettled({ url, dataUri: undefined });
       }
     })();
 
@@ -70,5 +67,5 @@ export function useAuthenticatedImage(url: string | null | undefined): Authentic
     };
   }, [url]);
 
-  return { url: dataUri, isLoading };
+  return { url: url && settled?.url === url ? settled.dataUri : undefined, isLoading };
 }

--- a/clients/openframe-chat/src/hooks/useAuthenticatedImage.ts
+++ b/clients/openframe-chat/src/hooks/useAuthenticatedImage.ts
@@ -5,8 +5,9 @@ import { tokenService } from '../services/tokenService';
  * The chat backend serves the Fae avatar behind a Bearer-protected endpoint
  * (`www-authenticate: Bearer`). A plain `<img src>` can't carry the
  * `Authorization` header, so the image 401s. This hook fetches the bytes with
- * the Bearer token, wraps them in an `object URL`, and returns that — safe to
- * feed straight into an `<img src>` (no auth needed on a blob URL).
+ * the Bearer token and returns them as a `data:` URI — safe to feed straight
+ * into an `<img src>` (no auth needed), and persistable as-is by the branding
+ * pre-paint cache so the next cold start paints the real image immediately.
  *
  * `url` is `undefined` until the image resolves (or on error). `isLoading`
  * stays `true` while the fetch is in flight so callers can keep showing a
@@ -21,21 +22,29 @@ export interface AuthenticatedImage {
   isLoading: boolean;
 }
 
+function blobToDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
 export function useAuthenticatedImage(url: string | null | undefined): AuthenticatedImage {
-  const [objectUrl, setObjectUrl] = useState<string | undefined>(undefined);
+  const [dataUri, setDataUri] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!url) {
-      setObjectUrl(undefined);
+      setDataUri(undefined);
       setIsLoading(false);
       return;
     }
 
     let cancelled = false;
-    let createdUrl: string | undefined;
     setIsLoading(true);
-    setObjectUrl(undefined);
+    setDataUri(undefined);
 
     (async () => {
       try {
@@ -47,12 +56,10 @@ export function useAuthenticatedImage(url: string | null | undefined): Authentic
         if (!response.ok) {
           throw new Error(`Avatar fetch failed (${response.status})`);
         }
-        const blob = await response.blob();
-        if (cancelled) return;
-        createdUrl = URL.createObjectURL(blob);
-        setObjectUrl(createdUrl);
+        const uri = await blobToDataUri(await response.blob());
+        if (!cancelled) setDataUri(uri);
       } catch (_error) {
-        if (!cancelled) setObjectUrl(undefined);
+        if (!cancelled) setDataUri(undefined);
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -60,9 +67,8 @@ export function useAuthenticatedImage(url: string | null | undefined): Authentic
 
     return () => {
       cancelled = true;
-      if (createdUrl) URL.revokeObjectURL(createdUrl);
     };
   }, [url]);
 
-  return { url: objectUrl, isLoading };
+  return { url: dataUri, isLoading };
 }

--- a/clients/openframe-chat/src/hooks/useChat.ts
+++ b/clients/openframe-chat/src/hooks/useChat.ts
@@ -121,7 +121,7 @@ export function useChat({
   >(new Map());
 
   const { debugMode } = useDebugMode();
-  const { quickActions, isSettingsLoading } = useChatConfig();
+  const { quickActions, isQuickActionsLoading } = useChatConfig();
   const { assistantName, assistantAvatar } = useAssistantBranding();
 
   const apiServiceRef = useRef<ChatApiService | null>(null);
@@ -971,7 +971,7 @@ export function useChat({
     resumeDialog,
     showTicketPreview,
     quickActions,
-    isSettingsLoading,
+    isQuickActionsLoading,
     hasMessages: allMessages.length > 0,
     isTicketPreview,
     /** Ticket linked to the open dialog — escalation is keyed on it. */

--- a/clients/openframe-chat/src/hooks/useChatConfig.ts
+++ b/clients/openframe-chat/src/hooks/useChatConfig.ts
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
-import { useAiSettingsQuery } from './useAiSettingsQuery';
+import { readBrandingCache, updateBrandingCache } from '../services/brandingCache';
+import { useAiSettingsQuery, useApiConnectionState } from './useAiSettingsQuery';
 import { useHubQuickActionsQuery } from './useHubQuickActionsQuery';
 
 export interface QuickAction {
@@ -23,7 +24,7 @@ export interface DefaultChatModel {
 }
 
 export function useChatConfig() {
-  const { flags } = useFeatureFlags();
+  const { flags, isError: flagsUnavailable } = useFeatureFlags();
   const customizationEnabled = flags['customer-ai-assistant-settings'];
   // Always fetch: the effective provider/model (org override -> tenant
   // default, resolved server-side from the machine token) seeds the footer
@@ -62,7 +63,25 @@ export function useChatConfig() {
     }));
   }, [customizationEnabled, useHubDefaults, hubQuery.data, query.data]);
 
-  const quickActions = resolvedActions ?? [];
+  // Cold-start bridge: serve the last-resolved set for this connection while
+  // the live one is still in flight, so a repeat launch paints real actions
+  // instead of a skeleton. `null` when there is no cache entry (first launch).
+  const { apiBaseUrl } = useApiConnectionState();
+  const cachedActions = useMemo<QuickAction[] | null>(
+    () => (customizationEnabled ? (readBrandingCache(apiBaseUrl)?.quickActions ?? null) : null),
+    [customizationEnabled, apiBaseUrl],
+  );
+
+  const settingsUnavailable = flagsUnavailable || (customizationEnabled && query.isError);
+
+  // Persist only authoritative resolutions - never the flags-fallback or
+  // error paths, which would poison the next start's first paint.
+  useEffect(() => {
+    if (!apiBaseUrl || settingsUnavailable || resolvedActions === null) return;
+    updateBrandingCache(apiBaseUrl, { quickActions: resolvedActions });
+  }, [apiBaseUrl, settingsUnavailable, resolvedActions]);
+
+  const quickActions = resolvedActions ?? cachedActions ?? [];
 
   // Effective model for the NEXT reply (org override -> tenant default).
   // Null when the tenant never configured CLIENT AI at all - the footer then
@@ -81,10 +100,22 @@ export function useChatConfig() {
     // was flag-disabled.
     aiSettings: customizationEnabled ? (query.data ?? null) : null,
     defaultModel,
+    // Branding/appearance skeleton: true while the AiSettings query itself has
+    // not produced data (including the wait for the token/API URL). Previously
+    // this was derived from the quick-actions resolution, whose hub request is
+    // an independent round-trip — it could resolve first and release branding
+    // consumers into their defaults while `clientView` was still in flight.
+    isSettingsLoading: customizationEnabled && query.isPending,
     // Skeleton state for the quick-action block: true whenever the flag is on
-    // but the server set hasn't resolved (still loading OR the request errored).
+    // but neither the server set nor the per-connection cache has an answer.
     // With no bundled fallback, the block stays a skeleton until real actions
     // arrive rather than flashing generic defaults.
-    isSettingsLoading: customizationEnabled && resolvedActions === null,
+    isQuickActionsLoading: customizationEnabled && resolvedActions === null && cachedActions === null,
+    // True when we cannot know the real customization state: the feature-flags
+    // fetch failed or timed out (flag values are guesses), or the settings
+    // query itself errored. Consumers must NOT treat this as an authoritative
+    // "not customized" answer — in particular the appearance hook keeps the
+    // persisted pre-paint theme/accent instead of wiping it.
+    settingsUnavailable,
   };
 }

--- a/clients/openframe-chat/src/hooks/useChatConfig.ts
+++ b/clients/openframe-chat/src/hooks/useChatConfig.ts
@@ -75,11 +75,13 @@ export function useChatConfig() {
   const settingsUnavailable = flagsUnavailable || (customizationEnabled && query.isError);
 
   // Persist only authoritative resolutions - never the flags-fallback or
-  // error paths, which would poison the next start's first paint.
+  // error paths, which would poison the next start's first paint. A disabled
+  // flag merely HIDES customization, it doesn't say the tenant has none - so
+  // it must not overwrite a previously resolved entry either.
   useEffect(() => {
-    if (!apiBaseUrl || settingsUnavailable || resolvedActions === null) return;
+    if (!apiBaseUrl || !customizationEnabled || settingsUnavailable || resolvedActions === null) return;
     updateBrandingCache(apiBaseUrl, { quickActions: resolvedActions });
-  }, [apiBaseUrl, settingsUnavailable, resolvedActions]);
+  }, [apiBaseUrl, customizationEnabled, settingsUnavailable, resolvedActions]);
 
   const quickActions = resolvedActions ?? cachedActions ?? [];
 
@@ -95,6 +97,9 @@ export function useChatConfig() {
 
   return {
     quickActions,
+    // Exposed so branding consumers can skip cache writes while the feature
+    // is hidden (a disabled flag is not a "no customization" answer).
+    customizationEnabled,
     // Customization consumers (appearance, branding, welcome screen) only see
     // settings when the flag is on - same behavior as when the query itself
     // was flag-disabled.

--- a/clients/openframe-chat/src/services/brandingCache.ts
+++ b/clients/openframe-chat/src/services/brandingCache.ts
@@ -1,0 +1,60 @@
+import type { QuickAction } from '../hooks/useChatConfig';
+
+/**
+ * Last-resolved branding, persisted per connection so a cold start can paint
+ * the customized identity immediately instead of flashing the OpenFrame
+ * defaults while the four async hops (token IPC -> flags -> AiSettings ->
+ * avatar bytes) resolve. Companion to the theme/accent pre-paint script in
+ * index.html - those cover CSS, this covers the React-rendered identity
+ * (name, avatar, quick actions).
+ *
+ * A `null` field is an authoritative "not customized" answer from the last
+ * session (paint the defaults, no flash); a missing cache entry means we have
+ * never resolved settings for this connection (callers keep their skeletons).
+ * Writers only run once settings resolved successfully - never from the
+ * flags-fallback or query-error paths - so the cache can't be poisoned by an
+ * offline start. The entry is keyed by API base URL: a server change never
+ * paints the previous tenant's branding.
+ */
+
+const STORAGE_KEY = 'openframe-chat-branding';
+
+export interface CachedBranding {
+  apiBaseUrl: string;
+  /** Customized assistant name, or null when resolved as not customized. */
+  assistantName?: string | null;
+  /** Avatar as a data: URI, or null when resolved as not customized. */
+  assistantAvatar?: string | null;
+  /** Resolved quick actions ([] is a resolved "hide the block" answer). */
+  quickActions?: QuickAction[] | null;
+}
+
+export function readBrandingCache(apiBaseUrl: string | null): CachedBranding | null {
+  if (!apiBaseUrl) return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedBranding;
+    return parsed && parsed.apiBaseUrl === apiBaseUrl ? parsed : null;
+  } catch {
+    // Storage may be unavailable in some webview contexts.
+    return null;
+  }
+}
+
+/**
+ * Merges `partial` into the entry for `apiBaseUrl` (branding and quick actions
+ * resolve in different hooks). An entry for another server is replaced, not
+ * merged. No-ops when the merged value is unchanged.
+ */
+export function updateBrandingCache(apiBaseUrl: string, partial: Omit<CachedBranding, 'apiBaseUrl'>): void {
+  try {
+    const current = readBrandingCache(apiBaseUrl);
+    const next: CachedBranding = { ...current, ...partial, apiBaseUrl };
+    const serialized = JSON.stringify(next);
+    if (current && JSON.stringify(current) === serialized) return;
+    localStorage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    // Storage may be unavailable in some webview contexts.
+  }
+}

--- a/clients/openframe-chat/src/services/brandingCache.ts
+++ b/clients/openframe-chat/src/services/brandingCache.ts
@@ -29,13 +29,35 @@ export interface CachedBranding {
   quickActions?: QuickAction[] | null;
 }
 
+function isNullableString(value: unknown): value is string | null | undefined {
+  return value === null || value === undefined || typeof value === 'string';
+}
+
+function isQuickAction(value: unknown): value is QuickAction {
+  if (typeof value !== 'object' || value === null) return false;
+  const action = value as Record<string, unknown>;
+  return typeof action.id === 'string' && typeof action.name === 'string' && typeof action.instructions === 'string';
+}
+
+/** Runtime shape check - localStorage can hold anything (older versions,
+ *  manual edits); a malformed entry must read as "no cache", not crash or
+ *  leak wrong types into consumers. */
+function isCachedBranding(value: unknown): value is CachedBranding {
+  if (typeof value !== 'object' || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.apiBaseUrl !== 'string') return false;
+  if (!isNullableString(entry.assistantName) || !isNullableString(entry.assistantAvatar)) return false;
+  if (entry.quickActions === null || entry.quickActions === undefined) return true;
+  return Array.isArray(entry.quickActions) && entry.quickActions.every(isQuickAction);
+}
+
 export function readBrandingCache(apiBaseUrl: string | null): CachedBranding | null {
   if (!apiBaseUrl) return null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as CachedBranding;
-    return parsed && parsed.apiBaseUrl === apiBaseUrl ? parsed : null;
+    const parsed: unknown = JSON.parse(raw);
+    return isCachedBranding(parsed) && parsed.apiBaseUrl === apiBaseUrl ? parsed : null;
   } catch {
     // Storage may be unavailable in some webview contexts.
     return null;

--- a/clients/openframe-chat/src/views/ChatView.tsx
+++ b/clients/openframe-chat/src/views/ChatView.tsx
@@ -189,7 +189,7 @@ export function ChatView() {
     stopGeneration,
     handleQuickAction,
     quickActions,
-    isSettingsLoading,
+    isQuickActionsLoading,
     hasMessages,
     clearMessages,
     resumeDialog,
@@ -639,10 +639,10 @@ export function ChatView() {
                 `agentSlug="fae"` caps the brick stack at 2 rows. Product Hub
                 defaults carry a glyph (iconName/iconUrl/iconProps) → rendered on
                 the chip; tenant customs have none. */}
-            {!isDialogActive && !isDisconnected && (isSettingsLoading || quickActions.length > 0) && (
+            {!isDialogActive && !isDisconnected && (isQuickActionsLoading || quickActions.length > 0) && (
               <QuickActionWall
                 className="mb-[var(--spacing-system-s)] max-h-44 shrink-0"
-                loading={isSettingsLoading}
+                loading={isQuickActionsLoading}
                 agentSlug="fae"
                 rows={4}
                 pauseOnHover


### PR DESCRIPTION
## Summary
ClickUp [86ajn9q9f](https://app.clickup.com/t/86ajn9q9f): a customized Fae briefly rendered the default OpenFrame branding (name "Fae", pink accent, default avatar) at first paint before the client configuration loaded, breaking the white-label experience.

## Root causes fixed
1. **Wrong loading flag.** `isSettingsLoading` was derived from the quick-actions resolution, whose Product Hub request is an independent round-trip - it could resolve first and release branding consumers into defaults while `clientView` was still in flight. It now tracks the AiSettings query itself; the quick-action wall keeps its own `isQuickActionsLoading`.
2. **Pre-paint cache wiped mid-load.** The same early release (and the feature-flags fallback/timeout path) cleared the persisted theme/accent localStorage used by the index.html no-flash script, so the NEXT cold start flashed too. A new `settingsUnavailable` state keeps the pre-paint values whenever the real customization state is unknowable; only a successfully resolved "not customized" answer reverts to defaults.
3. **No cache for identity.** Theme/accent had a pre-paint cache, but name, avatar, and quick actions did not - every cold start went through 4 serialized async hops (token IPC -> flags -> AiSettings GraphQL -> avatar fetch) with skeletons at best. New per-connection `brandingCache` (localStorage, keyed by API base URL) serves the last-resolved identity while settings load, so repeat launches paint the customized branding on the first frame. Authenticated images now resolve to data URIs so the avatar is persistable as-is; only authoritative resolutions are written (fallback/error paths never poison the cache), and a server change never paints the previous tenant's branding.

## Testing
- `tsc --noEmit`, Biome, and `vite build` clean
- Manually verified on a production Tauri build against a customized tenant: cold start with empty cache (skeletons, no default flash), repeat launch (customized branding at first paint), welcome-screen persistence, offline start does not wipe the cache

## Out of scope
- First-ever launch still shows skeletons until config resolves - planned follow-up (Rust prefetch / deferred window.show)
- Hardcoded "Fae"/greeting/accent literals in WelcomeScreen - separate follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Assistant branding and quick actions now load from cached connection-specific data for faster, more consistent cold starts.
  - Branding updates persist across sessions, with sensible fallbacks when configuration is unavailable.

- **Bug Fixes**
  - Appearance settings remain intact while configuration loads or is temporarily unavailable.
  - Improved loading states distinguish settings from quick actions.
  - Authenticated images now remain available reliably after loading, including across page refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->