### PR TITLE
feat(nats): allow device connections to publish user.*.installed-agent

### DIFF
--- a/manifests/datasources/nats/templates/configmap.yaml
+++ b/manifests/datasources/nats/templates/configmap.yaml
@@ -43,7 +43,8 @@ data:
                   "$JS.ACK.TOOL_UPDATE.>",
                   "machine.*.tool-connection",
                   "machine.*.heartbeat",
-                  "machine.*.installed-agent"
+                  "machine.*.installed-agent",
+                  "user.*.installed-agent"
                 ]
               },
               subscribe: {


### PR DESCRIPTION
## Summary
Adds `user.*.installed-agent` to the device user's publish allowlist in the NATS datasource config, so the desktop app can report its installed version on `user.{userId}.installed-agent` (userId from the connection's authenticated user token).

Companion to flamingo-stack/openframe-oss-lib#1771, which adds the backend consumer and per-user version tracking.

Note for devops: single-line permission addition mirroring the existing `machine.*.installed-agent` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)