### PR TITLE
chore: remove the dead openframe-events Kafka topic key

### DIFF
--- a/configs/base/openframe-external-api.yml
+++ b/configs/base/openframe-external-api.yml
@@ -44,7 +44,6 @@ openframe:
     kafka:
       topics:
         outbound:
-          openframe-events: openframe.events
           devices-topic: devices-topic
 
 # NATS connection for the spring-cloud-stream nats binder (lib >= 6.16 binds


### PR DESCRIPTION
Config-only companion to flamingo-stack/openframe-oss-lib#1911 (removal of the dead Event domain): the `openframe.oss-tenant.kafka.topics.outbound.openframe-events` key in the external-api config is read by no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)