### PR TITLE
feat(chat): poll AI settings so admin edits reach idle sessions

### DIFF
--- a/clients/openframe-chat/src/hooks/.useAiSettingsQuery.md
+++ b/clients/openframe-chat/src/hooks/.useAiSettingsQuery.md
@@ -15,6 +15,7 @@ The primary query hook. Fetches `AiSettingsResponse` (client assistant appearanc
 **Query behaviour:**
 - `staleTime`: 60 seconds — minimises redundant fetches while ensuring admin edits land without a restart
 - `refetchOnWindowFocus` / `refetchOnReconnect`: `true` — picks up changes passively
+- `refetchInterval`: 60s with `refetchIntervalInBackground` — an idle, unfocused window also converges on admin edits within a minute (no server push exists for config changes)
 - `retry`: 1 — one automatic retry on failure
 - Returns `null` when no settings record exists yet
 

--- a/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
+++ b/clients/openframe-chat/src/hooks/useAiSettingsQuery.ts
@@ -59,11 +59,16 @@ export function useAiSettingsQuery({ enabled }: { enabled: boolean }) {
     queryFn: () => aiSettingsService.fetchAiSettings(),
     enabled: enabled && connection.isReady,
     retry: 1,
-    // Appearance changes rarely but should land without a restart. No polling;
-    // instead refetch when the user refocuses the window or the app reconnects,
-    // with a short staleTime so that refocus actually picks up admin edits.
+    // Admin edits must land in running sessions without a restart. There is no
+    // server push for configuration changes (and no server-side cache - every
+    // read returns fresh values), so the client polls: refetch on refocus and
+    // reconnect for immediacy, plus a background interval so an idle, unfocused
+    // chat window also converges within a minute. Background refetches keep the
+    // previous data, so the UI never flickers while polling.
     staleTime: 60 * 1000,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
+    refetchInterval: 60 * 1000,
+    refetchIntervalInBackground: true,
   });
 }


### PR DESCRIPTION
## Summary
Part of ClickUp [86ajn8hnq](https://app.clickup.com/t/86ajn8hnq) (live customization). BE confirmed there will be no push event for configuration changes and no server-side caching exists - every read returns fresh values. The only stale layer is therefore the client, so the chat polls.

## Change
`useAiSettingsQuery` adds `refetchInterval: 60s` with `refetchIntervalInBackground: true` on top of the existing focus/reconnect refetch: an idle, unfocused chat window now converges on admin edits within a minute. Background refetches keep previous data, so the UI never flickers while polling.

## Testing
- `tsc --noEmit` and Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI settings now refresh automatically every 60 seconds, even when the browser window is unfocused.
  * Settings continue to refresh when the window regains focus or reconnects to the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->