### PR TITLE
chore(config): remove local-tenant flag

### DIFF
--- a/configs/base/openframe-authorization-server.yml
+++ b/configs/base/openframe-authorization-server.yml
@@ -33,9 +33,6 @@ openframe:
   auth:
     error-url: "${TENANT_HOST_URL:https://localhost}/auth/error"
 
-  # SSO Configuration
-  tenancy:
-    local-tenant: true
 
   sso:
     google:


### PR DESCRIPTION
Companion to [openframe-oss-lib #1924](https://github.com/flamingo-stack/openframe-oss-lib/pull/1924): the authorization service no longer reads `openframe.tenancy.local-tenant`, so the `local-tenant: true` setting here is dead config. Note this repo was the only deployment that set it to `true` — with the lib change, the OSS authorization server now resolves tenants by real id like everything else (single-tenant installs have exactly one tenant document, so lookups by its id behave identically as long as data carries the tenant id).

CU-86ak52ttd