### PR TITLE
Allow device user to publish machine.*.hostname to NATS

### DIFF
--- a/manifests/datasources/nats/templates/configmap.yaml
+++ b/manifests/datasources/nats/templates/configmap.yaml
@@ -43,7 +43,8 @@ data:
                   "$JS.ACK.TOOL_UPDATE.>",
                   "machine.*.tool-connection",
                   "machine.*.heartbeat",
-                  "machine.*.installed-agent"
+                  "machine.*.installed-agent",
+                  "machine.*.hostname"
                 ]
               },
               subscribe: {


### PR DESCRIPTION
The agent's hostname_report_publisher publishes hostname changes to machine.<machine_id>.hostname, but the subject was missing from the device user publish allow-list, so NATS rejected it with a Permissions Violation and hostname updates never reached MachineHostnameListener.