### PR TITLE
chore(fleet): bump the chart to 0.4.3

### DIFF
--- a/manifests/tenant/Chart.yaml
+++ b/manifests/tenant/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "0.0.1"
 
 dependencies:
   - name: fleet
-    version: "0.1.8"
+    version: "0.4.3"
     repository: "oci://ghcr.io/flamingo-stack/fleetmdm/helm-charts"
     condition: fleet.enabled
   - name: meshcentral


### PR DESCRIPTION
Chart 0.4.3 brings the non-root securityContext. The image is already on latest,
which runs as uid 3333, so nothing else changes here.
