### PR TITLE
ci: drop paths filter so required "All Checks" always reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths:
-      - 'openframe/**'
-      - 'integrated-tools/**'
-      - 'pom.xml'
-      - '.github/**'
-      - 'manifests/**'
-      - 'clients/**'
-      - 'configs/**'
-      - 'renovate.json'
+    # NOTE: no `paths:` filter here — "All Checks" is a REQUIRED status check in the
+    # branch ruleset, and a path-filtered workflow never reports on non-matching PRs,
+    # leaving them stuck at "Expected — waiting for status to be reported" forever.
+    # The `changes` job below does the path-based change detection instead: heavy jobs
+    # skip when nothing relevant changed, and the all-checks gate still reports green.
 
 concurrency:
   group: pr-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Problem

The `main` branch ruleset requires the **All Checks** status check, but `test.yml`'s `pull_request` trigger had a `paths:` filter. A PR touching only unlisted files never triggers the workflow, so the required check sits at **"Expected — Waiting for status to be reported"** forever and the PR can never merge without a bypass. Live example: #1852 (docs-only) has no All Checks report at all.

This is the same bug class just fixed in multi-platform-hub (stale/never-reporting required check), and it's the documented GitHub footgun: required status checks + workflow-level path filters don't mix.

## Fix

Remove the `paths:` filter from the `pull_request` trigger. Path-based skipping already happens **inside** the workflow via the `changes` (Detect Changes) reusable workflow — #2223 shows the machinery working: every heavy job `SKIPPED`, yet `All Checks = SUCCESS`. So on non-code PRs the workflow now costs one cheap change-detection job and reports green instead of hanging the merge.

No job logic changed; only the trigger block (with an explanatory comment so the filter doesn't get re-added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)