### PR TITLE
task-01: bump mongo to 7.0.40 and 8.0.29, mysql to 8.0.46

### DIFF
--- a/manifests/datasources/mongodb-meshcentral/values.yaml
+++ b/manifests/datasources/mongodb-meshcentral/values.yaml
@@ -3,7 +3,7 @@ mongodb:
   image:
     registry: ghcr.io/flamingo-stack/registry
     repository: mongo
-    tag: "8.0.9"
+    tag: "8.0.29"
   initImage:
     registry: ghcr.io/flamingo-stack/registry
     repository: busybox

--- a/manifests/datasources/mongodb/values.yaml
+++ b/manifests/datasources/mongodb/values.yaml
@@ -2,7 +2,7 @@
 image:
   registry: ghcr.io/flamingo-stack/registry
   repository: mongo
-  tag: "7.0.18"
+  tag: "7.0.40"
 podAnnotations:
   loki.grafana.com/scrape: "true"
   prometheus.io/scrape: "true"

--- a/manifests/datasources/mysql-fleetmdm/values.yaml
+++ b/manifests/datasources/mysql-fleetmdm/values.yaml
@@ -3,7 +3,7 @@ mysql:
   image:
     registry: ghcr.io/flamingo-stack/registry
     repository: mysql
-    tag: "8.0.35"
+    tag: "8.0.46"
   podAnnotations:
     loki.grafana.com/scrape: "true"
     prometheus.io/scrape: "true"


### PR DESCRIPTION
Bumps the docker-library mongo and mysql images. The current pins ship gosu built with go1.18.2; the target tags ship gosu 1.19 (go1.24.6), which is what closes the bulk of the SCC findings for these images.

  mongodb              7.0.18 -> 7.0.40
  mongodb-meshcentral  8.0.9  -> 8.0.29
  mysql-fleetmdm       8.0.35 -> 8.0.46

mongodb-meshcentral is not listed in the task doc - it was found while applying the change and is on the same gosu 1.18.2 line, so it is included here.

There are no per-environment value files in this repo, so this lands in one step rather than the dev/stage/prod sequence used in openframe-saas-shared and openframe-saas-tenant.

Ref: docs/soc2-findings/scc/devops/task-01-bump-mongo-mysql-gosu.md